### PR TITLE
Chat input doesn't send messages after clicking "new chat"

### DIFF
--- a/frontend/chat/graphql/useSendInput.js
+++ b/frontend/chat/graphql/useSendInput.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useMutation, graphql } from "react-relay/hooks";
 
 const SEND_FEEDBACK_MUTATION = graphql`
@@ -21,26 +21,29 @@ export const useSendInput = (chat_id) => {
   const [commit, isInFlight] = useMutation(SEND_FEEDBACK_MUTATION);
   const [error, setError] = useState(null);
 
-  const sendInput = (text) => {
-    return commit({
-      variables: {
-        input: {
-          chatId: chat_id,
-          text,
+  const sendInput = useCallback(
+    (text) => {
+      return commit({
+        variables: {
+          input: {
+            chatId: chat_id,
+            text,
+          },
         },
-      },
-      onCompleted: (response, errors) => {
-        if (errors) {
-          setError(errors[0]);
-        } else {
-          setError(null);
-        }
-      },
-      onError: (err) => {
-        setError(err);
-      },
-    });
-  };
+        onCompleted: (response, errors) => {
+          if (errors) {
+            setError(errors[0]);
+          } else {
+            setError(null);
+          }
+        },
+        onError: (err) => {
+          setError(err);
+        },
+      });
+    },
+    [chat_id]
+  );
 
   return { sendInput, error, loading: isInFlight };
 };

--- a/frontend/chat/input/ChatInput.js
+++ b/frontend/chat/input/ChatInput.js
@@ -144,7 +144,7 @@ export const ChatInput = ({ chat }) => {
         }
       }
     },
-    [results, editor, index, target]
+    [results, editor, index, target, chat.id]
   );
 
   // handler for editor changes

--- a/frontend/chat/input/ChatInput.js
+++ b/frontend/chat/input/ChatInput.js
@@ -95,8 +95,7 @@ export const ChatInput = ({ chat }) => {
 
   const { sendInput, error, loading } = useSendInput(chat.id);
 
-  const handleSendInput = async () => {
-    // don't send empty input
+  const handleSendInput = useCallback(async () => {
     const input = serialize(editor.children);
     if (input === "") {
       return;
@@ -105,7 +104,7 @@ export const ChatInput = ({ chat }) => {
     // send input and then clear the input
     await sendInput(input);
     clear_editor(editor);
-  };
+  }, [editor, sendInput]);
 
   // key press handler attached to editor
   const onKeyDown = useCallback(


### PR DESCRIPTION
### Description
v0.3 introduced a bug where `ChatInput` does not send messages to the current chat after pressing enter. Messages were sent to the prior chat because the `ChatInput` did not update to the new `chat.id`.

Tracked the bug to a `useCallback` that did not have `chat.id` as a dependency.

### Changes
- `ChatInput.onKeyDown` is now recreated when `chat.id` changes.
- `useSendInput` now uses `useCallback` to cache callback function
- `ChatInput` now uses `useCallback` to cache `handleSendInput`

### How Tested
- manual testing

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
