### PR TITLE
Agents and tools

### DIFF
--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -205,7 +205,9 @@ const ChainGraphEditor = ({ graph }) => {
           : source.data.type.type;
 
       // connection types must match
-      if (expectedType === providedType) {
+      // HAX: adding a special case for chain-agent connections until expectedType can be
+      //      expanded to be a set of types
+      if (expectedType === providedType || (expectedType === "chain" && providedType === "agent")) {
         const instanceEdges = reactFlowInstance.getEdges();
         const targetEdges = instanceEdges.filter(
           (e) =>

--- a/frontend/chains/editor/styles.js
+++ b/frontend/chains/editor/styles.js
@@ -29,6 +29,7 @@ export const NODE_STYLES = {
   },
   agent: {
     icon: faRobot,
+    component: ChainNode,
   },
   tool: {
     icon: faTools,

--- a/frontend/chains/editor/useColorMode.js
+++ b/frontend/chains/editor/useColorMode.js
@@ -44,7 +44,7 @@ export const useEditorColorMode = () => {
       memory: isLight ? "purple.500" : "purple.300",
       memory_backend: isLight ? "purple.500" : "purple.300",
       chain: isLight ? "blue.500" : "blue.300",
-      agent: isLight ? "green.500" : "green.300",
+      agent: isLight ? "green.500" : "green.600",
       tool: isLight ? "yellow.500" : "yellow.600",
     },
   };

--- a/frontend/chains/flow/ConfigNode.js
+++ b/frontend/chains/flow/ConfigNode.js
@@ -153,7 +153,7 @@ export const ConfigNode = ({ data }) => {
       <Handle
         id={type.type}
         type="source"
-        position={type.type === "chain" ? "left" : "right"}
+        position={type.type === "chain" || type.type === "agent" ? "left" : "right"}
         style={{ top: "15px", transform: "translateX(-2px)" }}
       />
       <Heading

--- a/ix/agents/process.py
+++ b/ix/agents/process.py
@@ -133,7 +133,8 @@ class AgentProcess:
 
         start = time.time()
         try:
-            response = await chain.arun(**user_input)
+            # Hax: copy user_input to input to support agents.
+            response = await chain.arun(input=user_input["user_input"], **user_input)
         except:  # noqa: E722
             raise
         finally:

--- a/ix/chains/agents.py
+++ b/ix/chains/agents.py
@@ -1,0 +1,62 @@
+from typing import List, Dict, Any, Optional
+
+from langchain.agents import AgentExecutor
+from langchain.callbacks.manager import (
+    AsyncCallbackManagerForChainRun,
+    CallbackManagerForChainRun,
+)
+from langchain.chains.base import Chain
+
+from ix.task_log.models import TaskLogMessage
+
+
+class AgentReply(Chain):
+    """
+    An chain that wraps an AgentExecutor to capture the reply and send it to the
+    chat using a TaskLogMessage.
+
+    This chain is a workaround until replies are captured with chain callbacks.
+    """
+
+    agent_executor: AgentExecutor
+    output_key: str = "output"
+
+    @property
+    def _chain_type(self) -> str:
+        return "agent_reply"
+
+    @property
+    def input_keys(self) -> List[str]:
+        return []
+
+    @property
+    def output_keys(self) -> List[str]:
+        return [self.output_key]
+
+    def _call(
+        self,
+        inputs: Dict[str, Any],
+        run_manager: Optional[CallbackManagerForChainRun] = None,
+    ) -> Dict[str, Any]:
+        pass
+
+    async def _acall(
+        self,
+        inputs: Dict[str, Any],
+        run_manager: Optional[AsyncCallbackManagerForChainRun] = None,
+    ) -> Dict[str, Any]:
+        result = await self.agent_executor.acall(inputs, callbacks=run_manager)
+
+        await TaskLogMessage.objects.acreate(
+            task_id=self.callbacks.task.id,
+            role="assistant",
+            parent=self.callbacks.think_msg,
+            content={
+                "type": "ASSISTANT",
+                "text": result[self.output_key],
+                # "agent": str(self.callback_manager.task.agent.id),
+                "agent": self.callbacks.agent.alias,
+            },
+        )
+
+        return result

--- a/ix/chains/fixture_src/agents.py
+++ b/ix/chains/fixture_src/agents.py
@@ -1,0 +1,116 @@
+from ix.chains.fixture_src.targets import PROMPT_TARGET, TOOLS_TARGET, LLM_TARGET
+
+
+EXECUTOR_BASE_FIELDS = [
+    {
+        "name": "return_intermediate_steps",
+        "type": "boolean",
+        "default": False,
+    },
+    {
+        "name": "max_iterations",
+        "type": "integer",
+        "default": 15,
+        "nullable": True,
+    },
+    {
+        "name": "max_execution_time",
+        "type": "float",
+        "nullable": True,
+    },
+]
+
+
+OPENAI_FUNCTIONS_AGENT = {
+    "class_path": "ix.chains.loaders.agents.initialize_openai_functions",
+    "type": "agent",
+    "name": "OpenAI Function Agent",
+    "description": "Agent that uses OpenAI's API to generate text.",
+    "connectors": [LLM_TARGET, TOOLS_TARGET, PROMPT_TARGET],
+    "fields": EXECUTOR_BASE_FIELDS,
+}
+
+OPENAI_MULTIFUNCTION_AGENT = {
+    "class_path": "ix.chains.loaders.agents.initialize_openai_multi_functions",
+    "type": "agent",
+    "name": "OpenAI Multifunction Agent",
+    "description": "Agent that uses OpenAI's API to generate text.",
+    "connectors": [LLM_TARGET, TOOLS_TARGET, PROMPT_TARGET],
+    "fields": EXECUTOR_BASE_FIELDS,
+}
+
+ZERO_SHOT_REACT_DESCRIPTION_AGENT = {
+    "class_path": "ix.chains.loaders.agents.initialize_zero_shot_react_description",
+    "type": "agent",
+    "name": "Zero Shot React Description Agent",
+    "description": "Agent that generates descriptions by taking zero-shot approach using reaction information.",
+    "connectors": [LLM_TARGET, TOOLS_TARGET, PROMPT_TARGET],
+    "fields": EXECUTOR_BASE_FIELDS,
+}
+
+REACT_DOCSTORE_AGENT = {
+    "class_path": "ix.chains.loaders.agents.initialize_react_docstore",
+    "type": "agent",
+    "name": "React Docstore Agent",
+    "description": "Agent that interacts with the document store to obtain reaction-based information.",
+    "connectors": [LLM_TARGET, TOOLS_TARGET, PROMPT_TARGET],
+    "fields": EXECUTOR_BASE_FIELDS,
+}
+
+SELF_ASK_WITH_SEARCH_AGENT = {
+    "class_path": "ix.chains.loaders.agents.initialize_self_ask_with_search",
+    "type": "agent",
+    "name": "Self Ask with Search Agent",
+    "description": "Agent that asks itself queries and searches for answers in a given context.",
+    "connectors": [LLM_TARGET, TOOLS_TARGET, PROMPT_TARGET],
+    "fields": EXECUTOR_BASE_FIELDS,
+}
+
+CONVERSATIONAL_REACT_DESCRIPTION_AGENT = {
+    "class_path": "ix.chains.loaders.agents.initialize_conversational_react_description",
+    "type": "agent",
+    "name": "Conversational React Description Agent",
+    "description": "Agent that provides descriptions in a conversational manner using reaction information.",
+    "connectors": [LLM_TARGET, TOOLS_TARGET, PROMPT_TARGET],
+    "fields": EXECUTOR_BASE_FIELDS,
+}
+
+CHAT_ZERO_SHOT_REACT_DESCRIPTION_AGENT = {
+    "class_path": "ix.chains.loaders.agents.initialize_chat_zero_shot_react_description",
+    "type": "agent",
+    "name": "Chat Zero Shot React Description Agent",
+    "description": "Agent that generates descriptions in a chat-based context using a zero-shot approach and reaction information.",
+    "connectors": [LLM_TARGET, TOOLS_TARGET, PROMPT_TARGET],
+    "fields": EXECUTOR_BASE_FIELDS,
+}
+
+CHAT_CONVERSATIONAL_REACT_DESCRIPTION_AGENT = {
+    "class_path": "ix.chains.loaders.agents.initialize_chat_conversational_react_description",
+    "type": "agent",
+    "name": "Chat Conversational React Description Agent",
+    "description": "Agent that provides descriptions in a chat-based context in a conversational manner using reaction information.",
+    "connectors": [LLM_TARGET, TOOLS_TARGET, PROMPT_TARGET],
+    "fields": EXECUTOR_BASE_FIELDS,
+}
+
+STRUCTURED_CHAT_ZERO_SHOT_REACT_DESCRIPTION_AGENT = {
+    "class_path": "ix.chains.loaders.agents.initialize_structured_chat_zero_shot_react_description",
+    "type": "agent",
+    "name": "Structured Chat Zero Shot React Description Agent",
+    "description": "Agent that generates descriptions in a structured chat context using a zero-shot approach and reaction information.",
+    "connectors": [LLM_TARGET, TOOLS_TARGET, PROMPT_TARGET],
+    "fields": EXECUTOR_BASE_FIELDS,
+}
+
+
+AGENTS = [
+    OPENAI_FUNCTIONS_AGENT,
+    OPENAI_MULTIFUNCTION_AGENT,
+    ZERO_SHOT_REACT_DESCRIPTION_AGENT,
+    REACT_DOCSTORE_AGENT,
+    SELF_ASK_WITH_SEARCH_AGENT,
+    CONVERSATIONAL_REACT_DESCRIPTION_AGENT,
+    CHAT_ZERO_SHOT_REACT_DESCRIPTION_AGENT,
+    CHAT_CONVERSATIONAL_REACT_DESCRIPTION_AGENT,
+    STRUCTURED_CHAT_ZERO_SHOT_REACT_DESCRIPTION_AGENT,
+]

--- a/ix/chains/fixture_src/targets.py
+++ b/ix/chains/fixture_src/targets.py
@@ -67,3 +67,10 @@ VECTORSTORE_TARGET = {
     "type": "target",
     "source_type": "vectorstore",
 }
+
+TOOLS_TARGET = {
+    "key": "tools",
+    "type": "target",
+    "source_type": "tool",
+    "multiple": True,
+}

--- a/ix/chains/fixture_src/tools.py
+++ b/ix/chains/fixture_src/tools.py
@@ -1,0 +1,58 @@
+from langchain import ArxivAPIWrapper
+
+from ix.chains.fixture_src.common import VERBOSE
+from ix.chains.types import FieldConfig
+
+DESCRIPTION = {
+    "name": "description",
+    "type": "str",
+    "default": "",
+}
+
+RETURN_DIRECT = {
+    "name": "return_direct",
+    "type": "boolean",
+    "default": False,
+}
+
+TOOL_BASE_FIELDS = [DESCRIPTION, RETURN_DIRECT, VERBOSE]
+
+GOOGLE_SEARCH = {
+    "class_path": "ix.tools.google.get_google_search",
+    "type": "tool",
+    "name": "Google Search",
+    "description": "Tool that searches Google for a given query.",
+    "fields": TOOL_BASE_FIELDS + [],
+}
+
+GOOGLE_SERPER = {
+    "class_path": "ix.tools.google.get_google_search",
+    "type": "tool",
+    "name": "Google Search",
+    "description": "Tool that searches Google for a given query.",
+    "fields": TOOL_BASE_FIELDS + [],
+}
+
+
+WOLFRAM = {
+    "name": "Wolfram Alpha",
+    "description": "Wolfram Alpha search engine for math and science",
+    "class_path": "ix.tools.wolfram_alpha.get_wolfram_alpha",
+    "display_type": "node",
+    "type": "tool",
+    "fields": TOOL_BASE_FIELDS
+    + [
+        {
+            "name": "wolfram_alpha_app_id",
+            "label": "Wolfram Alpha App ID",
+            "type": "str",
+            "input": "secret",
+        },
+    ],
+}
+
+
+TOOLS = [
+    GOOGLE_SEARCH,
+    WOLFRAM,
+]

--- a/ix/chains/fixture_src/tools.py
+++ b/ix/chains/fixture_src/tools.py
@@ -1,7 +1,4 @@
-from langchain import ArxivAPIWrapper
-
 from ix.chains.fixture_src.common import VERBOSE
-from ix.chains.types import FieldConfig
 
 DESCRIPTION = {
     "name": "description",

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -38,6 +38,54 @@
 },
 {
   "model": "chains.nodetype",
+  "pk": "01fc1524-9c01-4970-a01f-56ff70218500",
+  "fields": {
+    "name": "React Docstore Agent",
+    "description": "Agent that interacts with the document store to obtain reaction-based information.",
+    "class_path": "ix.chains.loaders.agents.initialize_react_docstore",
+    "type": "chain",
+    "display_type": "node",
+    "connectors": [
+      {
+        "key": "llm",
+        "type": "target",
+        "source_type": "llm"
+      },
+      {
+        "key": "tools",
+        "type": "target",
+        "multiple": true,
+        "source_type": "tool"
+      },
+      {
+        "key": "prompt",
+        "type": "target",
+        "source_type": "prompt"
+      }
+    ],
+    "fields": [
+      {
+        "name": "return_intermediate_steps",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "max_iterations",
+        "type": "integer",
+        "default": 15,
+        "nullable": true
+      },
+      {
+        "name": "max_execution_time",
+        "type": "float",
+        "nullable": true
+      }
+    ],
+    "child_field": null
+  }
+},
+{
+  "model": "chains.nodetype",
   "pk": "151cbfff-6e65-4ed1-9c70-100deee0e873",
   "fields": {
     "name": "Parse JSON",
@@ -56,6 +104,54 @@
         "name": "output_key",
         "type": "text",
         "label": "Output Key"
+      }
+    ],
+    "child_field": null
+  }
+},
+{
+  "model": "chains.nodetype",
+  "pk": "1b76aa58-eca9-41fa-b255-1d572de46aa8",
+  "fields": {
+    "name": "Zero Shot React Description Agent",
+    "description": "Agent that generates descriptions by taking zero-shot approach using reaction information.",
+    "class_path": "ix.chains.loaders.agents.initialize_zero_shot_react_description",
+    "type": "chain",
+    "display_type": "node",
+    "connectors": [
+      {
+        "key": "llm",
+        "type": "target",
+        "source_type": "llm"
+      },
+      {
+        "key": "tools",
+        "type": "target",
+        "multiple": true,
+        "source_type": "tool"
+      },
+      {
+        "key": "prompt",
+        "type": "target",
+        "source_type": "prompt"
+      }
+    ],
+    "fields": [
+      {
+        "name": "return_intermediate_steps",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "max_iterations",
+        "type": "integer",
+        "default": 15,
+        "nullable": true
+      },
+      {
+        "name": "max_execution_time",
+        "type": "float",
+        "nullable": true
       }
     ],
     "child_field": null
@@ -248,6 +344,102 @@
 },
 {
   "model": "chains.nodetype",
+  "pk": "35152553-b5b4-4130-97e2-bda033ca23b2",
+  "fields": {
+    "name": "Structured Chat Zero Shot React Description Agent",
+    "description": "Agent that generates descriptions in a structured chat context using a zero-shot approach and reaction information.",
+    "class_path": "ix.chains.loaders.agents.initialize_structured_chat_zero_shot_react_description",
+    "type": "chain",
+    "display_type": "node",
+    "connectors": [
+      {
+        "key": "llm",
+        "type": "target",
+        "source_type": "llm"
+      },
+      {
+        "key": "tools",
+        "type": "target",
+        "multiple": true,
+        "source_type": "tool"
+      },
+      {
+        "key": "prompt",
+        "type": "target",
+        "source_type": "prompt"
+      }
+    ],
+    "fields": [
+      {
+        "name": "return_intermediate_steps",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "max_iterations",
+        "type": "integer",
+        "default": 15,
+        "nullable": true
+      },
+      {
+        "name": "max_execution_time",
+        "type": "float",
+        "nullable": true
+      }
+    ],
+    "child_field": null
+  }
+},
+{
+  "model": "chains.nodetype",
+  "pk": "36edc450-6ea3-4fd4-abf6-a5fff02da718",
+  "fields": {
+    "name": "Self Ask with Search Agent",
+    "description": "Agent that asks itself queries and searches for answers in a given context.",
+    "class_path": "ix.chains.loaders.agents.initialize_self_ask_with_search",
+    "type": "chain",
+    "display_type": "node",
+    "connectors": [
+      {
+        "key": "llm",
+        "type": "target",
+        "source_type": "llm"
+      },
+      {
+        "key": "tools",
+        "type": "target",
+        "multiple": true,
+        "source_type": "tool"
+      },
+      {
+        "key": "prompt",
+        "type": "target",
+        "source_type": "prompt"
+      }
+    ],
+    "fields": [
+      {
+        "name": "return_intermediate_steps",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "max_iterations",
+        "type": "integer",
+        "default": 15,
+        "nullable": true
+      },
+      {
+        "name": "max_execution_time",
+        "type": "float",
+        "nullable": true
+      }
+    ],
+    "child_field": null
+  }
+},
+{
+  "model": "chains.nodetype",
   "pk": "3ffc030c-f6cb-4fc2-9cd7-ff1cfd3a5c99",
   "fields": {
     "name": "OpenAI Embeddings",
@@ -268,6 +460,102 @@
         ],
         "default": "text-embedding-ada-002",
         "description": "The model to use."
+      }
+    ],
+    "child_field": null
+  }
+},
+{
+  "model": "chains.nodetype",
+  "pk": "54d5cfcb-bf9c-4fe2-9692-075d6849ce23",
+  "fields": {
+    "name": "Chat Zero Shot React Description Agent",
+    "description": "Agent that generates descriptions in a chat-based context using a zero-shot approach and reaction information.",
+    "class_path": "ix.chains.loaders.agents.initialize_chat_zero_shot_react_description",
+    "type": "chain",
+    "display_type": "node",
+    "connectors": [
+      {
+        "key": "llm",
+        "type": "target",
+        "source_type": "llm"
+      },
+      {
+        "key": "tools",
+        "type": "target",
+        "multiple": true,
+        "source_type": "tool"
+      },
+      {
+        "key": "prompt",
+        "type": "target",
+        "source_type": "prompt"
+      }
+    ],
+    "fields": [
+      {
+        "name": "return_intermediate_steps",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "max_iterations",
+        "type": "integer",
+        "default": 15,
+        "nullable": true
+      },
+      {
+        "name": "max_execution_time",
+        "type": "float",
+        "nullable": true
+      }
+    ],
+    "child_field": null
+  }
+},
+{
+  "model": "chains.nodetype",
+  "pk": "59a9e9c2-df2e-42be-be5d-d642deff11ae",
+  "fields": {
+    "name": "Conversational React Description Agent",
+    "description": "Agent that provides descriptions in a conversational manner using reaction information.",
+    "class_path": "ix.chains.loaders.agents.initialize_conversational_react_description",
+    "type": "chain",
+    "display_type": "node",
+    "connectors": [
+      {
+        "key": "llm",
+        "type": "target",
+        "source_type": "llm"
+      },
+      {
+        "key": "tools",
+        "type": "target",
+        "multiple": true,
+        "source_type": "tool"
+      },
+      {
+        "key": "prompt",
+        "type": "target",
+        "source_type": "prompt"
+      }
+    ],
+    "fields": [
+      {
+        "name": "return_intermediate_steps",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "max_iterations",
+        "type": "integer",
+        "default": 15,
+        "nullable": true
+      },
+      {
+        "name": "max_execution_time",
+        "type": "float",
+        "nullable": true
       }
     ],
     "child_field": null
@@ -315,6 +603,54 @@
         "input": "secret",
         "width": "100%",
         "description": "MosaicML API token"
+      }
+    ],
+    "child_field": null
+  }
+},
+{
+  "model": "chains.nodetype",
+  "pk": "74fd7b8b-4be7-49dc-a925-5e522c03bbf4",
+  "fields": {
+    "name": "OpenAI Function Agent",
+    "description": "Agent that uses OpenAI's API to generate text.",
+    "class_path": "ix.chains.loaders.agents.initialize_openai_functions_agent",
+    "type": "chain",
+    "display_type": "node",
+    "connectors": [
+      {
+        "key": "llm",
+        "type": "target",
+        "source_type": "llm"
+      },
+      {
+        "key": "tools",
+        "type": "target",
+        "multiple": true,
+        "source_type": "tool"
+      },
+      {
+        "key": "prompt",
+        "type": "target",
+        "source_type": "prompt"
+      }
+    ],
+    "fields": [
+      {
+        "name": "return_intermediate_steps",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "max_iterations",
+        "type": "integer",
+        "default": 15,
+        "nullable": true
+      },
+      {
+        "name": "max_execution_time",
+        "type": "float",
+        "nullable": true
       }
     ],
     "child_field": null
@@ -718,6 +1054,54 @@
         "name": "encode_kwargs",
         "type": "dictionary",
         "description": "Key word arguments to pass when calling the `encode` method of the model"
+      }
+    ],
+    "child_field": null
+  }
+},
+{
+  "model": "chains.nodetype",
+  "pk": "a3dd72e8-1554-47dd-8f42-0dda58c06f7c",
+  "fields": {
+    "name": "Chat Conversational React Description Agent",
+    "description": "Agent that provides descriptions in a chat-based context in a conversational manner using reaction information.",
+    "class_path": "ix.chains.loaders.agents.initialize_chat_conversational_react_description",
+    "type": "chain",
+    "display_type": "node",
+    "connectors": [
+      {
+        "key": "llm",
+        "type": "target",
+        "source_type": "llm"
+      },
+      {
+        "key": "tools",
+        "type": "target",
+        "multiple": true,
+        "source_type": "tool"
+      },
+      {
+        "key": "prompt",
+        "type": "target",
+        "source_type": "prompt"
+      }
+    ],
+    "fields": [
+      {
+        "name": "return_intermediate_steps",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "max_iterations",
+        "type": "integer",
+        "default": 15,
+        "nullable": true
+      },
+      {
+        "name": "max_execution_time",
+        "type": "float",
+        "nullable": true
       }
     ],
     "child_field": null

--- a/ix/chains/loaders/agents.py
+++ b/ix/chains/loaders/agents.py
@@ -1,0 +1,78 @@
+import sys
+from typing import Callable
+
+from langchain.agents import AgentType, AgentExecutor
+from langchain.agents import initialize_agent as initialize_agent_base
+from langchain.chains.base import Chain
+
+from ix.chains.agents import AgentReply
+
+
+def initialize_agent(agent: AgentType, **kwargs) -> Chain:
+    """
+    Extended version of the initialize_agent function from ix.chains.agents.
+
+    Modifications:
+    - unpacks agent_kwargs: allows agent_kwargs to be flattened into the ChainNode config
+      A flattened config simplifies the UX integration such that it works with TypeAutoFields
+    """
+    # Re-pack agent_kwargs__* arguments into agent_kwargs
+    agent_kwargs = {}
+    for key, value in kwargs.items():
+        if key.startswith("agent_kwargs__"):
+            agent_kwargs[key[15:]] = value
+            del kwargs[key]
+    kwargs["agent_kwargs"] = agent_kwargs
+
+    # TODO: wrap agents in AgentReply until streaming callbacks are implemented
+    agent_executor = initialize_agent_base(agent=agent, **kwargs)
+    return AgentReply(
+        agent_executor=agent_executor,
+        callback_manager=kwargs.get("callback_manager", None),
+    )
+
+
+def create_init_func(agent_type: AgentType) -> Callable:
+    """
+    This function creates a new initialization function for a given agent type. The initialization
+    function is a proxy to the initialize_agent function, but it has a distinct name and can be
+    imported directly from this module.
+
+    Agent initialization functions are used so there is a distinct class_path for each agent type.
+    This allows class_path to be used as an identifier for the agent type.
+
+    Args:
+        agent_type (str): The type of the agent to create an initialization function for.
+
+    Returns:
+        function: The newly created initialization function.
+    """
+
+    def init_func(**kwargs) -> AgentExecutor:
+        return initialize_agent(agent=agent_type, **kwargs)
+
+    return init_func
+
+
+# list of function names that are created, used for debugging
+FUNCTION_NAMES = []
+
+
+def create_functions() -> None:
+    """
+    Generate initialization functions for each agent type and add them to this module.
+    This will automatically create a new function for each agent type as LangChain
+    creates them.
+    """
+    for agent_type in AgentType:
+        # create an initialization function for this agent type
+        init_func = create_init_func(agent_type)
+        func_name = "initialize_" + agent_type.value.replace("-", "_")
+        FUNCTION_NAMES.append(func_name)
+
+        # add the function to the current module
+        setattr(sys.modules[__name__], func_name, init_func)
+
+
+# auto-run the function that creates the initialization functions
+create_functions()

--- a/ix/chains/loaders/core.py
+++ b/ix/chains/loaders/core.py
@@ -112,7 +112,7 @@ def load_node(node: ChainNode, callback_manager: IxCallbackManager, parent=None)
 
     node_class = import_node_class(node.class_path)
 
-    if node_type.type == "chain":
+    if node_type.type in {"chain", "agent"}:
         config["callback_manager"] = callback_manager
 
     instance = node_class(**config)

--- a/ix/chains/loaders/tools.py
+++ b/ix/chains/loaders/tools.py
@@ -1,0 +1,15 @@
+from ix.chains.fixture_src.tools import TOOL_BASE_FIELDS
+
+
+TOOL_BASE_FIELD_NAMES = {tool["name"] for tool in TOOL_BASE_FIELDS}
+
+
+def extract_tool_kwargs(kwargs: dict) -> dict:
+    """
+    Extract tool kwargs from kwargs.
+    """
+    tool_kwargs = {}
+    for key, value in list(kwargs.items()):
+        if key in TOOL_BASE_FIELD_NAMES:
+            tool_kwargs[key] = kwargs.pop(key)
+    return tool_kwargs

--- a/ix/chains/management/commands/import_langchain.py
+++ b/ix/chains/management/commands/import_langchain.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand
 
+from ix.chains.fixture_src.agents import AGENTS
 from ix.chains.fixture_src.artifacts import ARTIFACT_MEMORY, SAVE_ARTIFACT
 from ix.chains.fixture_src.chains import LLM_CHAIN, LLM_TOOL_CHAIN, LLM_REPLY
 from ix.chains.fixture_src.chat_memory_backend import (
@@ -29,6 +30,7 @@ from ix.chains.fixture_src.openai_functions import (
 from ix.chains.fixture_src.prompts import CHAT_PROMPT_TEMPLATE
 from ix.chains.fixture_src.routing import SEQUENCE, MAP_SUBCHAIN
 from ix.chains.fixture_src.testing import MOCK_MEMORY, MOCK_CHAIN
+from ix.chains.fixture_src.tools import TOOLS
 from ix.chains.fixture_src.vectorstores import REDIS_VECTORSTORE
 from ix.chains.models import NodeType
 
@@ -45,6 +47,10 @@ COMPONENTS.extend(
         MOSAICML_INSTRUCTOR_EMBEDDINGS,
     ]
 )
+
+# Agents
+COMPONENTS.extend(AGENTS)
+COMPONENTS.extend(TOOLS)
 
 # LLMS
 COMPONENTS.extend(

--- a/ix/tools/google.py
+++ b/ix/tools/google.py
@@ -1,0 +1,65 @@
+from asgiref.sync import sync_to_async
+from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
+
+from ix.chains.loaders.tools import extract_tool_kwargs
+from typing import Any, Optional
+
+from langchain import GoogleSerperAPIWrapper, GoogleSearchAPIWrapper, SerpAPIWrapper
+from langchain.tools import (
+    BaseTool,
+    Tool,
+    GoogleSearchResults,
+    GoogleSerperRun,
+    GoogleSerperResults,
+)
+
+
+def get_google_serper(**kwargs: Any) -> BaseTool:
+    tool_kwargs = extract_tool_kwargs(kwargs)
+    wrapper = GoogleSerperAPIWrapper(**kwargs)
+    return GoogleSerperRun(api_wrapper=wrapper, **tool_kwargs)
+
+
+def get_google_serper_results_json(**kwargs: Any) -> BaseTool:
+    tool_kwargs = extract_tool_kwargs(kwargs)
+    wrapper = GoogleSerperAPIWrapper(**kwargs)
+    return GoogleSerperResults(api_wrapper=wrapper, **tool_kwargs)
+
+
+class GoogleSearchResults2(GoogleSearchResults):
+    async def _arun(
+        self,
+        query: str,
+        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
+    ) -> str:
+        """Use the tool asynchronously."""
+        result = await sync_to_async(self.run)(query, run_manager=run_manager)
+        return result
+
+
+def get_google_search(**kwargs: Any) -> BaseTool:
+    tool_kwargs = extract_tool_kwargs(kwargs)
+    wrapper = GoogleSearchAPIWrapper(**kwargs)
+    return GoogleSearchResults2(
+        api_wrapper=wrapper, name="google_search", **tool_kwargs
+    )
+
+
+def get_google_search_results_json(**kwargs: Any) -> BaseTool:
+    tool_kwargs = extract_tool_kwargs(kwargs)
+    wrapper = GoogleSearchAPIWrapper(**kwargs)
+    return GoogleSearchResults2(
+        api_wrapper=wrapper, name="google_search", **tool_kwargs
+    )
+
+
+def get_serpapi(**kwargs: Any) -> BaseTool:
+    tool_kwargs = extract_tool_kwargs(kwargs)
+    return Tool(
+        name="Search",
+        description="A search engine. Useful for when you need to answer questions "
+        "about current events. Input should be a search query.",
+        func=SerpAPIWrapper(**kwargs).run,
+        coroutine=SerpAPIWrapper(**kwargs).arun,
+        **tool_kwargs
+    )

--- a/ix/tools/wolfram_alpha.py
+++ b/ix/tools/wolfram_alpha.py
@@ -1,0 +1,11 @@
+from langchain import WolframAlphaAPIWrapper
+from langchain.tools import BaseTool, WolframAlphaQueryRun
+
+from ix.chains.loaders.tools import extract_tool_kwargs
+from typing import Any
+
+
+def get_wolfram_alpha(**kwargs: Any) -> BaseTool:
+    tool_kwargs = extract_tool_kwargs(kwargs)
+    wrapper = WolframAlphaAPIWrapper(**kwargs)
+    return WolframAlphaQueryRun(api_wrapper=wrapper, **tool_kwargs)


### PR DESCRIPTION
### Description
This PR adds initial support for LangChain Agents and Tools. Both may be added to chains in the UX.

![image](https://github.com/kreneskyp/ix/assets/68635/5f8f1d26-1b17-490b-86ac-219a1fe89b51)
![image](https://github.com/kreneskyp/ix/assets/68635/82613ce0-9551-444a-a5b1-034d15aa117a)


Agents included:
- OPENAI_FUNCTIONS_AGENT
- OPENAI_MULTIFUNCTION_AGENT
- ZERO_SHOT_REACT_DESCRIPTION_AGENT
- REACT_DOCSTORE_AGENT
- SELF_ASK_WITH_SEARCH_AGENT
- CONVERSATIONAL_REACT_DESCRIPTION_AGENT
- CHAT_ZERO_SHOT_REACT_DESCRIPTION_AGENT
- CHAT_CONVERSATIONAL_REACT_DESCRIPTION_AGENT
- STRUCTURED_CHAT_ZERO_SHOT_REACT_DESCRIPTION_AGENT

Tools:
- Google search
- Wolfram search

### Changes


### How Tested
- New unittests
- Manual testing

### TODOs
For follow up:
- initialize_agent does not  support `FunctionSchema`.
- This PR has a very limited set of tools. I'm partially done importing most tools provided by LangChain. Subsequent PRs will add more tools.
- `intialize_agent` does not support for loading `ToolKits`
- `Agents` nodes can be connected to other agents and chains but they aren't executing in sequence.


