### PR TITLE
Chat artifact list wasn't resetting when switching chats.

### DIFF
--- a/frontend/chat/sidebar/SideBarArtifactList.js
+++ b/frontend/chat/sidebar/SideBarArtifactList.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { HStack, VStack, Heading, Box, Text } from "@chakra-ui/react";
 import { useColorMode } from "@chakra-ui/color-mode";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -25,6 +25,11 @@ const TypeIcon = ({ artifact }) => {
 const SideBarArtifactList = ({ queryRef }) => {
   const { chat } = usePreloadedQuery(ChatByIdQuery, queryRef);
   const [artifacts, setArtifacts] = useState(chat.task.artifacts);
+
+  // Reset artifacts when chat.id changes
+  useEffect(() => {
+    setArtifacts(chat.task.artifacts);
+  }, [chat.id]);
 
   const { colorMode } = useColorMode();
 


### PR DESCRIPTION
### Description
Chat artifact list wasn't resetting when switching chats.

### Changes
- added a useEffect to reset `artifacts` 

### How Tested
- manual test

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
