### PR TITLE
AgentCard should still render when chain is null

### DIFF
--- a/frontend/agents/AgentCard.js
+++ b/frontend/agents/AgentCard.js
@@ -41,7 +41,7 @@ const AgentCard = () => {
           </Text>
           <Divider />
           <Heading as="h5" size="xs">
-            {agent.chain.name}
+            {agent.chain?.name || "No Chain"}
           </Heading>
           <Box
             maxWidth="350px"
@@ -55,7 +55,7 @@ const AgentCard = () => {
               WebkitLineClamp: 3,
             }}
           >
-            {agent.chain.description}
+            {agent.chain?.description || "No Chain"}
           </Box>
         </VStack>
       </CardBody>


### PR DESCRIPTION
### Description
Agent list can't render when an agent is missing a chain. This shouldn't happen but is somehow possible through the agent form.

Closes #68 

![image](https://github.com/kreneskyp/ix/assets/68635/18606ae7-3c91-4d87-9a35-4a3b639b34c9)


### Changes
- added fallback rendering to `AgentCard` when `AgentCard.chain === null`

### How Tested
Manual test to verify fix.

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
