### PR TITLE
add md5 as fallback for when md5sum isn't available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
-
 DOCKER_COMPOSE=docker-compose.yml
 DOCKERFILE=Dockerfile
 DOCKER_REGISTRY=ghcr.io
 DOCKER_REPOSITORY=${DOCKER_REGISTRY}/ix/sandbox
 HASH_FILES=requirements*.txt package.json Dockerfile
+
+# check for md5sum or md5 for hashing
+HASHER := $(shell command -v md5sum 2> /dev/null)
+ifndef HASHER
+    HASHER := md5 -r
+endif
+
 IMAGE_TAG=$(shell cat $(HASH_FILES) | md5sum | cut -d ' ' -f 1)
 IMAGE_URL=$(DOCKER_REPOSITORY):$(IMAGE_TAG)
 IMAGE_SENTINEL=.sentinel/image


### PR DESCRIPTION
### Description
User reported `md5sum` was not available on his mac. (#46)  Adding a fallback option.

cc @jonarjeo

### Changes
- Makefile will now fallback to `md5 -r` when `md5sum` is not available in shell 

### How Tested
- manual test in windows (WSL)
- manual test that `md5` exists in macOS shell. 

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
