### PR TITLE
Task start

### DIFF
--- a/frontend/chat/RunButton.js
+++ b/frontend/chat/RunButton.js
@@ -1,0 +1,35 @@
+import React from "react";
+import {Button, useToast} from "@chakra-ui/react";
+import { useTask } from "tasks/contexts";
+import useStartTask from "tasks/graphql/useStartTask";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faPlay} from "@fortawesome/free-solid-svg-icons";
+
+export const TaskRunButton = () => {
+  const { task } = useTask();
+  const { startTask } = useStartTask();
+  const toast = useToast();
+  const handleStart = async () => {
+    try {
+      await startTask(task.id);
+    } catch (error) {
+      toast({
+        title: "Error starting task",
+        description:
+          error.message || "An error occurred while starting the task.",
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  return (
+    <Button onClick={handleStart} colorScheme="green" px={10}>
+      Run
+        <FontAwesomeIcon icon={faPlay} ml={5} style={{paddingLeft: "5px"}}/>
+    </Button>
+  );
+};
+
+export default TaskRunButton;

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -166,18 +166,61 @@ enum TaskLogTaskLogMessageRoleChoices {
   USER
 }
 
-"""Aggregation of graphql queries"""
+"""Aggregation of graphql mutations"""
 type Mutation {
+  sendFeedback(input: TaskFeedbackInput!): TaskFeedbackMutation
+  authorizeCommand(input: CommandAuthorizeInput!): AuthorizeCommandMutation
+  createTask(input: CreateTaskInput!): CreateTaskResponse
+  startTask(taskId: UUID!): StartTaskMutation
+  setTaskAutonomous(autonomous: Boolean!, taskId: UUID!): SetTaskAutonomousMutation
   createAgent(input: AgentInput!): CreateAgentMutation
   updateAgent(input: AgentInput!): UpdateAgentMutation
   deleteAgent(id: UUID!): DeleteAgentMutation
   createResource(input: ResourceInput!): CreateResourceMutation
   updateResource(input: ResourceInput!): UpdateResourceMutation
   deleteResource(id: UUID!): DeleteResourceMutation
-  createTask(input: CreateTaskInput!): CreateTaskResponse
-  sendFeedback(input: TaskFeedbackInput!): TaskFeedbackMutation
-  authorizeCommand(input: CommandAuthorizeInput!): AuthorizeCommandMutation
-  setTaskAutonomous(autonomous: Boolean!, taskId: UUID!): SetTaskAutonomousMutation
+}
+
+type TaskFeedbackMutation {
+  taskLogMessage: TaskLogMessageType
+  errors: [String]
+}
+
+input TaskFeedbackInput {
+  taskId: UUID!
+  feedback: String!
+}
+
+type AuthorizeCommandMutation {
+  taskLogMessage: TaskLogMessageType
+  errors: [String]
+}
+
+input CommandAuthorizeInput {
+  messageId: UUID!
+}
+
+type CreateTaskResponse {
+  task: TaskType
+}
+
+input CreateTaskInput {
+  name: String!
+  goals: [GoalInput]
+  agentId: UUID
+  autonomous: Boolean
+}
+
+input GoalInput {
+  description: String!
+}
+
+type StartTaskMutation {
+  task: TaskType
+}
+
+type SetTaskAutonomousMutation {
+  task: TaskType
 }
 
 type CreateAgentMutation {
@@ -219,42 +262,4 @@ type UpdateResourceMutation {
 
 type DeleteResourceMutation {
   success: Boolean
-}
-
-type CreateTaskResponse {
-  task: TaskType
-}
-
-input CreateTaskInput {
-  name: String!
-  goals: [GoalInput]
-  agentId: UUID
-  autonomous: Boolean
-}
-
-input GoalInput {
-  description: String!
-}
-
-type TaskFeedbackMutation {
-  taskLogMessage: TaskLogMessageType
-  errors: [String]
-}
-
-input TaskFeedbackInput {
-  taskId: UUID!
-  feedback: String!
-}
-
-type AuthorizeCommandMutation {
-  taskLogMessage: TaskLogMessageType
-  errors: [String]
-}
-
-input CommandAuthorizeInput {
-  messageId: UUID!
-}
-
-type SetTaskAutonomousMutation {
-  task: TaskType
 }

--- a/frontend/task_log/TaskLogView.js
+++ b/frontend/task_log/TaskLogView.js
@@ -1,6 +1,6 @@
 import React, { Suspense } from "react";
 import { useParams } from "react-router-dom";
-import { Box, Center } from "@chakra-ui/react";
+import {Box, Center, HStack} from "@chakra-ui/react";
 
 import { TaskProvider } from "tasks/contexts";
 import TaskLogMessageStream from "task_log/TaskLogMessageStream";
@@ -9,6 +9,7 @@ import AutonomousToggle from "chat/AutonomousToggle";
 import { Layout, LayoutContent, LayoutLeftPane } from "site/Layout";
 import { ScrollableBox } from "site/ScrollableBox";
 import TaskLogLeftPane from "task_log/TaskLogLeftPane";
+import RunButton from "chat/RunButton";
 
 export const TaskLogView = () => {
   const { id } = useParams();
@@ -41,7 +42,10 @@ export const TaskLogView = () => {
           <Box width={100}>
             <Suspense>
               <TaskProvider taskId={id}>
-                <AutonomousToggle />
+                <HStack>
+                  <RunButton />
+                  <AutonomousToggle />
+                </HStack>
               </TaskProvider>
             </Suspense>
           </Box>

--- a/frontend/tasks/graphql/useStartTask.js
+++ b/frontend/tasks/graphql/useStartTask.js
@@ -1,0 +1,33 @@
+import { useMutation, graphql } from "react-relay/hooks";
+
+const START_TASK_MUTATION = graphql`
+  mutation useStartTaskMutation($taskId: UUID!) {
+    startTask(taskId: $taskId) {
+      task {
+        id
+      }
+    }
+  }
+`;
+
+function useStartTask() {
+  const [commit, isInFlight] = useMutation(START_TASK_MUTATION);
+
+  const startTask = (taskId) => {
+    commit({
+      variables: { taskId },
+      onCompleted: (data, errors) => {
+        if (errors) {
+          console.error(errors);
+        }
+      },
+      onError: (error) => {
+        console.error(error);
+      },
+    });
+  };
+
+  return { startTask, isInFlight };
+}
+
+export default useStartTask;

--- a/ix/agents/process.py
+++ b/ix/agents/process.py
@@ -357,10 +357,15 @@ You are {agent.name}, {agent.purpose}
         end_index = response.find(end_marker)
 
         if start_index == -1 or end_index == -1:
-            raise MissingCommandMarkers
-
-        json_slice = response[start_index + len(start_marker) : end_index].strip()
-        data = json.loads(json_slice)
+            # before raising attempt to parse the response as json
+            # sometimes the AI returns responses that are still usable even without the markers
+            try:
+                data = json.loads(response)
+            except Exception:
+                raise MissingCommandMarkers
+        else:
+            json_slice = response[start_index + len(start_marker) : end_index].strip()
+            data = json.loads(json_slice)
 
         logger.debug(f"parsed message={data}")
         return data

--- a/ix/agents/tests/test_process.py
+++ b/ix/agents/tests/test_process.py
@@ -764,9 +764,14 @@ class TestAgentProcessTicks:
 
         command_output.assert_called_once_with("ECHO: this is a test")
 
-    def test_tick_response_without_command_markers(
-        self, task, mock_openai, mock_embeddings
+    def test_tick_response_without_command_markers_valid_command(
+        self, task, mock_openai, mock_embeddings, command_output
     ):
+        """
+        Command responses missing command markers will be parsed as JSON if possible.
+        Testing that a valid command is still executed.
+        """
+
         mock_reply = fake_command_reply()
         mock_reply.delete()
         query = TaskLogMessage.objects.filter(task=task)
@@ -780,6 +785,48 @@ class TestAgentProcessTicks:
         mock_content = mock_content.replace("###START###", "")
         mock_content = mock_content.replace("###END###", "")
         mock_response["choices"][0]["message"]["content"] = mock_content
+        mock_openai.return_value = mock_response
+        return_value = agent_process.tick(execute=True)
+
+        # return value is True because the loop should continue
+        assert return_value is True
+
+        assert query.count() == 4
+        think_msg = query[0]
+        thought_msg = query[1]
+        assert think_msg.content["type"] == "THINK"
+        assert thought_msg.content["type"] == "THOUGHT"
+
+        msg_1 = query[2]
+        msg_2 = query[3]
+        assert msg_1.role == "assistant"
+        assert msg_1.content["type"] == "COMMAND"
+        assert msg_1.content["thoughts"] == mock_reply.content["thoughts"]
+        assert msg_1.content["command"] == mock_reply.content["command"]
+        assert msg_2.role == "assistant"
+        assert msg_2.content["type"] == "EXECUTED"
+        assert msg_2.content["message_id"] == str(msg_1.id)
+
+        command_output.assert_called_once_with("ECHO: this is a test")
+
+    def test_tick_response_without_command_markers_invalid_json(
+            self, task, mock_openai, mock_embeddings
+    ):
+        """
+        Command responses missing command markers will be parsed as JSON if possible.
+        Testing that invalid JSON is handled correctly.
+        """
+
+        mock_reply = fake_command_reply()
+        mock_reply.delete()
+        query = TaskLogMessage.objects.filter(task=task)
+        assert query.count() == 0
+        agent_process = AgentProcess(
+            task_id=task.id, command_modules=["ix.agents.tests.echo_command"]
+        )
+        # Remove command markers from mock reply
+        mock_response = msg_to_response(mock_reply)
+        mock_response["choices"][0]["message"]["content"] = "this is not valid json"
         mock_openai.return_value = mock_response
         return_value = agent_process.tick(execute=True)
 

--- a/ix/agents/tests/test_process.py
+++ b/ix/agents/tests/test_process.py
@@ -810,7 +810,7 @@ class TestAgentProcessTicks:
         command_output.assert_called_once_with("ECHO: this is a test")
 
     def test_tick_response_without_command_markers_invalid_json(
-            self, task, mock_openai, mock_embeddings
+        self, task, mock_openai, mock_embeddings
     ):
         """
         Command responses missing command markers will be parsed as JSON if possible.

--- a/ix/schema/__init__.py
+++ b/ix/schema/__init__.py
@@ -2,8 +2,8 @@ import logging
 import graphene
 from django.contrib.auth.models import User
 
-from ix.schema.mutations.chat import TaskFeedbackMutation, AuthorizeCommandMutation
-from ix.schema.mutations.tasks import CreateTaskMutation, SetTaskAutonomousMutation
+from ix.schema.mutations.chat import Mutation as ChatMutation
+from ix.schema.mutations.tasks import Mutation as TaskMutation
 from ix.schema.mutations.agents import Mutation as AgentMutation
 from ix.schema.types.agents import Query as AgentQuery
 from ix.schema.types.auth import UserType
@@ -40,15 +40,10 @@ class Query(AgentQuery, graphene.ObjectType):
         return TaskLogMessage.objects.filter(task_id=task_id).select_related("agent")
 
 
-class Mutation(AgentMutation, graphene.ObjectType):
+class Mutation(AgentMutation, TaskMutation, ChatMutation, graphene.ObjectType):
     """
-    Aggregation of graphql queries
+    Aggregation of graphql mutations
     """
-
-    create_task = CreateTaskMutation.Field()
-    send_feedback = TaskFeedbackMutation.Field()
-    authorize_command = AuthorizeCommandMutation.Field()
-    set_task_autonomous = SetTaskAutonomousMutation.Field()
 
 
 # full graphql schema

--- a/ix/schema/mutations/chat.py
+++ b/ix/schema/mutations/chat.py
@@ -91,3 +91,12 @@ class TaskFeedbackMutation(graphene.Mutation):
         start_agent_loop.delay(input.task_id)
 
         return TaskLogMessageResponse(task_log_message=message)
+
+
+class Mutation(graphene.ObjectType):
+    """
+    Aggregation of chat mutations
+    """
+
+    send_feedback = TaskFeedbackMutation.Field()
+    authorize_command = AuthorizeCommandMutation.Field()

--- a/ix/schema/mutations/chat.py
+++ b/ix/schema/mutations/chat.py
@@ -43,7 +43,7 @@ class AuthorizeCommandMutation(graphene.Mutation):
         logger.info(
             f"Requesting agent loop resume task_id={message.task_id} message_id={message.pk}"
         )
-        start_agent_loop.delay(responding_to.task_id)
+        start_agent_loop.delay(str(responding_to.task_id))
 
         return TaskLogMessageResponse(task_log_message=message)
 
@@ -88,7 +88,7 @@ class TaskFeedbackMutation(graphene.Mutation):
 
         # Start agent loop. This does NOT check if the loop is already running
         # the agent_runner task is responsible for blocking duplicate runners
-        start_agent_loop.delay(input.task_id)
+        start_agent_loop.delay(str(input.task_id))
 
         return TaskLogMessageResponse(task_log_message=message)
 

--- a/ix/schema/mutations/tasks.py
+++ b/ix/schema/mutations/tasks.py
@@ -65,7 +65,7 @@ class CreateTaskMutation(graphene.Mutation):
         )
 
         # Start task loop
-        start_agent_loop.delay(task_id=task.id)
+        start_agent_loop.delay(task_id=str(task.id))
 
         return CreateTaskResponse(task=task)
 
@@ -104,7 +104,7 @@ class StartTaskMutation(graphene.Mutation):
     @handle_exceptions
     def mutate(self, info, task_id, n=1):
         task = Task.objects.get(pk=task_id)
-        start_agent_loop.delay(task_id=task.id)
+        start_agent_loop.delay(task_id=str(task.id))
 
         return StartTaskMutation(task=task)
 

--- a/ix/schema/mutations/tasks.py
+++ b/ix/schema/mutations/tasks.py
@@ -93,3 +93,27 @@ class SetTaskAutonomousMutation(graphene.Mutation):
         )
 
         return SetTaskAutonomousMutation(task=task)
+
+
+class StartTaskMutation(graphene.Mutation):
+    task = graphene.Field(TaskType)
+
+    class Arguments:
+        task_id = graphene.UUID(required=True)
+
+    @handle_exceptions
+    def mutate(self, info, task_id, n=1):
+        task = Task.objects.get(pk=task_id)
+        start_agent_loop.delay(task_id=task.id)
+
+        return StartTaskMutation(task=task)
+
+
+class Mutation(graphene.ObjectType):
+    """
+    Aggregation of task mutations
+    """
+
+    create_task = CreateTaskMutation.Field()
+    start_task = StartTaskMutation.Field()
+    set_task_autonomous = SetTaskAutonomousMutation.Field()

--- a/ix/schema/tests/test_chat_mutations.py
+++ b/ix/schema/tests/test_chat_mutations.py
@@ -62,7 +62,7 @@ class TestAuthorizeCommandMutation:
             "message_id": str(responding_to.id),
         }
 
-        mock_start_agent_loop.delay.assert_called_once_with(responding_to.task_id)
+        mock_start_agent_loop.delay.assert_called_once_with(str(responding_to.task_id))
 
 
 # graphql queries should be in the module scope
@@ -126,4 +126,4 @@ class TestTaskFeedbackMutation:
         }
 
         # Assert that the Celery task is dispatched
-        mock_start_agent_loop.delay.assert_called_once_with(task.id)
+        mock_start_agent_loop.delay.assert_called_once_with(str(task.id))

--- a/ix/task_log/tasks/agent_runner.py
+++ b/ix/task_log/tasks/agent_runner.py
@@ -1,12 +1,22 @@
-from celery import shared_task
-
+from celery_singleton import Singleton
 from ix.agents.process import AgentProcess
+from ix.server.celery import app
 
 
-@shared_task
-def start_agent_loop(task_id: int):
+@app.task(
+    base=Singleton,
+    unique_on=[
+        "task_id",
+    ],
+)
+def start_agent_loop(task_id: str):
     """
-    Start agent process loop
+    Start agent process loop.
+
+    This method uses celery `Singleton`. If executed again with the same `task_id`, it will not start a new process.
+    An AsyncResult for the running task will be returned.
+
+    This method expects `task_id` to be a string to be compatible with celery Singleton.
     """
     process = AgentProcess(task_id=task_id)
     return process.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 beautifulsoup4==4.12.2
 black==23.3.0
 celery==5.2.7
+celery-singleton==0.3.1
 channels==4.0.0
 channels_redis==4.1.0
 colorlog==6.5.0


### PR DESCRIPTION
### Description
This adds a much needed `Run` button to the UI to start and restart tasks. The button isn't yet wired up to detect when a task is already running but multiple clicks are ignored by the backend.

![image](https://user-images.githubusercontent.com/68635/233717099-2f202164-ea6d-41ff-acee-5d3df252a697.png)


### Changes
- Added API mutation for starting task
- Added RunButton to chat interface
- Added `celery_singleton` to prevent click spam from starting multiple `AgentProcess` for the same task.
- `AgentProcess.handle_response` now attempts to parse response into json even if command markers are missing. The model sometimes responds with raw json excluding the markers. Attempting recovery is cheaper than going right to re-try.
- `AgentProcess.msg_execute` now handles exceptions so exceptions are caught if called from `start` in addition to `tick`

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
