### PR TITLE
ChatInput now has a max height of 400px + scrolling

### DIFF
--- a/frontend/chat/input/ChatInput.js
+++ b/frontend/chat/input/ChatInput.js
@@ -256,7 +256,7 @@ export const ChatInput = ({ chat }) => {
   );
 
   return (
-    <Box width={800} sx={sx} p={2} border="1px solid" borderRadius={5}>
+    <Box width={800} sx={sx} p={2} border="1px solid" borderRadius={5} maxH="400px"  overflowY="auto">
       {agentSearchRunner}
       {artifactSearchRunner}
       <Popover


### PR DESCRIPTION
### Description
ChatInput added in #58 allows multi-line content. There was no max height set so it would take over the entire screen with enough content.

### Changes
- add max height and overflow scrolling to `Box` containing the input.

### How Tested
manual testing

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
