### PR TITLE
Use NodeType label as first fallback option if node isn't named

### DIFF
--- a/frontend/chains/flow/ConfigNode.js
+++ b/frontend/chains/flow/ConfigNode.js
@@ -168,9 +168,9 @@ export const ConfigNode = ({ data }) => {
         className="drag-handle"
       >
         <Flex alignItems="center" justifyContent="space-between" width="100%">
-          <Box>
+          <Box pr={5}>
             <FontAwesomeIcon icon={styles?.icon} />{" "}
-            {node.name || node.classPath.split(".").pop()}
+            {node.name || type?.name || node.classPath.split(".").pop()}
           </Box>
           <DeleteIcon node={node} />
         </Flex>


### PR DESCRIPTION
### Description
If a node isn't named then it should use `NodeType.label` 

### Changes
- add `NodeType.label` as first fallback for unnamed nodes

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
