### PR TITLE
Add overflow scrolling to SideBarArtifactList

### DIFF
--- a/frontend/chat/sidebar/SideBarArtifactList.js
+++ b/frontend/chat/sidebar/SideBarArtifactList.js
@@ -11,6 +11,7 @@ import { usePreloadedQuery } from "react-relay/hooks";
 import { ChatByIdQuery } from "chat/graphql/ChatByIdQuery";
 import ArtifactModalButton from "chat/sidebar/ArtifactModalButton";
 import { useChatArtifactSubscription } from "chat/graphql/useChatArtifactSubscription";
+import { SCROLLBAR_CSS } from "site/css";
 
 const ARTIFACT_TYPE_ICONS = {
   file: faFile,
@@ -47,40 +48,55 @@ const SideBarArtifactList = ({ queryRef }) => {
   );
 
   return (
-    <VStack spacing={1}>
+    <Box
+      mt={5}
+      pt={5}
+      width="100%"
+      maxHeight={"60vh"}
+      minWidth={170}
+      overflowY={"hidden"}
+    >
       <Heading as="h3" size="md" width="100%" align="left" mt={5}>
         Artifacts
       </Heading>
-      {artifacts?.length === 0 ? (
-        <Text
-          p={2}
-          fontSize="xs"
-          color={colorMode === "light" ? "gray.800" : "gray.400"}
-          sx={{ borderRadius: "5px" }}
-        >
-          Artifacts will appear here as they are created by agents.
-        </Text>
-      ) : null}
-      {artifacts?.map((artifact, i) => (
-        <Box
-          key={i}
-          bg="transparent"
-          color={colorMode === "light" ? "gray.700" : "gray.400"}
-          _hover={{
-            bg: colorMode === "light" ? "gray.300" : "gray.700",
-            cursor: "pointer",
-          }}
-          width="100%"
-        >
-          <ArtifactModalButton artifact={artifact}>
-            <HStack justify="left" py={1} pl={2} width="100%">
-              <TypeIcon artifact={artifact} />
-              <span style={{ marginLeft: 10 }}>{artifact.name}</span>
-            </HStack>
-          </ArtifactModalButton>
-        </Box>
-      ))}
-    </VStack>
+      <VStack
+        overflowY="scroll"
+        css={SCROLLBAR_CSS}
+        maxHeight={"30vh"}
+        spacing={2}
+        width="100%"
+      >
+        {artifacts?.length === 0 ? (
+          <Text
+            p={2}
+            fontSize="xs"
+            color={colorMode === "light" ? "gray.800" : "gray.400"}
+            sx={{ borderRadius: "5px" }}
+          >
+            Artifacts will appear here as they are created by agents.
+          </Text>
+        ) : null}
+        {artifacts?.map((artifact, i) => (
+          <Box
+            key={i}
+            bg="transparent"
+            color={colorMode === "light" ? "gray.700" : "gray.400"}
+            _hover={{
+              bg: colorMode === "light" ? "gray.300" : "gray.700",
+              cursor: "pointer",
+            }}
+            width="100%"
+          >
+            <ArtifactModalButton artifact={artifact}>
+              <HStack justify="left" py={1} pl={2} width="100%">
+                <TypeIcon artifact={artifact} />
+                <span style={{ marginLeft: 10 }}>{artifact.name}</span>
+              </HStack>
+            </ArtifactModalButton>
+          </Box>
+        ))}
+      </VStack>
+    </Box>
   );
 };
 


### PR DESCRIPTION
### Description
The artifact list in chat has no size limit.  It pushes the navigation menu off the page.

This adds scrolling to the component as a partial fix. 

### Changes
- `SideBarArtifactList` overflow now scrolls.

### How Tested
- manual testing

### TODOs
- for follow-up: Better css for the sidebar.
