### PR TITLE
HighlightText now preserves indentation

### DIFF
--- a/frontend/components/HighlightText.js
+++ b/frontend/components/HighlightText.js
@@ -11,7 +11,7 @@ const HighlightText = ({ content }) => {
   const { mention, artifact } = useChatColorMode();
 
   const formattedContent = React.useMemo(() => {
-    return content.split(/(\s|\n)/).map((segment, idx) => {
+    return content.split(/(\s+)/).map((segment, idx) => {
       if (segment.startsWith("@")) {
         return (
           <Text as="span" sx={mention} key={idx}>
@@ -24,15 +24,15 @@ const HighlightText = ({ content }) => {
             {segment}
           </Text>
         );
-      } else if (segment === "\n") {
-        return <br key={idx} />;
       } else {
         return segment;
       }
     });
   }, [content, mention, artifact]);
 
-  return <Box>{formattedContent}</Box>;
+  return (
+    <Box style={{ whiteSpace: "pre-wrap" }}>{formattedContent}</Box>
+  );
 };
 
 HighlightText.propTypes = {


### PR DESCRIPTION
### Description
Updates to `HighlightText` to retain indent spacing in chat messages.

![image](https://github.com/kreneskyp/ix/assets/68635/6e3fd56c-a23a-4df9-9b9b-041cacc46e47)


### Changes
- `HighlightText` now uses `whitespace: pre-wrap` to retain spacing/indents

### How Tested
Manual test

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
