### PR TITLE
Update to langchain 0.177

### DIFF
--- a/ix/agents/callback_manager.py
+++ b/ix/agents/callback_manager.py
@@ -1,6 +1,6 @@
 import logging
 
-from langchain.callbacks import CallbackManager
+from langchain.callbacks.manager import CallbackManager
 
 from ix.commands import CommandRegistry
 from ix.task_log.models import Task

--- a/ix/agents/llm.py
+++ b/ix/agents/llm.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Dict, Any, Union
-from langchain.schema import BaseLanguageModel
+
+from langchain.base_language import BaseLanguageModel
 
 from ix.agents.callback_manager import IxCallbackManager
 from ix.utils.importlib import import_class

--- a/ix/chains/artifacts.py
+++ b/ix/chains/artifacts.py
@@ -77,7 +77,7 @@ class SaveArtifact(Chain):
                 "key": self.artifact_key,
                 "name": self.artifact_name,
                 "description": self.artifact_description,
-                "identifier": f"{self.artifact_key}_{self.callback_manager.think_msg.id}",
+                "identifier": f"{self.artifact_key}_{self.callbacks.think_msg.id}",
             }
 
         # Storage is always set from the config for now
@@ -98,7 +98,7 @@ class SaveArtifact(Chain):
         # Associate the artifact with the parent task (chat) until
         # frontend API call can include artifacts from any descendant
         # of the Chat's task.
-        task = self.callback_manager.task
+        task = self.callbacks.task
         artifact_task_id = task.parent_id if task.parent_id else task.id
 
         # save to artifact storage
@@ -114,9 +114,9 @@ class SaveArtifact(Chain):
         # send message to log
         TaskLogMessage.objects.create(
             role="assistant",
-            task=self.callback_manager.task,
-            agent=self.callback_manager.task.agent,
-            parent=self.callback_manager.think_msg,
+            task=self.callbacks.task,
+            agent=self.callbacks.task.agent,
+            parent=self.callbacks.think_msg,
             content={
                 "type": "ARTIFACT",
                 "artifact_type": artifact.artifact_type,
@@ -142,4 +142,4 @@ class SaveArtifact(Chain):
 
     @classmethod
     def from_config(cls, config: Dict[str, Any], callback_manager: IxCallbackManager):
-        return cls(**config, callback_manager=callback_manager)
+        return cls(**config, callbacks=callback_manager)

--- a/ix/chains/llm_chain.py
+++ b/ix/chains/llm_chain.py
@@ -67,8 +67,9 @@ class LLMChain(LangchainLLMChain):
 
         # build prompt & chain
         prompt = ChatPromptTemplate.from_messages(messages)
-        chain = cls(**config, prompt=prompt, verbose=True)
-        chain.callback_manager = callback_manager
+        chain = cls(
+            **config, callback_manager=callback_manager, prompt=prompt, verbose=True
+        )
 
         return chain
 
@@ -82,14 +83,14 @@ class LLMReply(LLMChain):
     def run(self, *args, **kwargs) -> Any:
         response = super().run(*args, **kwargs)
         TaskLogMessage.objects.create(
-            task_id=self.callback_manager.task.id,
+            task_id=self.callbacks.task.id,
             role="assistant",
-            parent=self.callback_manager.think_msg,
+            parent=self.callbacks.think_msg,
             content={
                 "type": "ASSISTANT",
                 "text": response,
                 # "agent": str(self.callback_manager.task.agent.id),
-                "agent": self.callback_manager.task.agent.alias,
+                "agent": self.callbacks.task.agent.alias,
             },
         )
 

--- a/ix/chains/moderator.py
+++ b/ix/chains/moderator.py
@@ -57,7 +57,6 @@ class ChatModerator(Chain):
 
     llm: Any = None
     selection_chain: Chain = None
-    callback_manager: Any = None
 
     def __init__(
         self,
@@ -67,7 +66,7 @@ class ChatModerator(Chain):
     ):
         super().__init__(**data)
         self.selection_chain = selection_chain
-        self.callback_manager = callback_manager
+        self.callbacks = callback_manager
         self.llm = data["llm"]
 
     @property
@@ -107,13 +106,13 @@ class ChatModerator(Chain):
 
         # 2. report delegation
         TaskLogMessage.objects.create(
-            task_id=self.callback_manager.task.id,
+            task_id=self.callbacks.task.id,
             role="assistant",
-            parent=self.callback_manager.think_msg,
+            parent=self.callbacks.think_msg,
             content={
                 "type": "ASSISTANT",
                 "text": f"Delegating to @{alias}",
-                "agent": self.callback_manager.task.agent.alias,
+                "agent": self.callbacks.task.agent.alias,
             },
         )
 
@@ -140,7 +139,7 @@ class ChatModerator(Chain):
         chooser_config = LLM_CHOOSE_AGENT_CONFIG.copy()
         chooser_config["llm"] = llm
         chooser = LLMChain.from_config(chooser_config, callback_manager)
-        chooser.callback_manager = callback_manager
+        chooser.callbacks = callback_manager
 
         instance = cls(
             llm=llm,

--- a/ix/chains/planning.py
+++ b/ix/chains/planning.py
@@ -41,14 +41,14 @@ class SavePlan(Chain):
         plan = Plan.objects.create(
             name=response["name"],
             description=response["description"],
-            creator=self.callback_manager.task,
+            creator=self.callbacks.task,
         )
 
         for command in response["commands"]:
             PlanSteps.objects.create(plan=plan, details=command)
 
         artifact = Artifact.objects.create(
-            task=self.callback_manager.task,
+            task=self.callbacks.task,
             key="plan",
             name=response["name"],
             description=response["description"],
@@ -58,9 +58,9 @@ class SavePlan(Chain):
 
         TaskLogMessage.objects.create(
             role="assistant",
-            task=self.callback_manager.task,
-            agent=self.callback_manager.task.agent,
-            parent=self.callback_manager.think_msg,
+            task=self.callbacks.task,
+            agent=self.callbacks.task.agent,
+            parent=self.callbacks.think_msg,
             content={
                 "type": "ARTIFACT",
                 "artifact_type": "PLAN",
@@ -121,7 +121,7 @@ class RunPlan(Chain):
             tool_name = tool_config["command"]["name"]
             tool_kwargs = tool_config["command"]["args"]
             logger.info(
-                f"executing task_id={self.callback_manager.task.id} tool={tool_name} kwargs={tool_kwargs}"
+                f"executing task_id={self.callbacks.task.id} tool={tool_name} kwargs={tool_kwargs}"
             )
             result = self.tool_registry.call(command_name=tool_name, **tool_kwargs)
             results[tool_name] = result
@@ -130,7 +130,7 @@ class RunPlan(Chain):
             artifacts = []
             for artifact_definition in tool_config.get("produces_artifacts", []):
                 artifact = Artifact.objects.create(
-                    task=self.callback_manager.task,
+                    task=self.callbacks.task,
                     key=artifact_definition["key"],
                     name=artifact_definition["name"],
                     description=artifact_definition["description"],
@@ -143,8 +143,8 @@ class RunPlan(Chain):
                 artifacts.append(artifact)
 
             TaskLogMessage.objects.create(
-                task_id=self.callback_manager.task.id,
-                parent=self.callback_manager.think_msg,
+                task_id=self.callbacks.task.id,
+                parent=self.callbacks.think_msg,
                 role="assistant",
                 content={
                     "type": "EXECUTED",

--- a/ix/chains/routing.py
+++ b/ix/chains/routing.py
@@ -2,9 +2,9 @@ import logging
 from typing import Dict, Any, List
 
 from jsonpath_ng import parse as jsonpath_parse
+from langchain.base_language import BaseLanguageModel
 from langchain.chains import SequentialChain
 from langchain.chains.base import Chain
-from langchain.schema import BaseLanguageModel
 
 from ix.agents.callback_manager import IxCallbackManager
 from ix.agents.llm import load_chain

--- a/ix/chains/tests/mock_chain.py
+++ b/ix/chains/tests/mock_chain.py
@@ -53,5 +53,5 @@ class MockChain(Chain):
         cls, config: Dict[str, Any], callback_manager: IxCallbackManager
     ) -> "MockChain":
         chain = MockChain(**config)
-        chain.callback_manager = callback_manager
+        chain.callbacks = callback_manager
         return chain

--- a/ix/chains/tests/test_llm_chain.py
+++ b/ix/chains/tests/test_llm_chain.py
@@ -80,4 +80,4 @@ class TestLLMChain:
             == EXAMPLE_CONFIG["config"]["messages"][0]["partial_variables"]
         )
         assert result.prompt.messages[1].prompt.partial_variables == {}
-        assert result.callback_manager == callback_manager_mock
+        assert result.callbacks == callback_manager_mock

--- a/ix/chains/tests/test_moderator.py
+++ b/ix/chains/tests/test_moderator.py
@@ -43,4 +43,4 @@ class TestChatModerator:
         chat_moderator = ChatModerator.from_config(config, callback_manager)
 
         assert isinstance(chat_moderator.selection_chain, LLMChain)
-        assert chat_moderator.callback_manager == callback_manager
+        assert chat_moderator.callbacks == callback_manager

--- a/ix/chains/tool_chooser.py
+++ b/ix/chains/tool_chooser.py
@@ -3,13 +3,13 @@ import logging
 from typing import Dict, Any, List
 
 from langchain import LLMChain
+from langchain.base_language import BaseLanguageModel
 from langchain.chains.base import Chain
 from langchain.prompts import (
     ChatPromptTemplate,
     SystemMessagePromptTemplate,
     HumanMessagePromptTemplate,
 )
-from langchain.schema import BaseLanguageModel
 
 from ix.agents.callback_manager import IxCallbackManager
 from ix.agents.exceptions import MissingCommandMarkers

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ googlesearch-python==1.2.3
 ipython==8.12.0
 isort==5.12.0
 jsonpath-ng==1.5.3
-langchain==0.0.149
+langchain==0.0.177
 openai==0.27.2
 pinecone-client==2.2.1
 pyright==1.1.301


### PR DESCRIPTION

### Description
Update to latest langchain 0.177

### Changes
- updated langchain to 0.177
- `Chain` callback handlers were refactored requiring changes to how they are initialized in Ix
- `BaseLanguageModel` references updated

### How Tested
- unittests and manual testing

### TODOs
- Further work needed to use callbacks as intended. 
- #39 requires integrating callbacks so the cleanup will occur as part of that effort.
