### PR TITLE
Artifacts content is now written as expected

### DIFF
--- a/frontend/chat/messages/ArtifactFileContent.js
+++ b/frontend/chat/messages/ArtifactFileContent.js
@@ -16,7 +16,7 @@ export const ArtifactFileContent = ({ message }) => {
     <Box my={4}>
       <Text color="blue.300">{message.content.storage.id}</Text>
       <SyntaxHighlighter style={syntaxTheme} wrapLines={true}>
-        {message.content.data.file_content}
+        {message.content.data}
       </SyntaxHighlighter>
     </Box>
   );

--- a/ix/chains/artifacts.py
+++ b/ix/chains/artifacts.py
@@ -130,10 +130,11 @@ class SaveArtifact(Chain):
 
         # write to storage (i.e. file, database, or a cache)
         if self.artifact_storage == "write_to_file":
-            # Todo map content with jsonpath
             file_path = artifact.storage["id"]
             logger.debug(f"writing content to file file_path={file_path} {content}")
-            write_to_file(file_path, json.dumps(content))
+            if not isinstance(content, str):
+                content = json.dumps(content)
+            write_to_file(file_path, content)
 
         return {self.output_key: str(artifact.id)}
 

--- a/ix/chains/management/commands/create_coder_v1.py
+++ b/ix/chains/management/commands/create_coder_v1.py
@@ -197,6 +197,7 @@ SAVE_FILE_ARTIFACT = {
         "artifact_type": "file",
         "artifact_storage": "write_to_file",
         "content_key": "generated_file_json",
+        "content_path": "generated_file_json.file_content",
         "output_key": "generated_file_artifact",
     },
 }


### PR DESCRIPTION

### Description
A last minute change for `SaveArtifacts` chain broke file writes.  Files were displayed correctly in the UX but as a JSON object
in the filesystem

### Changes
- `SaveArtifact` now only serializes content when content is not already a string
- `Coder v1` now sets `SaveArtifact.content_path`  to properly map content to file
- Updated `ArtifactContent` to expect a `message.data` to be a `str` instead of json.

### How Tested
- manual tests
- added a new unittests:
    - to test `SaveArtifact.content_path`
    - to test non-json file write 

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
