### PR TITLE
Node resizer usability fixes

### DIFF
--- a/frontend/chains/editor/PromptEditor.js
+++ b/frontend/chains/editor/PromptEditor.js
@@ -100,6 +100,14 @@ const PromptEditor = ({ data, onChange }) => {
 
   return (
     <VStack spacing={1} align="stretch">
+      <NodeResizeControl
+        variant={"line"}
+        minWidth={400}
+        position={"left"}
+        h={"100%"}
+        style={{ border: "5px solid transparent" }}
+      />
+
       {messages.map((message, index) => (
         <VStack key={index} p={2} spacing={2}>
           <Flex
@@ -176,7 +184,7 @@ const PromptEditor = ({ data, onChange }) => {
         variant={"line"}
         minWidth={400}
         h={"100%"}
-        style={{ border: 0 }}
+        style={{ border: "5px solid transparent" }}
       />
     </VStack>
   );

--- a/frontend/chains/flow/FunctionSchemaNode.js
+++ b/frontend/chains/flow/FunctionSchemaNode.js
@@ -23,6 +23,14 @@ export const FunctionSchemaNode = ({ config, onFieldChange }) => {
   return (
     <>
       <Box p={2} minWidth={200}>
+        <NodeResizeControl
+          variant={"line"}
+          minWidth={250}
+          position={"left"}
+          h={"100%"}
+          w={"10px"}
+          style={{ border: "5px solid transparent" }}
+        />
         <FormLabel justify="start">Name</FormLabel>
         <Input name="name" value={config.name} onChange={handleChange} />
         <FormLabel justify="start">Description</FormLabel>
@@ -48,7 +56,7 @@ export const FunctionSchemaNode = ({ config, onFieldChange }) => {
           variant={"line"}
           minWidth={250}
           h={"100%"}
-          style={{ border: 0 }}
+          style={{ border: "5px solid transparent" }}
         />
       </Box>
     </>


### PR DESCRIPTION
### Description
Improvements to resizing for Prompt and FunctionSchema nodes:


### Changes
- Left side resizer added to `PromptNode` and `FunctionSchemaNode`
- Resizer target is now larger and easier to grab

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
