### PR TITLE
Chat artifacts update subscription

### DIFF
--- a/frontend/chat/graphql/useChatArtifactSubscription.js
+++ b/frontend/chat/graphql/useChatArtifactSubscription.js
@@ -1,0 +1,63 @@
+import React, { useState, useEffect, createContext, useContext } from "react";
+import { graphql, requestSubscription } from "react-relay";
+import environment from "relay-environment";
+
+export const MessagesContext = createContext();
+export const SubscriptionActiveContext = createContext();
+
+export const useArtifactsContext = () => useContext(MessagesContext);
+export const useSubscriptionActiveContext = () =>
+  useContext(SubscriptionActiveContext);
+
+const chatArtifactSubscription = graphql`
+  subscription useChatArtifactSubscription($chatId: String!) {
+    chatArtifactSubscription(chatId: $chatId) {
+      artifact {
+        id
+        key
+        artifactType
+        name
+        description
+        storage
+        createdAt
+      }
+    }
+  }
+`;
+
+export function useChatArtifactSubscription(chatId, onNewMessage) {
+  const [connectionActive, setConnectionActive] = useState(false);
+
+  useEffect(() => {
+    let subscription;
+
+    const connect = () => {
+      setConnectionActive(true);
+      subscription = requestSubscription(environment, {
+        subscription: chatArtifactSubscription,
+        variables: { chatId },
+        updater: (store, data) => {
+          onNewMessage(data.chatArtifactSubscription.artifact);
+        },
+        onError: (error) => {
+          console.error("An error occurred:", error);
+          setConnectionActive(false);
+
+          // Reconnect after a delay
+          setTimeout(connect, 5000);
+        },
+      });
+    };
+
+    connect();
+
+    return () => {
+      if (subscription) {
+        subscription.dispose();
+      }
+      setConnectionActive(false);
+    };
+  }, [onNewMessage, chatId]);
+
+  return connectionActive;
+}

--- a/frontend/chat/sidebar/SideBarArtifactList.js
+++ b/frontend/chat/sidebar/SideBarArtifactList.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useState } from "react";
 import { HStack, VStack, Heading, Box, Text } from "@chakra-ui/react";
 import { useColorMode } from "@chakra-ui/color-mode";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -10,6 +10,7 @@ import {
 import { usePreloadedQuery } from "react-relay/hooks";
 import { ChatByIdQuery } from "chat/graphql/ChatByIdQuery";
 import ArtifactModalButton from "chat/sidebar/ArtifactModalButton";
+import { useChatArtifactSubscription } from "chat/graphql/useChatArtifactSubscription";
 
 const ARTIFACT_TYPE_ICONS = {
   file: faFile,
@@ -23,8 +24,22 @@ const TypeIcon = ({ artifact }) => {
 
 const SideBarArtifactList = ({ queryRef }) => {
   const { chat } = usePreloadedQuery(ChatByIdQuery, queryRef);
-  const artifacts = chat.task.artifacts;
+  const [artifacts, setArtifacts] = useState(chat.task.artifacts);
+
   const { colorMode } = useColorMode();
+
+  // Handle incoming new messages and update message groups
+  const handleNewArtifact = useCallback((artifact) => {
+    setArtifacts((prevArtifacts) => {
+      return [...prevArtifacts, artifact];
+    });
+  }, []);
+
+  // subscribe to messages
+  const subscriptionActive = useChatArtifactSubscription(
+    chat.id,
+    handleNewArtifact
+  );
 
   return (
     <VStack spacing={1}>

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -4,6 +4,7 @@ type Query {
   agents: [AgentType]
   searchAgents(search: String): [AgentType]
   chat(id: UUID!): ChatType
+  chats: [ChatType]
   chatPage(limit: Int = 10, offset: Int = 0): ChatsPage
   chain(id: UUID!): ChainType
   chains: [ChainType]
@@ -395,6 +396,7 @@ type DeleteResourceMutation {
 """Aggregation of graphql subscriptions"""
 type Subscription {
   chatMessageSubscription(chatId: String): ChatMessageSubscription
+  chatArtifactSubscription(chatId: String): ChatArtifactSubscription
 }
 
 """GraphQL subscription to TaskLogMessage instances."""
@@ -402,4 +404,9 @@ type ChatMessageSubscription {
   taskLogMessage: TaskLogMessageType
   agent: AgentType
   parentId: UUID
+}
+
+"""GraphQL subscription to Artifact instances."""
+type ChatArtifactSubscription {
+  artifact: ArtifactType
 }

--- a/ix/chat/apps.py
+++ b/ix/chat/apps.py
@@ -1,4 +1,3 @@
-# your_app/apps.py
 from django.apps import AppConfig
 
 

--- a/ix/schema/subscriptions.py
+++ b/ix/schema/subscriptions.py
@@ -6,6 +6,7 @@ import channels_graphql_ws
 from ix.chat.models import Chat
 from ix.schema.types.agents import AgentType
 from ix.schema.types.messages import TaskLogMessageType
+from ix.schema.types.tasks import ArtifactType
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +61,50 @@ class ChatMessageSubscription(channels_graphql_ws.Subscription):
         )
 
 
+class ChatArtifactSubscription(channels_graphql_ws.Subscription):
+    """GraphQL subscription to Artifact instances."""
+
+    artifact = graphene.Field(ArtifactType)
+
+    class Arguments:
+        chatId = graphene.String()
+
+    @staticmethod
+    async def subscribe(root, info, chatId):
+        """Called when client subscribes."""
+        logger.debug(f"client subscribing for chat artifacts for chat_id={chatId}")
+        chat = await Chat.objects.aget(id=chatId)
+        task_id = chat.task_id
+        return [f"artifacts_task_id_{task_id}"]
+
+    @staticmethod
+    async def publish(payload, info, chatId):
+        """Called to notify subscribed clients."""
+        instance = payload.get("instance")
+        return ChatArtifactSubscription(artifact=instance)
+
+    @classmethod
+    def new_artifact(cls, sender, **kwargs):
+        """
+        Called when new task artifact instance is saved. Messages are
+        Broadcast to all clients subscribed to the chat's task_id.
+        Subtasks are broadcast to the parent task's task_id.
+        """
+        # messages shouldn't be updated but check just in case
+        if not kwargs.get("created", False):
+            return
+
+        instance = kwargs["instance"]
+        parent_id = instance.task.parent_id
+        task_id = parent_id if parent_id else instance.task_id
+        cls.broadcast(
+            group=f"artifacts_task_id_{task_id}",
+            payload={"instance": instance},
+        )
+
+
 class Subscription(graphene.ObjectType):
     """Root GraphQL subscription."""
 
     chatMessageSubscription = ChatMessageSubscription.Field()
+    chatArtifactSubscription = ChatArtifactSubscription.Field()

--- a/ix/task_log/apps.py
+++ b/ix/task_log/apps.py
@@ -1,0 +1,13 @@
+from django.apps import AppConfig
+
+
+class TaskAppConfig(AppConfig):
+    name = "ix.task_log"
+
+    def ready(self):
+        from django.db.models.signals import post_save
+        from ix.schema.subscriptions import ChatArtifactSubscription
+        from ix.task_log.models import Artifact
+
+        # attach signal handler to report new artifacts to subscribed chat clients
+        post_save.connect(ChatArtifactSubscription.new_artifact, sender=Artifact)


### PR DESCRIPTION
### Description
Chat artifacts weren't updating without a refresh.  This PR adds a graphql subscription
to handle real time updates.

### Changes
- Adds `chatArtifactSubscription` to graphql schema
- `SidebarArtifactList` is now subscribed to chat artifacts stream.

### How Tested
- manually tested. 

### TODOs

