### PR TITLE
ChainEditor node connectors now have a larger hitbox.

### DIFF
--- a/frontend/chains/styles.css
+++ b/frontend/chains/styles.css
@@ -17,6 +17,21 @@
   background-color: transparent;
 }
 
+.react-flow__handle::before {
+  content: "";
+  position: absolute;
+  top: -10px;
+  right: -10px;
+  bottom: -10px;
+  left: -2px;
+  border-radius: 10px;
+}
+
+.react-flow__handle:hover {
+  background-color: #fff;
+  border-color: #fff;
+}
+
 .react-flow__handle-connecting {
   background-color: #ff6060;
   border-color: #ff6060;


### PR DESCRIPTION
### Description
The default ReactFlow connectors are very small.  This PR adds a larger hitbox so it's easier to grab a connector when creating a new edge.

### Changes
- added css element to all ReactFlow `Handle` to increase hitbox

### How Tested
- manual testing

### TODOs
