### PR TITLE
Artifact memory

### DIFF
--- a/docs/chains/artifacts.rst
+++ b/docs/chains/artifacts.rst
@@ -1,10 +1,72 @@
-Artifact Chains
-======================
 
-Chains that integrate with the artifact system. Artifacts are used to
-to record milestones, state, objects, and change created by a chain. Artifacts
-provide a reference point to interact with these results in subsequent
-chains.
+Artifacts
+#########
+
+Artifacts are used to record milestones, state, objects, and change created by a chain. Artifacts
+provide a reference point to interact with these results in subsequent chains. Artifacts may be saved
+explicitly with ``SaveArtifact`` and then referenced with ``ArtifactMemory``.
+
+Artifact Memory
+~~~~~~~~~~~~~~~
+
+ArtifactMemory loads an artifact from the database and loads it into the prompt as an input.
+
+.. code-block:: python
+
+    ARTIFACT_MEMORY = {
+        "class_path": "ix.memory.artifacts.ArtifactMemory",
+        "config": {
+            "load_artifact": True
+            "input_key": "artifact_keys",
+            "memory_key": "related_artifacts",
+        }
+    }
+
+``ArtifactMemory`` will read from ``input_key`` and load the artifact into ``memory_key``, if ``load_artifact`` is set
+to ``True``.  Prompts can then output the formatted artifact using ``memory_key``.
+
+The prompt should include ``memory_key`` to render the output.
+
+.. code-block:: python
+
+    PROMPT = """
+    {related_artifacts}
+
+    Tell me about the artifact [{artifact_keys}]
+    """
+
+Prompt will be rendered with the artifact information.
+
+
+.. code-block:: text
+
+    RELATED ARTIFACTS
+
+    id: 00000000-0000-0000-0000-000000000000
+    key: my_key
+    type: my_type
+    name: my_name
+    description: my_description
+    data:
+    data stored in artifact
+
+    Tell me about the artifacts [{my_key}]
+
+Artifact memory matches based on ``artifact_key``. If there are multiple objects with the same key, then the most
+recent object is used.
+
+
+Artifact Memory Scope
+---------------------
+
+Artifact memory scope is limited to the current chat.
+
+
+
+Artifact Chains
+~~~~~~~~~~~~~~~
+
+Chains that integrate with the artifact system.
 
 SaveArtifact
 ------------

--- a/docs/chains/chains.rst
+++ b/docs/chains/chains.rst
@@ -161,7 +161,7 @@ determined by the order in which they are added, and recorded by the ``key`` fie
     }
 
     # Create root node as a sequence
-    root = ChainNode.objects.create(class_path="ix.chains.base.SequenceChain", node_type="list")
+    root = ChainNode.objects.create(class_path="ix.chains.routing.IXSequence", node_type="list")
 
     # Add the greeting and name-asking operations to the sequence
     root.add_child(**GREET_USER)

--- a/docs/chains/chains.rst
+++ b/docs/chains/chains.rst
@@ -27,8 +27,8 @@ Default chain types
 
 LLM Chains:
 
-* `LLMChain <./llm.rst#LLMChain>`_: wrapper around `langchain.LLMChain` to add Ix config loader.
-* `LLMToolChain <./llm.rst#LLMToolChain>`_: chain that has `tools` available in the prompt.
+* `LLMChain <./llm.rst#LLMChain>`_: wrapper around ``langchain.LLMChain`` to add Ix config loader.
+* `LLMToolChain <./llm.rst#LLMToolChain>`_: chain that has ``tools`` available in the prompt.
 * `LLMReply <./llm.rst#LLMReply>`_: Respond to chat stream with the result of an LLM prompt.
 
 Artifacts:
@@ -44,6 +44,13 @@ Routing / flow control:
 * `IxSequence <./routing.rst#IxSequence>`_: wrapper for Sequence that provides config loader.
 * `MapSubchain <./routing.rst#MapSubchain>`_: Run subchain for each item in a list.
 * `ChooseTool <./routing.rst#ChooseTool>`_: chain that chooses a tool with a subchain.
+
+Chain options
+^^^^^^^^^^^^^^
+
+* `Memory <./memory.rst>`_:  Shared and local scoped memory for chains linked to Ix runtime.
+
+
 
 Chain Models
 ------------

--- a/docs/chains/memory.rst
+++ b/docs/chains/memory.rst
@@ -1,0 +1,186 @@
+Chain Memory
+############
+
+Chains support Langchain memory classes. To add memory to a chain, add a ``memory`` field to the ``config`` of the
+chain.
+
+
+Details on available memory classes:
+
+* `Langchain memory classes <https://python.langchain.com/en/latest/modules/memory/how_to_guides.html>`_
+* `Artifact Memory <docs/chains/artifacts.rst>`_
+
+
+Usage
+=====
+
+Basic Example:
+--------------
+
+.. code-block:: python
+
+    # Defining memory class with llm and backend config
+    SUMMARY_MEMORY = {
+        "class_path": "langchain.memory.summary_buffer.ConversationSummaryBufferMemory",
+        "config": {
+            "input_key": "user_input",
+            "memory_key": "chat_summary",
+            "max_token_limit": 1500,
+            "llm": {
+                "class_path": "langchain.chat_models.openai.ChatOpenAI",
+                "config": {
+                    "verbose": True,
+                },
+            },
+            "backend": {
+                "class_path": "langchain.memory.RedisChatMessageHistory",
+                "config": {"url": "redis://redis:6379/0"},
+            },
+        },
+    }
+
+    # Prompt contains {chat_summary} input variable to hold the conversation summary
+    # The variable is set by `memory_key` in the memory config
+    PIRATE_PROMPT = """
+    You are a pirate. Talk like a pirate in all responses.
+
+    CHAT_SUMMARY:
+    {chat_summary}
+    """
+
+    # The chain must include input_variables required for the memory class.
+    # In this example, the message templates define the input_variables for
+    # the chains.
+    CHAT_MESSAGES_WITH_HISTORY: [
+        {
+            "role": "system",
+            "template": PIRATE_PROMPT,
+            "input_variables": ["chat_summary"],
+        },
+        {
+            "role": "user",
+            "template": "{user_input}",
+            "input_variables": ["user_input"],
+        },
+    ],
+
+    # Chain config with memory
+    PIRATE = {
+        "class_path": "ix.chains.llm_chain.LLMReply",
+        "config": {
+            "llm": {
+                "class_path": "langchain.chat_models.openai.ChatOpenAI",
+            },
+            "memory": SUMMARY_MEMORY,
+            "messages": CHAT_MESSAGES_WITH_HISTORY,
+        },
+    }
+
+     # Create root node as a sequence
+    root = ChainNode.objects.create(**PIRATE)
+
+
+Multiple Memory Classes
+------------------------
+
+Multiple memory classes may be used in a chain. The ``memory`` field accepts a single config object or a list of
+objects. The memory classes will automatically be combined with ``CombinedMemory`` class.
+
+
+
+.. code-block:: python
+
+    ARTIFACT_MEMORY = {
+        "class_path": "ix.memory.artifacts.ArtifactMemory",
+    }
+
+    PIRATE_WITH_ARTIFACTS = {
+        "class_path": "ix.chains.llm_chain.LLMReply",
+        "config": {
+            "llm": {
+                "class_path": "langchain.chat_models.openai.ChatOpenAI",
+            },
+        "memory":[SUMMARY_MEMORY, ARTIFACT_MEMORY]
+    }
+
+
+Configuring Sessions
+---------------------
+
+Memory session may be scoped to ``chat``, ``agent``, ``task``, ``user``. The chain loader builds a ``session_id``
+based on the scope and the runtime context. The ``chat.id`` or other id is included in the ``session_id``.
+
+Sessions may be added to the memory class or the backend depending on the implementation. For example
+``langchain.memory.BaseChatMessageHistory`` backends handle sessions for ``langchain.memory.BaseChatMemory``.
+
+Example session config:
+
+.. code-block:: python
+
+    # memory with this config will be scoped to the agent
+    # and use session_id `agent_<agent.id>`
+    AGENT_SESSION_CONFIG = {
+        'scope': 'agent'
+    }
+
+    AGENT_SCOPED_SUMMARY_MEMORY = {
+        "class_path": "langchain.memory.ConversationBufferMemory",
+        "config": {
+            "input_key": "user_input",
+            "memory_key": "chat_summary",
+            "max_token_limit": 1500,
+            "backend": {
+                "class_path": "langchain.memory.RedisChatMessageHistory",
+                "config": {
+                    "url": "redis://redis:6379/0"
+                    "session": AGENT_SESSION_CONFIG
+                },
+            },
+        },
+    }
+
+
+
+A prefix may be added to the ``session_id`` by adding a ``prefix`` field to the session config. The prefix allows
+for memory to be partitioned within the scope. For example, a subset of agents or chains in the chat may share
+a memory partition.
+
+.. code-block:: python
+
+    # memory with this config will be scoped to the chat and the prefix
+    # the session id will be `group_1_chat_<chat.id>`
+    PREFIXED_AGENT_SESSION_CONFIG = {
+        'scope': 'chat',
+        'prefix': 'group_1'
+    }
+
+
+Memory Backends
+----------------
+
+Memory classes such as ``ConversationBufferMemory`` and ``ConversationSummaryBufferMemory`` require a backend to store
+the conversation history. The backend is configured by adding a ``backend`` field to the memory config.
+
+.. code-block:: python
+    REDIS_MEMORY_BACKEND = {
+        "class_path": "langchain.memory.RedisChatMessageHistory",
+        "config": {
+            "url": "redis://redis:6379/0"
+            "session": AGENT_SESSION_CONFIG
+        },
+    },
+
+
+Memory LLMs
+------------
+
+Memory classes such as ``ConversationSummaryMemory`` and ``ConversationSummaryBufferMemory`` require an LLM to generate
+summarizations of the conversation history. The LLM is configured by adding a ``llm`` field to the memory config.
+
+.. code-block:: python
+    MEMORY_LLM = {
+        "class_path": "langchain.chat_models.openai.ChatOpenAI",
+        "config": {
+            "verbose": True,
+        },
+    },

--- a/ix/agents/callback_manager.py
+++ b/ix/agents/callback_manager.py
@@ -1,7 +1,9 @@
 import logging
+from functools import cached_property
 
 from langchain.callbacks.manager import CallbackManager
 
+from ix.chat.models import Chat
 from ix.commands import CommandRegistry
 from ix.task_log.models import Task
 
@@ -36,3 +38,25 @@ class IxCallbackManager(CallbackManager):
         )
         child.think_msg = self.think_msg
         return child
+
+    @property
+    def task_id(self) -> str:
+        return str(self.task.id)
+
+    @property
+    def agent_id(self) -> str:
+        return str(self.task.agent_id)
+
+    @property
+    def user_id(self) -> str:
+        # HAX: this is currently always the owner of the chat. Likely need to update
+        # this in the future to be the user making the request.
+        return str(self.task.user_id)
+
+    @cached_property
+    def chat_id(self) -> str:
+        try:
+            chat = Chat.objects.get(task=self.task)
+        except Chat.DoesNotExist:
+            return None
+        return chat.id

--- a/ix/agents/callback_manager.py
+++ b/ix/agents/callback_manager.py
@@ -1,6 +1,7 @@
 import logging
 from functools import cached_property
 
+from django.db.models import Q
 from langchain.callbacks.manager import CallbackManager
 
 from ix.chat.models import Chat
@@ -56,7 +57,7 @@ class IxCallbackManager(CallbackManager):
     @cached_property
     def chat_id(self) -> str:
         try:
-            chat = Chat.objects.get(task=self.task)
+            chat = Chat.objects.get(Q(task=self.task) | Q(task_id=self.task.parent_id))
         except Chat.DoesNotExist:
             return None
         return chat.id

--- a/ix/agents/llm.py
+++ b/ix/agents/llm.py
@@ -1,8 +1,11 @@
 import logging
-from typing import Dict, Any, Union
+from functools import singledispatch
+from typing import Dict, Any, Union, Type, Tuple, List
 
 from langchain.base_language import BaseLanguageModel
-from langchain.schema import BaseMemory
+from langchain.memory import CombinedMemory
+from langchain.schema import BaseMemory, BaseChatMessageHistory
+from pydantic import BaseModel
 
 from ix.agents.callback_manager import IxCallbackManager
 from ix.utils.importlib import import_class
@@ -33,16 +36,156 @@ def load_llm(
     return llm
 
 
-def load_memory(config: Dict[str, Any]) -> BaseMemory:
+# config options for memory classes that do not have Ix specific options
+MEMORY_CLASSES = {}
+
+
+def get_memory_option(cls: Type[BaseModel], name: str, default: Any):
+    """Get a memory config value from a class or default"""
+    if issubclass(cls, BaseModel) and name in cls.__fields__:
+        # support for pydantic models
+        return cls.__fields__[name].default
+    elif hasattr(cls, name):
+        # support for regular classes
+        return getattr(cls, name)
+    elif cls in MEMORY_CLASSES:
+        # fallback to separate config
+        return MEMORY_CLASSES[cls].get(name, default)
+    return default
+
+
+@singledispatch
+def load_memory(
+    config: Union[Dict[str, Any], List[Dict[str, Any]]],
+    callback_manager: IxCallbackManager,
+) -> BaseMemory:
     """Load a memory instance using a config"""
     memory_class = import_class(config["class_path"])
     logger.debug(f"loading memory class={memory_class} config={config}")
+    memory_config = config.get("config", {}).copy()
 
-    # TODO: how to integrate with redis, etc?
-    # TODO: any solution has to handle secrets.
+    # load session_id if scope is supported
+    if get_memory_option(memory_class, "supports_session", False):
+        session_id, session_id_key = get_memory_session(
+            memory_config.pop("session", {}), callback_manager, memory_class
+        )
+        memory_config[session_id_key] = session_id
 
-    instance = memory_class(**config.get("config", {}))
-    return instance
+    # load chat memory backend when needed
+    if "backend" in memory_config:
+        chat_memory = load_chat_memory_backend(
+            memory_config.pop("backend"), callback_manager
+        )
+        memory_config["chat_memory"] = chat_memory
+
+    # load chat memory llm when needed
+    if "llm" in memory_config and not isinstance(
+        memory_config["llm"], BaseLanguageModel
+    ):
+        llm = load_llm(memory_config.pop("llm"), callback_manager)
+        memory_config["llm"] = llm
+
+    return memory_class(**memory_config)
+
+
+@load_memory.register(list)
+def _(config: List[Dict[str, Any]], callback_manager: IxCallbackManager) -> BaseMemory:
+    """
+    Load memories from a list of configs and merge in to a CombinedMemory instance.
+    """
+    logger.debug(f"Combining memory classes config={config}")
+    # auto-merge into CombinedMemory
+    return CombinedMemory(memories=[load_memory(c, callback_manager) for c in config])
+
+
+def load_chat_memory_backend(config, callback_manager):
+    backend_class = import_class(config["class_path"])
+    logger.debug(
+        f"loading BaseChatMessageHistory class={backend_class} config={config}"
+    )
+    backend_config = config.get("config", {}).copy()
+
+    # always add scope to chat message backend
+    if "session" in backend_config:
+        session_id, session_id_key = get_memory_session(
+            backend_config.pop("session"), callback_manager, backend_class
+        )
+        logger.debug(
+            f"load_chat_memory_backend session_id={session_id} session_id_key={session_id_key}"
+        )
+        backend_config[session_id_key] = session_id
+
+    return backend_class(**backend_config)
+
+
+def get_memory_session(
+    config: Dict[str, Any],
+    callback_manager: IxCallbackManager,
+    cls: Union[BaseMemory, BaseChatMessageHistory],
+) -> Tuple[str, str]:
+    """
+    Parse the session scope from the given configuration and callback manager.
+
+    This function retrieves the scope from the configuration, verifies if the scope
+    is supported by the given class (cls), and then fetches the corresponding identifier
+    from the callback manager based on the scope. It then constructs the session id
+    by appending the session id base, scope, and scope id.
+
+    Parameters:
+    - config (Dict[str, Any]): The configuration dictionary. Config options include:
+      * "scope" (str): The scope of the interaction. Supported scopes are: "chat", "agent", "task", and "user".
+      * "prefix" (str): The base string for the session id. Default is an empty string.
+      * "key" (str): The key name for the session id in the return tuple. Default is "session_id".
+
+    - callback_manager (IxCallbackManager): The callback manager object which stores identifiers
+      for different scopes.
+
+    - cls (Union[BaseMemory, BaseChatMessageHistory]): Class object that supports the required scope.
+
+    Returns:
+    - Tuple[str, str]: A tuple containing the session id and session id key.
+
+    Raises:
+    - ValueError: If the given scope is not recognized.
+
+    Example:
+    config = {
+      "scope": "chat",
+      "prefix": "prefix_unique_to_chat_scope",
+      "key": "session_id"
+    }
+    session_id, session_id_key = get_memory_session(config, callback_manager, BaseChatMessageHistory)
+    """
+
+    # fetch scope
+    scope = config.get("scope", "chat")
+    if scope in {"", None}:
+        scope = "chat"
+    supported_scopes = get_memory_option(cls, "supported_scopes", False)
+    if supported_scopes:
+        assert scope in supported_scopes
+
+    # load session_id from context based on scope
+    if scope == "chat":
+        scope_id = callback_manager.chat_id
+    elif scope == "agent":
+        scope_id = callback_manager.agent_id
+    elif scope == "task":
+        scope_id = callback_manager.task_id
+    elif scope == "user":
+        scope_id = callback_manager.user_id
+    else:
+        raise ValueError(f"unknown scope={scope}")
+
+    # build session_id
+    prefix = config.get("prefix", None)
+    if prefix:
+        session_id = f"{prefix}_{scope}_{scope_id}"
+    else:
+        session_id = f"{scope}_{scope_id}"
+
+    key = config.get("key", "session_id")
+    return session_id, key
 
 
 def load_chain(config: Dict[str, Any], callback_manager: IxCallbackManager):

--- a/ix/agents/llm.py
+++ b/ix/agents/llm.py
@@ -2,6 +2,7 @@ import logging
 from typing import Dict, Any, Union
 
 from langchain.base_language import BaseLanguageModel
+from langchain.schema import BaseMemory
 
 from ix.agents.callback_manager import IxCallbackManager
 from ix.utils.importlib import import_class
@@ -30,6 +31,18 @@ def load_llm(
     llm = llm_class(**llm_config)
     llm.callback_manager = callback_manager
     return llm
+
+
+def load_memory(config: Dict[str, Any]) -> BaseMemory:
+    """Load a memory instance using a config"""
+    memory_class = import_class(config["class_path"])
+    logger.debug(f"loading memory class={memory_class} config={config}")
+
+    # TODO: how to integrate with redis, etc?
+    # TODO: any solution has to handle secrets.
+
+    instance = memory_class(**config.get("config", {}))
+    return instance
 
 
 def load_chain(config: Dict[str, Any], callback_manager: IxCallbackManager):

--- a/ix/agents/llm.py
+++ b/ix/agents/llm.py
@@ -106,14 +106,13 @@ def load_chat_memory_backend(config, callback_manager):
     backend_config = config.get("config", {}).copy()
 
     # always add scope to chat message backend
-    if "session" in backend_config:
-        session_id, session_id_key = get_memory_session(
-            backend_config.pop("session"), callback_manager, backend_class
-        )
-        logger.debug(
-            f"load_chat_memory_backend session_id={session_id} session_id_key={session_id_key}"
-        )
-        backend_config[session_id_key] = session_id
+    session_id, session_id_key = get_memory_session(
+        backend_config.pop("session", {}), callback_manager, backend_class
+    )
+    logger.debug(
+        f"load_chat_memory_backend session_id={session_id} session_id_key={session_id_key}"
+    )
+    backend_config[session_id_key] = session_id
 
     return backend_class(**backend_config)
 

--- a/ix/agents/tests/mock_llm.py
+++ b/ix/agents/tests/mock_llm.py
@@ -16,19 +16,17 @@ class MockChatOpenAI(ChatOpenAI):
     def set_return_value(self, return_value: Any):
         self.return_value = return_value
 
+    def get_mock_content(self):
+        content = self.return_value or "This is a test."
+        return {
+            "choices": [{"message": {"content": content, "role": "assistant"}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
+        }
+
     def completion_with_retry(self, *args, **kwargs) -> Dict[str, Any]:
         if self.raise_exception:
             raise self.raise_exception
-
-        content = self.return_value or "This is a test."
-        return {
-            "choices": [{"message": {"content": content, "role": "assistant"}}],
-            "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
-        }
+        return self.get_mock_content()
 
     async def _agenerate(self, *args, **kwargs) -> Dict[str, Any]:
-        content = self.return_value or "This is a test."
-        return {
-            "choices": [{"message": {"content": content, "role": "assistant"}}],
-            "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
-        }
+        return self.get_mock_content()

--- a/ix/chains/llm_chain.py
+++ b/ix/chains/llm_chain.py
@@ -58,12 +58,14 @@ class LLMChain(LangchainLLMChain):
     def from_config(cls, config: Dict[str, Any], callback_manager: IxCallbackManager):
         logger.debug(f"Loading IxLLMChain config={config}")
 
-        prepared_config, context = cls.prepare_config(config, callback_manager)
+        prepared_config, message_context = cls.prepare_config(config, callback_manager)
 
         # load message templates and build prompt
         messages = []
         for message in config.pop("messages"):
-            messages.append(cls.create_message(message, prepared_config, context))
+            messages.append(
+                cls.create_message(message, prepared_config, message_context)
+            )
         prompt = ChatPromptTemplate.from_messages(messages)
 
         # initialize memory

--- a/ix/chains/llm_chain.py
+++ b/ix/chains/llm_chain.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Any, Tuple
+from typing import Dict, Any, Tuple, List
 
 from langchain import LLMChain as LangchainLLMChain, PromptTemplate
 from langchain.prompts.chat import (
@@ -25,6 +25,18 @@ TEMPLATE_CLASSES = {
 
 class LLMChain(LangchainLLMChain):
     """Wrapper around LLMChain to provide from_config initialization"""
+
+    @property
+    def input_keys(self) -> List[str]:
+        """
+        Overridden to filter out memory variables from input_variables.
+        This is to be compatible with Sequence, which will raise a validation
+        error since it does not detect the variable is from memory.
+        """
+        as_set = set(self.prompt.input_variables)
+        if self.memory:
+            as_set -= set(self.memory.memory_variables)
+        return list(as_set)
 
     @staticmethod
     def create_message(

--- a/ix/chains/llm_chain.py
+++ b/ix/chains/llm_chain.py
@@ -84,7 +84,7 @@ class LLMChain(LangchainLLMChain):
         memory = None
         memory_config = config.pop("memory", None)
         if memory_config:
-            memory = load_memory(memory_config)
+            memory = load_memory(memory_config, callback_manager)
 
         # build instance
         chain = cls(

--- a/ix/chains/management/commands/create_coder_v1.py
+++ b/ix/chains/management/commands/create_coder_v1.py
@@ -86,6 +86,9 @@ CODER_SEQUENCE = {
     "class_path": "ix.chains.routing.IXSequence",
     "config": {
         "input_variables": ["user_input"],
+        "memory": {
+            "class_path": "ix.memory.artifacts.ArtifactMemory",
+        },
     },
 }
 
@@ -149,7 +152,7 @@ GENERATE_FILES_MAP = {
     "description": "Generates files for each artifact in the input list",
     "class_path": "ix.chains.routing.MapSubchain",
     "config": {
-        "input_variables": ["file_artifacts_json"],
+        "input_variables": ["file_artifacts_json", "related_artifacts"],
         "map_input": "file_artifacts_json",
         "map_input_to": "file_artifact",
         "output_key": "write_file_output",
@@ -169,14 +172,11 @@ GENERATE_FILE = {
                 "verbose": True,
             },
         },
-        "memory": {
-            "class_path": "ix.memory.artifacts.ArtifactMemory",
-        },
         "messages": [
             {
                 "role": "system",
                 "template": GENERATE_CODE_V1,
-                "input_variables": ["file_artifact"],
+                "input_variables": ["file_artifact", "related_artifacts"],
                 "partial_variables": {
                     "file_content_format": FILE_CONTENT_FORMAT,
                 },

--- a/ix/chains/management/commands/create_coder_v1.py
+++ b/ix/chains/management/commands/create_coder_v1.py
@@ -62,6 +62,8 @@ FILE_CONTENT_FORMAT = """
 GENERATE_CODE_V1 = """
 You are a python coder. You will writes files for the user request.
 
+{related_artifacts}
+
 FILE ARTIFACT:
 {file_artifact}
 
@@ -166,6 +168,9 @@ GENERATE_FILE = {
                 "temperature": 0.2,
                 "verbose": True,
             },
+        },
+        "memory": {
+            "class_path": "ix.memory.artifacts.ArtifactMemory",
         },
         "messages": [
             {

--- a/ix/chains/moderator.py
+++ b/ix/chains/moderator.py
@@ -119,7 +119,7 @@ class ChatModerator(Chain):
         # 3. delegate to the agent
         agent = chat.agents.get(alias=alias)
         subtask = chat.task.delegate_to_agent(agent)
-        logger.error(
+        logger.debug(
             f"Delegated to agent={agent.alias} task={subtask.id} input={inputs}"
         )
         start_agent_loop.delay(

--- a/ix/chains/routing.py
+++ b/ix/chains/routing.py
@@ -34,6 +34,9 @@ class IXSequence(SequentialChain):
             chain = load_chain(chain_config, callback_manager=chain_callback_manager)
             chains.append(chain)
 
+        if not chains:
+            raise ValueError("IXSequence requires at least one chain")
+
         return cls(callback_manager=callback_manager, chains=chains, **config)
 
 
@@ -93,7 +96,6 @@ class MapSubchain(Chain):
             iteration_inputs[map_input_to] = value
             logger.debug(f"MapSubchain iteration_inputs={iteration_inputs}")
             iteration_outputs = self.chain.run(outputs=outputs, **iteration_inputs)
-            logger.error(iteration_outputs)
             iteration_mapped_output = iteration_outputs
             logger.debug(f"MapSubchain response outputs={iteration_mapped_output}")
             outputs.append(iteration_mapped_output)

--- a/ix/chains/routing.py
+++ b/ix/chains/routing.py
@@ -5,10 +5,10 @@ from jsonpath_ng import parse as jsonpath_parse
 from langchain.base_language import BaseLanguageModel
 from langchain.chains import SequentialChain
 from langchain.chains.base import Chain
+from pydantic import root_validator
 
 from ix.agents.callback_manager import IxCallbackManager
-from ix.agents.llm import load_chain
-
+from ix.agents.llm import load_chain, load_memory
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +24,10 @@ class IXSequence(SequentialChain):
         # TODO: pass on llm?
         # llm_config = config["llm"]
         # llm = load_llm(llm_config, callback_manager=callback_manager)
+
+        # initialize memory
+        if "memory" in config:
+            config["memory"] = load_memory(config.pop("memory"))
 
         chains = []
         for i, chain_config in enumerate(config.pop("chains")):

--- a/ix/chains/routing.py
+++ b/ix/chains/routing.py
@@ -5,7 +5,6 @@ from jsonpath_ng import parse as jsonpath_parse
 from langchain.base_language import BaseLanguageModel
 from langchain.chains import SequentialChain
 from langchain.chains.base import Chain
-from pydantic import root_validator
 
 from ix.agents.callback_manager import IxCallbackManager
 from ix.agents.llm import load_chain, load_memory

--- a/ix/chains/routing.py
+++ b/ix/chains/routing.py
@@ -25,7 +25,7 @@ class IXSequence(SequentialChain):
         # llm = load_llm(llm_config, callback_manager=callback_manager)
 
         # initialize memory
-        if "memory" in config:
+        if config.get("memory", None):
             config["memory"] = load_memory(config.pop("memory"))
 
         chains = []
@@ -113,8 +113,10 @@ class MapSubchain(Chain):
         input_variables = list(config.get("input_variables", []))
 
         # load chains into an IXSequence to simplify setup
+        # pass memory to sequence since this chain just routes
         chain_config = {
             "chains": config.pop("chains"),
+            "memory": config.pop("memory", None),
             "input_variables": input_variables,
         }
 

--- a/ix/chains/routing.py
+++ b/ix/chains/routing.py
@@ -26,7 +26,7 @@ class IXSequence(SequentialChain):
 
         # initialize memory
         if config.get("memory", None):
-            config["memory"] = load_memory(config.pop("memory"))
+            config["memory"] = load_memory(config.pop("memory"), callback_manager)
 
         chains = []
         for i, chain_config in enumerate(config.pop("chains")):

--- a/ix/chains/tests/mock_memory.py
+++ b/ix/chains/tests/mock_memory.py
@@ -1,0 +1,25 @@
+from typing import Dict, Any, List
+
+from langchain.schema import BaseMemory
+
+
+class MockMemory(BaseMemory):
+    """
+    Mock memory that returns a fixed set of values
+    Used for testing only.
+    """
+
+    value_map: Dict[str, str] = {'mock_memory_input': 'mock memory'}
+
+    @property
+    def memory_variables(self) -> List[str]:
+        return list(self.value_map.keys())
+
+    def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+        return self.value_map
+
+    def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
+        pass
+
+    def clear(self) -> None:
+        pass

--- a/ix/chains/tests/mock_memory.py
+++ b/ix/chains/tests/mock_memory.py
@@ -9,7 +9,8 @@ class MockMemory(BaseMemory):
     Used for testing only.
     """
 
-    value_map: Dict[str, str] = {'mock_memory_input': 'mock memory'}
+    value_map: Dict[str, str] = {"mock_memory_input": "mock memory"}
+    session_id: str = "mock_session_id"
 
     @property
     def memory_variables(self) -> List[str]:

--- a/ix/chains/tests/test_artifacts.py
+++ b/ix/chains/tests/test_artifacts.py
@@ -153,8 +153,6 @@ class TestSaveArtifact:
         kwargs = {}
         if "artifact_from_key" in config["config"]:
             kwargs["mock_artifact"] = MOCK_ARTIFACT
-        print("kwargs", kwargs)
-        print("config", config)
 
         result = chain.run(artifact_content=MOCK_CONTENT, **kwargs)
 

--- a/ix/chains/tests/test_config_loader.py
+++ b/ix/chains/tests/test_config_loader.py
@@ -1,0 +1,306 @@
+from copy import deepcopy
+
+import pytest
+from unittest.mock import MagicMock
+
+from langchain.base_language import BaseLanguageModel
+from langchain.memory import (
+    ConversationBufferMemory,
+    ConversationSummaryBufferMemory,
+    CombinedMemory,
+)
+from langchain.schema import BaseChatMessageHistory, BaseMemory
+
+from ix.agents.callback_manager import IxCallbackManager
+from ix.agents.llm import (
+    get_memory_session,
+    load_chat_memory_backend,
+    load_memory,
+)
+from ix.chains.tests.mock_memory import MockMemory
+from ix.memory.artifacts import ArtifactMemory
+
+
+class TestLoadLLM:
+    pass
+
+
+MEMORY = {
+    "class_path": "langchain.memory.ConversationBufferMemory",
+    "config": {
+        "input_key": "user_input",
+        "memory_key": "chat_history",
+    },
+}
+
+MEMORY_WITH_BACKEND = {
+    "class_path": "langchain.memory.ConversationBufferMemory",
+    "config": {
+        "input_key": "user_input",
+        "memory_key": "chat_history",
+        "backend": {
+            "class_path": "langchain.memory.RedisChatMessageHistory",
+            "config": {"url": "redis://redis:6379/0", "session": {"scope": "task"}},
+        },
+    },
+}
+
+MEMORY_WITH_LLM = {
+    "class_path": "langchain.memory.summary_buffer.ConversationSummaryBufferMemory",
+    "config": {
+        "input_key": "user_input",
+        "memory_key": "chat_summary",
+        "llm": {
+            "class_path": "langchain.chat_models.openai.ChatOpenAI",
+        },
+    },
+}
+
+MEMORY_WITH_SCOPE = {
+    "class_path": "ix.memory.artifacts.ArtifactMemory",
+    "config": {
+        "variable": "chat_history",
+        "session": {"scope": "chat", "prefix": "tests"},
+    },
+}
+
+CHAT_MESSAGES = [
+    {
+        "role": "system",
+        "template": "You are a test bot.",
+    },
+    {
+        "role": "user",
+        "template": "{user_input}",
+        "input_variables": ["user_input"],
+    },
+]
+
+CHAT_MESSAGES_WITH_CHAT_HISTORY = [
+    {
+        "role": "system",
+        "template": "You are a test bot! HISTORY: {chat_history}",
+        "input_variables": ["chat_history"],
+    },
+    {
+        "role": "user",
+        "template": "{user_input}",
+        "input_variables": ["user_input"],
+    },
+]
+
+LLM_REPLY = {
+    "class_path": "ix.chains.llm_chain.LLMReply",
+    "config": {
+        "messages": CHAT_MESSAGES,
+        "llm": {
+            "class_path": "langchain.chat_models.openai.ChatOpenAI",
+        },
+    },
+}
+
+LLM_REPLY_WITH_HISTORY = {
+    "class_path": "ix.chains.llm_chain.LLMReply",
+    "config": {
+        "messages": CHAT_MESSAGES_WITH_CHAT_HISTORY,
+        "llm": {
+            "class_path": "langchain.chat_models.openai.ChatOpenAI",
+        },
+    },
+}
+
+LLM_REPLY_WITH_HISTORY_AND_MEMORY = {
+    "class_path": "ix.chains.llm_chain.LLMReply",
+    "config": {
+        "messages": CHAT_MESSAGES_WITH_CHAT_HISTORY,
+        "memory": MEMORY,
+        "llm": {
+            "class_path": "langchain.chat_models.openai.ChatOpenAI",
+        },
+    },
+}
+
+
+@pytest.mark.django_db
+class TestLoadMemory:
+    def test_load_memory(self, mock_callback_manager):
+        instance = load_memory(MEMORY, mock_callback_manager)
+        assert isinstance(instance, ConversationBufferMemory)
+
+    def test_load_multiple(self, mock_callback_manager):
+        """Test loading multiple memories into a CombinedMemory"""
+        MEMORY2 = deepcopy(MEMORY)
+        MEMORY2["config"]["memory_key"] = "chat_history2"
+
+        instance = load_memory([MEMORY, MEMORY2], mock_callback_manager)
+        assert isinstance(instance, CombinedMemory)
+        assert len(instance.memories) == 2
+        assert instance.memories[0].memory_key == "chat_history"
+        assert instance.memories[1].memory_key == "chat_history2"
+
+    def test_load_backend(self, mock_callback_manager):
+        """
+        A memory class can have a backend that separates memory logic from
+        the storage system. ChatMemory works this way.
+        """
+        instance = load_memory(MEMORY_WITH_BACKEND, mock_callback_manager)
+        assert isinstance(instance, ConversationBufferMemory)
+        assert isinstance(instance.chat_memory, BaseChatMessageHistory)
+
+    def test_load_memory_with_scope(self, task, mock_callback_manager):
+        """
+        Test loading with a scope.
+
+        Not all memories support sessions, for example ChatMemory
+        adds scoping to the backend.
+        """
+        chat_id = task.leading_chats.first().id
+        instance = load_memory(MEMORY_WITH_SCOPE, mock_callback_manager)
+        assert isinstance(instance, ArtifactMemory)
+        assert instance.session_id == f"tests_chat_{chat_id}"
+
+    def test_load_llm(self, mock_callback_manager):
+        """
+        Memory classes may optionally load an llm. (e.g. SummaryMemory)
+        """
+        instance = load_memory(MEMORY_WITH_LLM, mock_callback_manager)
+        assert isinstance(instance, ConversationSummaryBufferMemory)
+        assert isinstance(instance.llm, BaseLanguageModel)
+
+    def test_load_class_with_config(self, task, mocker, mock_callback_manager):
+        """
+        Test loading a class whose config is defined in MEMORY_CLASSES.
+        This tests configuring an external class with the required config
+        to integrate into Ix
+        """
+        chat_id = task.leading_chats.first().id
+
+        # patch MEMORY_CLASSES to setup the test
+        from ix.agents import llm
+
+        mock_memory_classes = {
+            MockMemory: {
+                "supports_session": True,
+            }
+        }
+        mocker.patch.object(llm, "MEMORY_CLASSES", mock_memory_classes)
+
+        # load a memory that will use the mock class config
+        instance = load_memory(
+            {
+                "class_path": "ix.chains.tests.mock_memory.MockMemory",
+                "config": {
+                    "session": {"scope": "chat", "prefix": "tests"},
+                },
+            },
+            mock_callback_manager,
+        )
+        assert isinstance(instance, MockMemory)
+        assert instance.session_id == f"tests_chat_{chat_id}"
+
+
+@pytest.mark.django_db
+class TestLoadChatMemoryBackend:
+    def test_load_chat_memory_backend(self, task, mock_callback_manager):
+        chat_id = task.leading_chats.first().id
+
+        # Config
+        config = {
+            "class_path": "langchain.memory.RedisChatMessageHistory",
+            "config": {
+                "url": "redis://redis:6379/0",
+                "session": {"scope": "chat", "prefix": "tests"},
+            },
+        }
+
+        # Run
+        backend = load_chat_memory_backend(config, mock_callback_manager)
+        assert backend.session_id == f"tests_chat_{chat_id}"
+
+
+@pytest.mark.django_db
+class TestGetMemorySession:
+    """Test parsing the session scope from the chain config and runtime context."""
+
+    @pytest.mark.parametrize(
+        "config, cls, expected",
+        [
+            # No scope - defaults to chat
+            (
+                {"scope": "", "prefix": "123", "key": "session_id"},
+                BaseChatMessageHistory,
+                ("123_chat_1000", "session_id"),
+            ),
+            (
+                {"scope": None, "prefix": "123", "key": "session_id"},
+                BaseChatMessageHistory,
+                ("123_chat_1000", "session_id"),
+            ),
+            (
+                {"prefix": "123", "key": "session_id"},
+                BaseChatMessageHistory,
+                ("123_chat_1000", "session_id"),
+            ),
+            # agent, task, user scopes
+            (
+                {"scope": "agent", "prefix": "456", "key": "session_id"},
+                BaseMemory,
+                ("456_agent_1001", "session_id"),
+            ),
+            (
+                {"scope": "task", "prefix": "789", "key": "session_id"},
+                BaseMemory,
+                ("789_task_1002", "session_id"),
+            ),
+            (
+                {"scope": "user", "prefix": "321", "key": "session_id"},
+                BaseChatMessageHistory,
+                ("321_user_1003", "session_id"),
+            ),
+            # custom session_id_key
+            (
+                {"scope": "chat", "key": "chat_session"},
+                BaseChatMessageHistory,
+                ("chat_1000", "chat_session"),
+            ),
+            # no session prefix
+            (
+                {"scope": "chat", "key": "session_id"},
+                BaseChatMessageHistory,
+                ("chat_1000", "session_id"),
+            ),
+            # custom session prefix
+            (
+                {"scope": "chat", "prefix": "static_session_id"},
+                BaseChatMessageHistory,
+                ("static_session_id_chat_1000", "session_id"),
+            ),
+        ],
+    )
+    def test_get_memory_session(self, task, config, cls, expected):
+        """Test various scope configurations."""
+        callback_manager = MagicMock(spec=IxCallbackManager)
+        callback_manager.task = task
+        callback_manager.chat_id = "1000"
+        callback_manager.agent_id = "1001"
+        callback_manager.task_id = "1002"
+        callback_manager.user_id = "1003"
+
+        result = get_memory_session(config, callback_manager, cls)
+        assert result == expected
+
+    def test_parse_scope_unsupported_scope(self, mock_callback_manager):
+        config = {
+            "scope": "unsupported_scope",
+            "session_id": "123",
+            "session_id_key": "session_id",
+        }
+        cls = BaseChatMessageHistory
+        with pytest.raises(ValueError) as excinfo:
+            get_memory_session(config, mock_callback_manager, cls)
+        assert "unknown scope" in str(excinfo.value)
+
+
+class TestLoadChain:
+    def test_load_chain(self):
+        pass

--- a/ix/chains/tests/test_config_loader.py
+++ b/ix/chains/tests/test_config_loader.py
@@ -59,7 +59,7 @@ MEMORY_WITH_LLM = {
 MEMORY_WITH_SCOPE = {
     "class_path": "ix.memory.artifacts.ArtifactMemory",
     "config": {
-        "variable": "chat_history",
+        "memory_key": "chat_history",
         "session": {"scope": "chat", "prefix": "tests"},
     },
 }

--- a/ix/chains/tests/test_config_loader.py
+++ b/ix/chains/tests/test_config_loader.py
@@ -217,6 +217,26 @@ class TestLoadChatMemoryBackend:
         backend = load_chat_memory_backend(config, mock_callback_manager)
         assert backend.session_id == f"tests_chat_{chat_id}"
 
+    def test_load_defaults(self, task, mock_callback_manager):
+        """
+        ChatMemoryBackend should always load session_id. If `session` isn't present then
+        load the `chat` scope by default.
+        """
+
+        chat_id = task.leading_chats.first().id
+
+        # Config
+        config = {
+            "class_path": "langchain.memory.RedisChatMessageHistory",
+            "config": {
+                "url": "redis://redis:6379/0",
+            },
+        }
+
+        # Run
+        backend = load_chat_memory_backend(config, mock_callback_manager)
+        assert backend.session_id == f"chat_{chat_id}"
+
 
 @pytest.mark.django_db
 class TestGetMemorySession:

--- a/ix/chains/tests/test_config_loader.py
+++ b/ix/chains/tests/test_config_loader.py
@@ -159,7 +159,7 @@ class TestLoadMemory:
         assert isinstance(instance, ArtifactMemory)
         assert instance.session_id == f"tests_chat_{chat_id}"
 
-    def test_load_llm(self, mock_callback_manager):
+    def test_load_llm(self, mock_callback_manager, mock_openai):
         """
         Memory classes may optionally load an llm. (e.g. SummaryMemory)
         """

--- a/ix/chains/tests/test_llm_chain.py
+++ b/ix/chains/tests/test_llm_chain.py
@@ -15,7 +15,7 @@ EXAMPLE_CONFIG = {
         },
         "memory": {
             "class_path": "ix.chains.tests.mock_memory.MockMemory",
-            "config": {"value_map": {'mock_memory_input': 'mock memory'}},
+            "config": {"value_map": {"mock_memory_input": "mock memory"}},
         },
         "messages": [
             {

--- a/ix/chains/tests/test_llm_chain.py
+++ b/ix/chains/tests/test_llm_chain.py
@@ -4,6 +4,7 @@ from langchain.chat_models.openai import ChatOpenAI
 
 from ix.agents.callback_manager import IxCallbackManager
 from ix.chains.llm_chain import LLMChain, TEMPLATE_CLASSES
+from ix.chains.tests.mock_memory import MockMemory
 
 EXAMPLE_CONFIG = {
     "class_path": "ix.chains.tool_chain.LLMToolChain",
@@ -11,6 +12,10 @@ EXAMPLE_CONFIG = {
         "llm": {
             "class_path": "langchain.chat_models.openai.ChatOpenAI",
             "config": {"request_timeout": 120, "temperature": 0.2, "verbose": True},
+        },
+        "memory": {
+            "class_path": "ix.chains.tests.mock_memory.MockMemory",
+            "config": {"value_map": {'mock_memory_input': 'mock memory'}},
         },
         "messages": [
             {
@@ -81,3 +86,5 @@ class TestLLMChain:
         )
         assert chain.prompt.messages[1].prompt.partial_variables == {}
         assert chain.callbacks == callback_manager_mock
+
+        assert isinstance(chain.memory, MockMemory)

--- a/ix/chains/tests/test_llm_chain.py
+++ b/ix/chains/tests/test_llm_chain.py
@@ -72,12 +72,12 @@ class TestLLMChain:
 
     def test_from_config(self, load_llm_mock, callback_manager_mock):
         config = EXAMPLE_CONFIG["config"].copy()
-        result = LLMChain.from_config(config, callback_manager_mock)
+        chain = LLMChain.from_config(config, callback_manager_mock)
 
-        assert isinstance(result, LLMChain)
+        assert isinstance(chain, LLMChain)
         assert (
-            result.prompt.messages[0].prompt.partial_variables
+            chain.prompt.messages[0].prompt.partial_variables
             == EXAMPLE_CONFIG["config"]["messages"][0]["partial_variables"]
         )
-        assert result.prompt.messages[1].prompt.partial_variables == {}
-        assert result.callbacks == callback_manager_mock
+        assert chain.prompt.messages[1].prompt.partial_variables == {}
+        assert chain.callbacks == callback_manager_mock

--- a/ix/chains/tests/test_routing.py
+++ b/ix/chains/tests/test_routing.py
@@ -1,13 +1,21 @@
 from copy import deepcopy
+from unittest.mock import MagicMock
 
 import pytest
+from langchain.schema import HumanMessage
 
 from ix.agents.llm import load_chain
 from ix.chains.models import ChainNode
 from ix.chains.routing import MapSubchain
 from ix.chains.tests.mock_chain import MOCK_CHAIN_CONFIG
+from ix.chains.tests.test_config_loader import (
+    MEMORY,
+    LLM_REPLY_WITH_HISTORY,
+    LLM_REPLY_WITH_HISTORY_AND_MEMORY,
+    LLM_REPLY,
+)
 
-EXAMPLE_CONFIG = {
+MAP_SUBCHAIN = {
     "name": "refine",
     "node_type": "list",
     "description": "testing MapSubchain",
@@ -21,11 +29,128 @@ EXAMPLE_CONFIG = {
 }
 
 
+MAP_SUBCHAIN_WITH_MEMORY = {
+    "name": "refine",
+    "node_type": "list",
+    "description": "testing MapSubchain",
+    "class_path": "ix.chains.routing.MapSubchain",
+    "config": {
+        "input_variables": ["user_inputs"],
+        "map_input": "user_inputs",
+        "map_input_to": "user_input",
+        "output_key": "output1",
+        "memory": MEMORY,
+    },
+}
+
+
+SEQUENCE = {
+    "name": "test sequence",
+    "node_type": "list",
+    "description": "testing IXSequence",
+    "class_path": "ix.chains.routing.IXSequence",
+    "config": {
+        "input_variables": ["user_input"],
+    },
+}
+
+
+# memory configured on sequence
+SEQUENCE_WITH_MEMORY = {
+    "class_path": "ix.chains.routing.IXSequence",
+    "node_type": "list",
+    "config": {
+        "chains": [],
+        "memory": MEMORY,
+        "input_variables": ["user_input"],
+    },
+}
+
+
 @pytest.fixture
 def mock_subchain_config():
-    config = deepcopy(EXAMPLE_CONFIG)
+    config = deepcopy(MAP_SUBCHAIN)
     config["config"]["chains"] = [MOCK_CHAIN_CONFIG]
     yield config
+
+
+@pytest.mark.django_db
+class TestIXSequence:
+    """Test loading sequences"""
+
+    def test_load(self, mock_callback_manager, mock_openai):
+        mock_openai.__dict__["completion_with_retry"] = MagicMock(
+            return_value=mock_openai.get_mock_content()
+        )
+
+        # create chain
+        node = ChainNode.objects.create(**SEQUENCE)
+        node.add_child(**LLM_REPLY)
+        chain = node.load_chain(mock_callback_manager)
+
+        # verify result
+        result = chain.run(user_input="test1")
+        assert result == "mock llm response"
+
+    def test_load_without_chains(self, mock_callback_manager):
+        """Requires at least one child chain"""
+        node = ChainNode.objects.create(**SEQUENCE)
+        with pytest.raises(ValueError, match="IXSequence requires at least one chain"):
+            node.load_chain(mock_callback_manager)
+
+    def test_with_memory(self, mock_callback_manager, mock_openai):
+        mock_openai.__dict__["completion_with_retry"] = MagicMock(
+            return_value=mock_openai.get_mock_content()
+        )
+
+        # create chain
+        node = ChainNode.objects.create(**SEQUENCE_WITH_MEMORY)
+        node.add_child(**LLM_REPLY_WITH_HISTORY)
+        chain = node.load_chain(mock_callback_manager)
+
+        # pre-seed memory
+        chain.memory.chat_memory.messages = [
+            HumanMessage(content="this is a seeded memory")
+        ]
+
+        # verify result
+        result = chain.run(user_input="test1")
+        assert result == "mock llm response"
+        messages = mock_openai.completion_with_retry.call_args_list[0].kwargs[
+            "messages"
+        ]
+        system_message = messages[0]
+        assert (
+            system_message["content"]
+            == "You are a test bot! HISTORY: Human: this is a seeded memory"
+        )
+
+    def test_with_memory_on_chain(self, mock_callback_manager, mock_openai):
+        mock_openai.__dict__["completion_with_retry"] = MagicMock(
+            return_value=mock_openai.get_mock_content()
+        )
+
+        # create chain
+        node = ChainNode.objects.create(**SEQUENCE)
+        node.add_child(**LLM_REPLY_WITH_HISTORY_AND_MEMORY)
+        chain = node.load_chain(mock_callback_manager)
+
+        # pre-seed memory
+        chain.chains[0].memory.chat_memory.messages = [
+            HumanMessage(content="this is a seeded memory")
+        ]
+
+        # verify result
+        result = chain.run(user_input="test1")
+        assert result == "mock llm response"
+        messages = mock_openai.completion_with_retry.call_args_list[0].kwargs[
+            "messages"
+        ]
+        system_message = messages[0]
+        assert (
+            system_message["content"]
+            == "You are a test bot! HISTORY: Human: this is a seeded memory"
+        )
 
 
 @pytest.mark.django_db
@@ -61,7 +186,7 @@ class TestMapSubchain:
 
     def test_model_save_load_run(self, mock_callback_manager):
         # create nodes
-        node = ChainNode.objects.create(**EXAMPLE_CONFIG)
+        node = ChainNode.objects.create(**MAP_SUBCHAIN)
         node.add_child(**MOCK_CHAIN_CONFIG)
 
         # load chain
@@ -71,3 +196,34 @@ class TestMapSubchain:
         inputs = {"input1": ["test1", "test2", "test3"]}
         output = chain.run(**inputs)
         assert output == ["test1", "test2", "test3"]
+
+    def test_memory(self, mock_callback_manager, mock_openai):
+        mock_openai.__dict__["completion_with_retry"] = MagicMock(
+            return_value=mock_openai.get_mock_content()
+        )
+
+        # create chain
+        node = ChainNode.objects.create(**MAP_SUBCHAIN_WITH_MEMORY)
+        node.add_child(**LLM_REPLY_WITH_HISTORY)
+        chain = node.load_chain(mock_callback_manager)
+
+        # pre-seed memory (chain is on MapSubchains internal IXSequence)
+        chain.chain.memory.chat_memory.messages = [
+            HumanMessage(content="this is a seeded memory")
+        ]
+
+        # run chain
+        inputs = {"user_inputs": ["test1", "test2", "test3"]}
+        output = chain.run(**inputs)
+        assert output == ["mock llm response", "mock llm response", "mock llm response"]
+
+        # assert memory was in the prompts
+        call_args_list = mock_openai.completion_with_retry.call_args_list
+        assert len(call_args_list) == 3
+        system_message1 = call_args_list[0].kwargs["messages"][0]["content"]
+        system_message2 = call_args_list[1].kwargs["messages"][0]["content"]
+        system_message3 = call_args_list[2].kwargs["messages"][0]["content"]
+        assert "this is a seeded memory" in system_message1
+        assert "Human: test1" in system_message2
+        assert "Human: test1" in system_message3
+        assert "Human: test2" in system_message3

--- a/ix/conftest.py
+++ b/ix/conftest.py
@@ -46,6 +46,7 @@ def mock_openai(mocker, mock_openai_key):
 
 @pytest.fixture
 def mock_callback_manager(task):
+    fake_chat(task=task)
     manager = IxCallbackManager(task)
     manager.think_msg = fake_think(task=task)
     yield manager

--- a/ix/conftest.py
+++ b/ix/conftest.py
@@ -31,6 +31,7 @@ def mock_openai_key(monkeypatch):
 def mock_openai(mocker, mock_openai_key):
     # create a mock instance of the class
     mock_llm = MockChatOpenAI()
+    mock_llm.return_value = "mock llm response"
 
     # mock the class to return the instance we're creating here
     mock_class = MagicMock(return_value=mock_llm)

--- a/ix/memory/artifacts.py
+++ b/ix/memory/artifacts.py
@@ -1,8 +1,13 @@
+import logging
 from typing import Dict, Any, List
 
+from django.db.models import Q
 from langchain.schema import BaseMemory
 
 from ix.task_log.models import Artifact
+
+
+logger = logging.getLogger(__name__)
 
 
 class ArtifactMemory(BaseMemory):
@@ -14,6 +19,7 @@ class ArtifactMemory(BaseMemory):
     load_artifact: bool = False
 
     # read
+    input_key: str = "artifact_keys"
     variable: str = "related_artifacts"
     scope: str = None
 
@@ -22,30 +28,41 @@ class ArtifactMemory(BaseMemory):
 
     @property
     def memory_variables(self) -> List[str]:
-        return ["related_artifacts"]
+        return [self.variable]
 
     def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Load related artifacts into memory"""
+        logger.debug(
+            f"ArtifactMemory.load_memory_variables input_key={self.input_key} inputs={inputs}"
+        )
 
         # search for artifacts
-
         # TODO: limit scope of artifact query
         # TODO: add support for LLM search
         # TODO: add support for similarity search
-        referenced_keys = inputs.get("referenced_artifact_keys", None)
-        if referenced_keys:
-            artifacts = Artifact.objects.filter(key__in=referenced_keys)
+        text = ""
+        artifact_keys = inputs.get(self.input_key, None)
+        if artifact_keys:
+            artifacts = Artifact.objects.filter(
+                Q(key__in=artifact_keys) | Q(name__in=artifact_keys)
+            ).order_by("-created_at")
 
-            # format each artifact
-            artifact_strs = []
-            for artifact in artifacts:
-                artifact_strs.append(artifact.as_memory_text())
-            artifact_prompt = "\n\n".join(artifact_strs)
-            text = f"REFERENCED ARTIFACTS:\n\n {artifact_prompt}"
-        else:
-            text = ""
+            logger.debug(f"Found n={len(artifacts)} artifacts")
+            if artifacts:
+                # format each artifact
+                # HAX: group by key to avoid duplicates, this is done here since it's
+                # a lot simpler than doing it in the query. This method will still
+                # query all the duplicates but only becomes an issue if there is a
+                # large number of duplicates
+                artifact_strs = {}
+                for artifact in artifacts:
+                    if artifact.key not in artifact_strs:
+                        artifact_strs[artifact.key] = artifact.as_memory_text()
+                artifact_prompt = "".join(artifact_strs.values())
+                text = f"REFERENCED ARTIFACTS:\n{artifact_prompt}"
 
         # return formatted artifacts
+        logger.debug(f"ArtifactMemory.load_memory_variables text={text}")
         return {self.variable: text}
 
     def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:

--- a/ix/memory/artifacts.py
+++ b/ix/memory/artifacts.py
@@ -1,0 +1,57 @@
+from typing import Dict, Any, List
+
+from langchain.schema import BaseMemory
+
+from ix.task_log.models import Artifact
+
+
+class ArtifactMemory(BaseMemory):
+    """
+    A memory implementation that loads artifacts into the context
+    """
+
+    save_artifact: bool = False
+    load_artifact: bool = False
+
+    # read
+    variable: str = "related_artifacts"
+    scope: str = None
+
+    # write
+    # TODO
+
+    @property
+    def memory_variables(self) -> List[str]:
+        return ["related_artifacts"]
+
+    def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+        """Load related artifacts into memory"""
+
+        # search for artifacts
+
+        # TODO: limit scope of artifact query
+        # TODO: add support for LLM search
+        # TODO: add support for similarity search
+        referenced_keys = inputs.get("referenced_artifact_keys", None)
+        if referenced_keys:
+            artifacts = Artifact.objects.filter(key__in=referenced_keys)
+
+            # format each artifact
+            artifact_strs = []
+            for artifact in artifacts:
+                artifact_strs.append(artifact.as_memory_text())
+            artifact_prompt = "\n\n".join(artifact_strs)
+            text = f"REFERENCED ARTIFACTS:\n\n {artifact_prompt}"
+        else:
+            text = ""
+
+        # return formatted artifacts
+        return {self.variable: text}
+
+    def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
+        """Save artifacts from step"""
+        # TODO: move SaveArtifact logic here
+        pass
+
+    def clear(self) -> None:
+        pass

--- a/ix/memory/artifacts.py
+++ b/ix/memory/artifacts.py
@@ -20,7 +20,7 @@ class ArtifactMemory(BaseMemory):
 
     # read
     input_key: str = "artifact_keys"
-    variable: str = "related_artifacts"
+    memory_key: str = "related_artifacts"
 
     session_id: str
     supports_session: bool = True
@@ -28,7 +28,7 @@ class ArtifactMemory(BaseMemory):
 
     @property
     def memory_variables(self) -> List[str]:
-        return [self.variable]
+        return [self.memory_key]
 
     def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Load related artifacts into memory"""
@@ -67,7 +67,7 @@ class ArtifactMemory(BaseMemory):
 
         # return formatted artifacts
         logger.debug(f"ArtifactMemory.load_memory_variables text={text}")
-        return {self.variable: text}
+        return {self.memory_key: text}
 
     def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
         """

--- a/ix/memory/tests/test_artifact_memory.py
+++ b/ix/memory/tests/test_artifact_memory.py
@@ -68,19 +68,18 @@ class TestArtifactMemory:
         ][0]
         assert artifact1.as_memory_text() in message["content"]
 
-    def test_defaults(self):
-        instance = load_memory(ARTIFACT_MEMORY)
+    def test_defaults(self, mock_callback_manager):
+        instance = load_memory(ARTIFACT_MEMORY, mock_callback_manager)
         assert isinstance(instance, ArtifactMemory)
 
         # test memory variables
         assert instance.memory_variables == ["related_artifacts"]
 
-    def test_load_memory(self, task):
+    def test_load_memory(self, task, mock_callback_manager):
         """
         Test various scenarios for loading memory variables.
         """
-        instance = load_memory(ARTIFACT_MEMORY)
-
+        instance = load_memory(ARTIFACT_MEMORY, mock_callback_manager)
         artifact1 = fake_artifact(task=task, key="test_artifact_1")
         artifact2 = fake_artifact(task=task, key="test_artifact_2")
 
@@ -117,13 +116,13 @@ class TestArtifactMemory:
         """Test mapping config input/outputs"""
         pass
 
-    def test_scope(self, task):
-        # artifact from another task, same user
+    def test_scope(self, task, mock_callback_manager):
+        # artifact from another chat
         unrelated_task = fake_task()
-        artifact2 = fake_artifact(task=unrelated_task, key="test_artifact_3")
+        fake_artifact(task=unrelated_task, key="test_artifact_3")
 
-        # artifact from another task, different user
-        unrelated_task = fake_task()
-        artifact3 = fake_artifact(task=unrelated_task, key="test_artifact_3")
-
-        pass
+        # none of the excluded artifacts should be included in the memory
+        instance = load_memory(ARTIFACT_MEMORY, mock_callback_manager)
+        inputs = dict(artifact_keys=["test_artifact_3"])
+        result1 = instance.load_memory_variables(inputs=inputs)
+        assert result1 == {"related_artifacts": ""}

--- a/ix/memory/tests/test_artifact_memory.py
+++ b/ix/memory/tests/test_artifact_memory.py
@@ -1,0 +1,129 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from ix.agents.llm import load_memory
+from ix.chains.llm_chain import LLMChain
+from ix.memory.artifacts import ArtifactMemory
+from ix.task_log.tests.fake import fake_artifact, fake_task
+
+ARTIFACT_MEMORY = {
+    "class_path": "ix.memory.artifacts.ArtifactMemory",
+    "config": {
+        "load_artifact": True,
+    },
+}
+
+
+TASK_WITH_ARTIFACT_MEMORY = {
+    "class_path": "ix.chains.tool_chain.LLMToolChain",
+    "config": {
+        "llm": {
+            "class_path": "langchain.chat_models.openai.ChatOpenAI",
+            "config": {"verbose": True},
+        },
+        "memory": ARTIFACT_MEMORY,
+        "messages": [
+            {
+                "role": "system",
+                "template": "You are {name}! Answer a question about artifacts {related_artifacts}",
+                "input_variables": ["name", "related_artifacts"],
+            },
+        ],
+    },
+}
+
+
+@pytest.mark.django_db
+class TestArtifactMemory:
+    def test_llm_integration(self, task, mock_callback_manager, mock_openai):
+        """
+        Test memory class when integrated with LLMChain. Tests that langchain
+        will detect the memory variables and include them when rendering the prompt.
+        """
+
+        # configure mock
+        mock_openai.__dict__["completion_with_retry"] = MagicMock(
+            return_value=mock_openai.get_mock_content()
+        )
+
+        # create chain
+        config = TASK_WITH_ARTIFACT_MEMORY["config"].copy()
+        chain = LLMChain.from_config(config, mock_callback_manager)
+        assert isinstance(chain, LLMChain)
+        assert isinstance(chain.memory, ArtifactMemory)
+
+        # verify memory isn't in input_keys. If it's in input_keys, it will be
+        # required as an input by Sequence.
+        assert chain.input_keys == ["name"]
+
+        # run
+        artifact1 = fake_artifact(task=task, key="test_artifact_1")
+        chain.run(name="tester", artifact_keys=["test_artifact_1"])
+
+        # assert artifact was used in prompt
+        mock_openai.completion_with_retry.assert_called_once()
+        message = mock_openai.completion_with_retry.call_args_list[0].kwargs[
+            "messages"
+        ][0]
+        assert artifact1.as_memory_text() in message["content"]
+
+    def test_defaults(self):
+        instance = load_memory(ARTIFACT_MEMORY)
+        assert isinstance(instance, ArtifactMemory)
+
+        # test memory variables
+        assert instance.memory_variables == ["related_artifacts"]
+
+    def test_load_memory(self, task):
+        """
+        Test various scenarios for loading memory variables.
+        """
+        instance = load_memory(ARTIFACT_MEMORY)
+
+        artifact1 = fake_artifact(task=task, key="test_artifact_1")
+        artifact2 = fake_artifact(task=task, key="test_artifact_2")
+
+        # test no artifact_keys
+        result1 = instance.load_memory_variables(dict())
+        assert result1 == {"related_artifacts": ""}
+
+        # test empty artifact_keys
+        result1 = instance.load_memory_variables(dict(artifact_keys=[]))
+        assert result1 == {"related_artifacts": ""}
+
+        # test one artifact_key
+        inputs = dict(artifact_keys=["test_artifact_1"])
+        result2 = instance.load_memory_variables(inputs=inputs)
+        assert "REFERENCED ARTIFACTS:" in result2["related_artifacts"]
+        assert artifact1.as_memory_text() in result2["related_artifacts"]
+        assert artifact2.as_memory_text() not in result2["related_artifacts"]
+
+        # test one artifact_key
+        inputs = dict(artifact_keys=["test_artifact_1", "test_artifact_2"])
+        result3 = instance.load_memory_variables(inputs=inputs)
+        assert "REFERENCED ARTIFACTS:" in result3["related_artifacts"]
+        assert artifact1.as_memory_text() in result3["related_artifacts"]
+        assert artifact2.as_memory_text() in result3["related_artifacts"]
+
+        # test unknown artifact_key
+        # hax: this won't raise an error of any kind now, but it's worth considering
+        #      how to handle this better in the future.
+        inputs = dict(artifact_keys=["test_artifact_does_not_exist"])
+        result4 = instance.load_memory_variables(inputs=inputs)
+        assert result4 == {"related_artifacts": ""}
+
+    def test_mapped_keys(self):
+        """Test mapping config input/outputs"""
+        pass
+
+    def test_scope(self, task):
+        # artifact from another task, same user
+        unrelated_task = fake_task()
+        artifact2 = fake_artifact(task=unrelated_task, key="test_artifact_3")
+
+        # artifact from another task, different user
+        unrelated_task = fake_task()
+        artifact3 = fake_artifact(task=unrelated_task, key="test_artifact_3")
+
+        pass

--- a/ix/schema/tests/test_chat_mutations.py
+++ b/ix/schema/tests/test_chat_mutations.py
@@ -184,7 +184,11 @@ class TestChatInputMutation:
         mock_start_agent_loop.delay.assert_called_once_with(
             str(chat.task.id),
             str(chat.task.chain.id),
-            inputs={"user_input": "Test input", "chat_id": str(chat.id)},
+            inputs={
+                "user_input": "Test input",
+                "chat_id": str(chat.id),
+                "artifact_keys": [],
+            },
         )
 
     def test_chat_input_non_existent_chat(self):

--- a/ix/task_log/models.py
+++ b/ix/task_log/models.py
@@ -157,13 +157,13 @@ class Artifact(models.Model):
         Return a string representation of this artifact for inclusion in prompts
         """
         return f"""
-        id: {self.id}
-        key: {self.key}
-        type: {self.artifact_type}
-        desc: {self.description}
-        data:
-        {self.data}
-        """
+id: {self.id}
+key: {self.key}
+type: {self.artifact_type}
+desc: {self.description}
+data:
+{self.data}
+"""
 
 
 class Plan(models.Model):

--- a/ix/task_log/models.py
+++ b/ix/task_log/models.py
@@ -5,6 +5,7 @@ from typing import TypedDict, Optional
 from django.db import models
 from ix.agents.models import Agent
 from ix.chains.models import Chain
+from ix.commands.filesystem import read_file
 
 
 class Task(models.Model):
@@ -140,6 +141,29 @@ class Artifact(models.Model):
     description = models.TextField()
     created_at = models.DateTimeField(auto_now_add=True)
     storage = models.JSONField()
+
+    @property
+    def data(self):
+        """Fetch related data for this artifact"""
+        storage_type = self.storage["type"]
+        storage_id = self.storage["id"]
+        if storage_type == "write_to_file":
+            # TODO: should push this out to a storage subsystem.
+            return read_file(storage_id)
+        return None
+
+    def as_memory_text(self):
+        """
+        Return a string representation of this artifact for inclusion in prompts
+        """
+        return f"""
+        id: {self.id}
+        key: {self.key}
+        type: {self.artifact_type}
+        desc: {self.description}
+        data:
+        {self.data}
+        """
 
 
 class Plan(models.Model):

--- a/ix/task_log/tests/fake.py
+++ b/ix/task_log/tests/fake.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 
 from ix.chains.models import Chain, ChainNode
 from ix.chat.models import Chat
-from ix.task_log.models import Agent, Task, TaskLogMessage
+from ix.task_log.models import Agent, Task, TaskLogMessage, Artifact
 from faker import Faker
 
 fake = Faker()

--- a/ix/task_log/tests/fake.py
+++ b/ix/task_log/tests/fake.py
@@ -282,12 +282,15 @@ def fake_planner():
 DEFAULT_CHAT_ID = "f0034449-f226-44b2-9036-ca49f7d2348e"
 
 
-def fake_chat():
+def fake_chat(**kwargs):
     Agent.objects.filter(leading_chats__pk=DEFAULT_CHAT_ID).delete()
     Chat.objects.filter(pk=DEFAULT_CHAT_ID).delete()
 
     agent = fake_planner()
-    task = fake_task(agent=agent)
+    if "task" in kwargs:
+        task = kwargs["task"]
+    else:
+        task = fake_task(agent=agent)
     chat = Chat.objects.create(
         id=DEFAULT_CHAT_ID, name="Test Chat", task=task, lead=agent
     )

--- a/ix/task_log/tests/fake.py
+++ b/ix/task_log/tests/fake.py
@@ -299,6 +299,21 @@ def fake_chat():
     return chat
 
 
+def fake_artifact(**kwargs) -> Artifact:
+    task = kwargs.get("task", Task.objects.order_by("?").first())
+    options = dict(
+        key="test_artifact_1",
+        artifact_type="file",
+        task=task,
+        name="Test Artifact 1",
+        description="This is a test artifact (1)",
+        storage={"type": "file", "id": "test_artifact"},
+    )
+    options.update(kwargs)
+
+    return Artifact.objects.create(**options)
+
+
 def task_setup():
     try:
         task = Task.objects.get(id=1)


### PR DESCRIPTION
### Description
Adds general support for Langchain memory classes + adds `ArtifactMemory`

#### Memory
All Langchain memory classes that extend `BaseMemory` should be supported unless they have custom loading requirements. (e. g. `BaseChatMemory` required a backend loader for persistence storage).

Memory loader will set `session_id` based on `session` config for the memory or backend class. Memory may be scoped to `chat`, `agent`, `task`, or `user` and allows grouping within those scopes. This provides a very flexible system for shared and localized memory.

Example use cases:
- Collective memory within a chat.
- Collective memory of an agent across multiple chats.
- Subgroup of agents within a chat.
- Individual agent memory.
- "short term" task specific memory.

#### Artifact Memory
Artifact Memory class for loading `{artifact}` references into the context. The user or a bot may include a reference to a name/key and the memory class will provide it as an input for the chain & prompt template.

![Ix_-_Google_Chrome_2023-05-24_20-49-45_V3](https://github.com/kreneskyp/ix/assets/68635/4383ea84-92ca-44cc-883c-db0570956273)
Demo of new ChatInput including artifact references

### Changes

#### Chain memory
Chains now support Langchain memory
- added `load_memory`  and `load_chat_memory_backend` helpers
- added `get_memory_session` helper for parsing session info out of runtime context
- `LLMChain`, `LLMReply`, `IXSequence`, `MapSubchain` now support memory.
- `LLMChain` now filters inputs keys provided by `memory` out of `input_keys` to support memory set directly on the chain when used inside a `Sequence`.

#### ArtifactMemory
- Implements `ArtifactMemory`
- Added `ArtifactMemory` to Coder v1
- Implements `Artifact.data` for loading artifact content (e.g. from file)
- Implements `Artifact.as_memory_text()` for rendering artifacts

#### Chat
- `ChatMutation` now parses `{artifact}` references from input into `artifact_keys`

#### Misc
- `IxCallbackManager` now has `task_id`, `chat_id`, `agent_id`, `user_id` properties
- `fake_chat` now allows task to be passed by kwarg
- `mock_callback_manager` now creates a chat if one does not exist


### How Tested
- new unit tests covering:
   - loading tools - covers all new memory related loaders
   - ArtifactMemory - full suite
   - IXSequence - full suite
   - MapSubchain - adds coverage for memory
- manual testing with `@pirate`

### TODOs
- [x] test for ChatMutation changes
- [x] need better test coverage for loading memory classes
- [x] need to decide how to handle secrets for loading memory classes
- [x] limit scope of artifact query
- [x] docs

