### PR TITLE
Fix dev setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
           path: docker-image.tar
           key: ${{ steps.load_image_url.outputs.image-url }}
 
-  frontend:
+  dev_setup:
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -55,12 +55,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build frontend
+      - name: Test dev_setup
         uses: ./.github/actions/run-docker
         with:
-          # build frontend
-          # For now just testing that frontend builds
-          command: make frontend
+          command: make dev_setup
 
   pytest:
     needs: build

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ dev_fixtures: compose
 	${DOCKER_COMPOSE_RUN} ./manage.py loaddata fake_user
 
 	# load component NodeTypes
-	${DOCKER_COMPOSE_RUN} ./manage.py import_langchain
+	${DOCKER_COMPOSE_RUN} ./manage.py loaddata node_types
 
  	# initial agents + chains
 	${DOCKER_COMPOSE_RUN} ./manage.py loaddata ix_v2 code_v2 pirate_v1


### PR DESCRIPTION
### Description
fixes #81 

@aatimofeev reported in #81 that `make dev_setup` is raising an error. 

Tracked the bug down to the usage of `./manage.py import_langchain` instead of the `node_types.json` fixture. The
former recreates the `NodeType` objects causing their identifiers to change. Agents and their chains are loaded from
a static fixture so there was a mismatch between the identifiers.

This was missed in local testing because I didn't do a final clean test after making the switch to `import_langchain`. It was also missed by the github workflow because it was only testing part of `dev_setup`

```
Updating component: ix.memory.artifacts.ArtifactMemory
Updating component: ix.chains.artifacts.SaveArtifact
Updating component: ix.chains.tests.mock_memory.MockMemory
Updating component: ix.chains.tests.mock_chain.MockChain
docker-compose run --rm web ./manage.py loaddata ix_v2 code_v2 pirate_v1
Creating ix_web_run ... done
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/django/db/backends/utils.py", line 87, in _execute
    return self.cursor.execute(sql)
           ^^^^^^^^^^^^^^^^^^^^^^^^
    return executor(sql, params, many, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/backends/utils.py", line 84, in _execute
    with self.db.wrap_database_errors:
  File "/usr/local/lib/python3.11/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/usr/local/lib/python3.11/site-packages/django/db/backends/utils.py", line 87, in _execute
    return self.cursor.execute(sql)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/psycopg/cursor.py", line 723, in execute
    raise ex.with_traceback(None)
django.db.utils.IntegrityError: Problem installing fixtures: insert or update on table "chains_chainnode" violates foreign key constraint "chains_chainnode_node_type_id_506db102_fk_chains_nodetyp
e_id"
DETAIL:  Key (node_type_id)=(7fff77c2-7ccc-4493-9f2b-54244c3d15e0) is not present in table "chains_nodetype".
ERROR: 1
make: *** [Makefile:164: dev_fixtures] Error 1
```

### Changes
- `dev_fixtures` and `dev_setup` targets now load static fixture from `node_types.json`
- github flow for testing `make frontend` now tests `make dev_setup`

### How Tested
- manually tested running `./manage.py reset_db` prior to `make dev_setup`
- updated github flow to test all of `dev_setup`

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
