### PR TITLE
frontend test build workflow was mislabeled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,12 +44,12 @@ jobs:
           path: docker-image.tar
           key: ${{ steps.load_image_url.outputs.image-url }}
 
-  dev_image:
+  frontend:
     needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Run pytest
+      - name: Build frontend
         uses: ./.github/actions/run-docker
         with:
           # build frontend


### PR DESCRIPTION
### Description
One of the build checks is `make frontend` it was mis-labled as `dev build`

### Changes
- update labels for frontend test build

### How Tested
This PR will test it in github actions

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
