### PR TITLE
Add Tools: Search

### DIFF
--- a/ix/chains/fixture_src/tools.py
+++ b/ix/chains/fixture_src/tools.py
@@ -1,3 +1,18 @@
+from langchain import (
+    GoogleSearchAPIWrapper,
+    GoogleSerperAPIWrapper,
+    ArxivAPIWrapper,
+    WikipediaAPIWrapper,
+)
+from langchain.utilities import (
+    BingSearchAPIWrapper,
+    DuckDuckGoSearchAPIWrapper,
+    GraphQLAPIWrapper,
+    LambdaWrapper,
+    PubMedAPIWrapper,
+)
+
+from ix.chains.config import NodeTypeField
 from ix.chains.fixture_src.common import VERBOSE
 
 DESCRIPTION = {
@@ -14,20 +29,149 @@ RETURN_DIRECT = {
 
 TOOL_BASE_FIELDS = [DESCRIPTION, RETURN_DIRECT, VERBOSE]
 
+ARXIV_SEARCH = {
+    "class_path": "ix.tools.arxiv.get_arxiv",
+    "type": "tool",
+    "name": " search",
+    "description": "Tool that searches Arxiv for a given query.",
+    "fields": TOOL_BASE_FIELDS
+    + NodeTypeField.get_fields(
+        ArxivAPIWrapper,
+        include=[
+            "top_k_results",
+            "ARXIV_MAX_QUERY_LENGTH",
+            "load_max_docs",
+            "load_all_available_meta",
+            "doc_content_chars_max",
+        ],
+    ),
+}
+
+BING_SEARCH = {
+    "class_path": "ix.tools.bing.get_bing_search",
+    "type": "tool",
+    "name": "Bing Search",
+    "description": "Tool that searches Bing for a given query.",
+    "fields": TOOL_BASE_FIELDS
+    + NodeTypeField.get_fields(
+        BingSearchAPIWrapper,
+        include=["bing_subscription_key", "bing_search_url", "k"],
+        field_options={
+            "bing_subscription_key": {
+                "input": "secret",
+            },
+            "bing_search_url": {
+                "style": {"width": "100%"},
+            },
+        },
+    ),
+}
+
+DUCK_DUCK_GO_SEARCH = {
+    "class_path": "ix.tools.duckduckgo.get_ddg_search",
+    "type": "tool",
+    "name": "DuckDuckGo Search",
+    "description": "Tool that searches DuckDuckGo for a given query.",
+    "fields": TOOL_BASE_FIELDS
+    + NodeTypeField.get_fields(
+        DuckDuckGoSearchAPIWrapper,
+        include=["k", "region", "safesearch", "time", "max_results"],
+    ),
+}
+
 GOOGLE_SEARCH = {
     "class_path": "ix.tools.google.get_google_search",
     "type": "tool",
     "name": "Google Search",
     "description": "Tool that searches Google for a given query.",
-    "fields": TOOL_BASE_FIELDS + [],
+    "fields": TOOL_BASE_FIELDS
+    + NodeTypeField.get_fields(
+        GoogleSearchAPIWrapper,
+        include=["google_api_key", "google_cse_id", "k", "siterestrict"],
+        field_options={
+            "google_api_key": {
+                "input": "secret",
+            },
+            "google_cse_id": {
+                "input": "secret",
+            },
+        },
+    ),
 }
 
 GOOGLE_SERPER = {
-    "class_path": "ix.tools.google.get_google_search",
+    "class_path": "ix.tools.google.get_google_serper",
     "type": "tool",
     "name": "Google Search",
     "description": "Tool that searches Google for a given query.",
-    "fields": TOOL_BASE_FIELDS + [],
+    "fields": TOOL_BASE_FIELDS
+    + NodeTypeField.get_fields(
+        GoogleSerperAPIWrapper,
+        include=["k", "gl", "hl", "type", "tbs", "serper_api_key"],
+        field_options={
+            "serper_api_key": {
+                "input": "secret",
+            },
+        },
+    ),
+}
+
+GRAPHQL_TOOL = {
+    "class_path": "ix.tools.graphql.get_graphql_tool",
+    "type": "tool",
+    "name": "GraphQL Tool",
+    "description": "Tool that searches GraphQL for a given query.",
+    "fields": TOOL_BASE_FIELDS
+    + NodeTypeField.get_fields(GraphQLAPIWrapper, include=["graphql_endpoint"]),
+}
+
+LAMBDA_API = {
+    "class_path": "ix.tools.lambda_api.get_lambda_api",
+    "type": "tool",
+    "name": "Lambda API",
+    "description": "Tool that searches Lambda for a given query.",
+    "fields": TOOL_BASE_FIELDS
+    + NodeTypeField.get_fields(
+        LambdaWrapper,
+        include=["function_name", "awslambda_tool_name", "awslambda_tool_description"],
+    ),
+}
+
+PUB_MED = {
+    "name": "Pubmed",
+    "description": "Pubmed search engine",
+    "class_path": "ix.tools.pubmed.get_pubmed",
+    "type": "tool",
+    "fields": TOOL_BASE_FIELDS
+    + NodeTypeField.get_fields(
+        PubMedAPIWrapper,
+        include=[
+            "max_retry",
+            "top_k_results",
+            "load_max_docs",
+            "ARXIV_MAX_QUERY_LENGTH",
+            "doc_content_chars_max",
+            "load_all_available_meta",
+            "email",
+        ],
+    ),
+}
+
+WIKIPEDIA = {
+    "name": "Wikipedia",
+    "description": "Wikipedia search engine",
+    "class_path": "ix.tools.wikipedia.get_wikipedia",
+    "type": "tool",
+    "fields": TOOL_BASE_FIELDS
+    + NodeTypeField.get_fields(
+        WikipediaAPIWrapper,
+        include=[
+            "top_k_results",
+            "lang",
+            "load_all_available_meta",
+            "doc_content_chars_max",
+        ],
+    ),
 }
 
 
@@ -50,6 +194,14 @@ WOLFRAM = {
 
 
 TOOLS = [
+    ARXIV_SEARCH,
+    BING_SEARCH,
+    DUCK_DUCK_GO_SEARCH,
     GOOGLE_SEARCH,
+    GOOGLE_SERPER,
+    GRAPHQL_TOOL,
+    LAMBDA_API,
+    PUB_MED,
+    WIKIPEDIA,
     WOLFRAM,
 ]

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -237,6 +237,97 @@
 },
 {
   "model": "chains.nodetype",
+  "pk": "2281566f-0611-4eef-b870-547e39bacc45",
+  "fields": {
+    "name": "Google Search",
+    "description": "Tool that searches Google for a given query.",
+    "class_path": "ix.tools.google.get_google_serper",
+    "type": "tool",
+    "display_type": "node",
+    "connectors": null,
+    "fields": [
+      {
+        "name": "description",
+        "type": "str",
+        "default": ""
+      },
+      {
+        "name": "return_direct",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "k",
+        "type": "int",
+        "label": "K",
+        "default": 10,
+        "required": false
+      },
+      {
+        "name": "gl",
+        "type": "str",
+        "label": "Gl",
+        "default": "us",
+        "required": false
+      },
+      {
+        "name": "hl",
+        "type": "str",
+        "label": "Hl",
+        "default": "en",
+        "required": false
+      },
+      {
+        "name": "type",
+        "type": "str",
+        "label": "Type",
+        "choices": [
+          {
+            "label": "News",
+            "value": "news"
+          },
+          {
+            "label": "Search",
+            "value": "search"
+          },
+          {
+            "label": "Places",
+            "value": "places"
+          },
+          {
+            "label": "Images",
+            "value": "images"
+          }
+        ],
+        "default": "search",
+        "required": false
+      },
+      {
+        "name": "tbs",
+        "type": "str",
+        "label": "Tbs",
+        "default": null,
+        "required": false
+      },
+      {
+        "name": "serper_api_key",
+        "type": "str",
+        "input": "secret",
+        "label": "Serper_api_key",
+        "default": null,
+        "required": false
+      }
+    ],
+    "child_field": null
+  }
+},
+{
+  "model": "chains.nodetype",
   "pk": "267a48b0-967d-4df9-b6ec-dec1dd3992b9",
   "fields": {
     "name": "LlamaCpp Embeddings",
@@ -488,6 +579,64 @@
 },
 {
   "model": "chains.nodetype",
+  "pk": "39414ada-446f-4949-b087-193d1c93cb27",
+  "fields": {
+    "name": "Wikipedia",
+    "description": "Wikipedia search engine",
+    "class_path": "ix.tools.wikipedia.get_wikipedia",
+    "type": "tool",
+    "display_type": "node",
+    "connectors": null,
+    "fields": [
+      {
+        "name": "description",
+        "type": "str",
+        "default": ""
+      },
+      {
+        "name": "return_direct",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "top_k_results",
+        "type": "int",
+        "label": "Top_k_results",
+        "default": 3,
+        "required": false
+      },
+      {
+        "name": "lang",
+        "type": "str",
+        "label": "Lang",
+        "default": "en",
+        "required": false
+      },
+      {
+        "name": "load_all_available_meta",
+        "type": "boolean",
+        "label": "Load_all_available_meta",
+        "default": false,
+        "required": false
+      },
+      {
+        "name": "doc_content_chars_max",
+        "type": "int",
+        "label": "Doc_content_chars_max",
+        "default": 4000,
+        "required": false
+      }
+    ],
+    "child_field": null
+  }
+},
+{
+  "model": "chains.nodetype",
   "pk": "3ffc030c-f6cb-4fc2-9cd7-ff1cfd3a5c99",
   "fields": {
     "name": "OpenAI Embeddings",
@@ -508,6 +657,43 @@
         ],
         "default": "text-embedding-ada-002",
         "description": "The model to use."
+      }
+    ],
+    "child_field": null
+  }
+},
+{
+  "model": "chains.nodetype",
+  "pk": "4eb6a170-d0e4-428e-be8d-09ca1ca8383d",
+  "fields": {
+    "name": "GraphQL Tool",
+    "description": "Tool that searches GraphQL for a given query.",
+    "class_path": "ix.tools.graphql.get_graphql_tool",
+    "type": "tool",
+    "display_type": "node",
+    "connectors": null,
+    "fields": [
+      {
+        "name": "description",
+        "type": "str",
+        "default": ""
+      },
+      {
+        "name": "return_direct",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "graphql_endpoint",
+        "type": "str",
+        "label": "Graphql_endpoint",
+        "default": null,
+        "required": true
       }
     ],
     "child_field": null
@@ -604,6 +790,129 @@
         "name": "max_execution_time",
         "type": "float",
         "nullable": true
+      }
+    ],
+    "child_field": null
+  }
+},
+{
+  "model": "chains.nodetype",
+  "pk": "62513b96-183d-43cb-a839-b44d024c2101",
+  "fields": {
+    "name": " search",
+    "description": "Tool that searches Arxiv for a given query.",
+    "class_path": "ix.tools.arxiv.get_arxiv",
+    "type": "tool",
+    "display_type": "node",
+    "connectors": null,
+    "fields": [
+      {
+        "name": "description",
+        "type": "str",
+        "default": ""
+      },
+      {
+        "name": "return_direct",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "top_k_results",
+        "type": "int",
+        "label": "Top_k_results",
+        "default": 3,
+        "required": false
+      },
+      {
+        "name": "load_max_docs",
+        "type": "int",
+        "label": "Load_max_docs",
+        "default": 100,
+        "required": false
+      },
+      {
+        "name": "load_all_available_meta",
+        "type": "boolean",
+        "label": "Load_all_available_meta",
+        "default": false,
+        "required": false
+      },
+      {
+        "name": "doc_content_chars_max",
+        "type": "int",
+        "label": "Doc_content_chars_max",
+        "default": 4000,
+        "required": false
+      }
+    ],
+    "child_field": null
+  }
+},
+{
+  "model": "chains.nodetype",
+  "pk": "68c6cb60-8ae6-4242-8e68-220d6b0ea472",
+  "fields": {
+    "name": "DuckDuckGo Search",
+    "description": "Tool that searches DuckDuckGo for a given query.",
+    "class_path": "ix.tools.duckduckgo.get_ddg_search",
+    "type": "tool",
+    "display_type": "node",
+    "connectors": null,
+    "fields": [
+      {
+        "name": "description",
+        "type": "str",
+        "default": ""
+      },
+      {
+        "name": "return_direct",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "k",
+        "type": "int",
+        "label": "K",
+        "default": 10,
+        "required": false
+      },
+      {
+        "name": "region",
+        "type": "str",
+        "label": "Region",
+        "default": "wt-wt",
+        "required": false
+      },
+      {
+        "name": "safesearch",
+        "type": "str",
+        "label": "Safesearch",
+        "default": "moderate",
+        "required": false
+      },
+      {
+        "name": "time",
+        "type": "str",
+        "label": "Time",
+        "default": "y",
+        "required": false
+      },
+      {
+        "name": "max_results",
+        "type": "int",
+        "label": "Max_results",
+        "default": 5,
+        "required": false
       }
     ],
     "child_field": null
@@ -1150,6 +1459,71 @@
         "name": "max_execution_time",
         "type": "float",
         "nullable": true
+      }
+    ],
+    "child_field": null
+  }
+},
+{
+  "model": "chains.nodetype",
+  "pk": "a9fb2b5d-78d6-428d-a968-11ff4f43ff1b",
+  "fields": {
+    "name": "Pubmed",
+    "description": "Pubmed search engine",
+    "class_path": "ix.tools.pubmed.get_pubmed",
+    "type": "tool",
+    "display_type": "node",
+    "connectors": null,
+    "fields": [
+      {
+        "name": "description",
+        "type": "str",
+        "default": ""
+      },
+      {
+        "name": "return_direct",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "top_k_results",
+        "type": "int",
+        "label": "Top_k_results",
+        "default": 3,
+        "required": false
+      },
+      {
+        "name": "load_max_docs",
+        "type": "int",
+        "label": "Load_max_docs",
+        "default": 25,
+        "required": false
+      },
+      {
+        "name": "doc_content_chars_max",
+        "type": "int",
+        "label": "Doc_content_chars_max",
+        "default": 2000,
+        "required": false
+      },
+      {
+        "name": "load_all_available_meta",
+        "type": "boolean",
+        "label": "Load_all_available_meta",
+        "default": false,
+        "required": false
+      },
+      {
+        "name": "email",
+        "type": "str",
+        "label": "Email",
+        "default": "your_email@example.com",
+        "required": false
       }
     ],
     "child_field": null
@@ -1850,6 +2224,112 @@
         "name": "output_key",
         "type": "string",
         "default": "text"
+      }
+    ],
+    "child_field": null
+  }
+},
+{
+  "model": "chains.nodetype",
+  "pk": "ef8a1cc4-a26c-4b95-b9f7-2d6ce0f176d0",
+  "fields": {
+    "name": "Bing Search",
+    "description": "Tool that searches Bing for a given query.",
+    "class_path": "ix.tools.bing.get_bing_search",
+    "type": "tool",
+    "display_type": "node",
+    "connectors": null,
+    "fields": [
+      {
+        "name": "description",
+        "type": "str",
+        "default": ""
+      },
+      {
+        "name": "return_direct",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "bing_subscription_key",
+        "type": "str",
+        "input": "secret",
+        "label": "Bing_subscription_key",
+        "default": null,
+        "required": true
+      },
+      {
+        "name": "bing_search_url",
+        "type": "str",
+        "label": "Bing_search_url",
+        "style": {
+          "width": "100%"
+        },
+        "default": null,
+        "required": true
+      },
+      {
+        "name": "k",
+        "type": "int",
+        "label": "K",
+        "default": 10,
+        "required": false
+      }
+    ],
+    "child_field": null
+  }
+},
+{
+  "model": "chains.nodetype",
+  "pk": "f1c98a9d-395b-45ed-91c5-448daf7c5b8d",
+  "fields": {
+    "name": "Lambda API",
+    "description": "Tool that searches Lambda for a given query.",
+    "class_path": "ix.tools.lambda_api.get_lambda_api",
+    "type": "tool",
+    "display_type": "node",
+    "connectors": null,
+    "fields": [
+      {
+        "name": "description",
+        "type": "str",
+        "default": ""
+      },
+      {
+        "name": "return_direct",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "function_name",
+        "type": "str",
+        "label": "Function_name",
+        "default": null,
+        "required": false
+      },
+      {
+        "name": "awslambda_tool_name",
+        "type": "str",
+        "label": "Awslambda_tool_name",
+        "default": null,
+        "required": false
+      },
+      {
+        "name": "awslambda_tool_description",
+        "type": "str",
+        "label": "Awslambda_tool_description",
+        "default": null,
+        "required": false
       }
     ],
     "child_field": null

--- a/ix/tools/arxiv.py
+++ b/ix/tools/arxiv.py
@@ -1,0 +1,11 @@
+from langchain import ArxivAPIWrapper
+from langchain.tools import BaseTool, ArxivQueryRun
+
+from ix.chains.loaders.tools import extract_tool_kwargs
+from typing import Any
+
+
+def get_arxiv(**kwargs: Any) -> BaseTool:
+    tool_kwargs = extract_tool_kwargs(kwargs)
+    wrapper = ArxivAPIWrapper(**kwargs)
+    return ArxivQueryRun(api_wrapper=wrapper, **tool_kwargs)

--- a/ix/tools/bing.py
+++ b/ix/tools/bing.py
@@ -1,0 +1,10 @@
+from langchain.tools import BaseTool, BingSearchRun
+from langchain.utilities import BingSearchAPIWrapper
+
+from ix.chains.loaders.tools import extract_tool_kwargs
+
+
+def get_bing_search(**kwargs) -> BaseTool:
+    tool_kwargs = extract_tool_kwargs(kwargs)
+    wrapper = BingSearchAPIWrapper(**kwargs)
+    return BingSearchRun(api_wrapper=wrapper, **tool_kwargs)

--- a/ix/tools/duckduckgo.py
+++ b/ix/tools/duckduckgo.py
@@ -1,0 +1,10 @@
+from langchain.tools import DuckDuckGoSearchRun, BaseTool
+from langchain.utilities import DuckDuckGoSearchAPIWrapper
+
+from ix.chains.loaders.tools import extract_tool_kwargs
+
+
+def get_ddg_search(**kwargs) -> BaseTool:
+    tool_kwargs = extract_tool_kwargs(kwargs)
+    wrapper = DuckDuckGoSearchAPIWrapper(**kwargs)
+    return DuckDuckGoSearchRun(api_wrapper=wrapper, **tool_kwargs)

--- a/ix/tools/graphql.py
+++ b/ix/tools/graphql.py
@@ -1,0 +1,10 @@
+from langchain.tools import BaseTool, BaseGraphQLTool
+from langchain.utilities import GraphQLAPIWrapper
+
+from ix.chains.loaders.tools import extract_tool_kwargs
+
+
+def get_graphql_tool(**kwargs) -> BaseTool:
+    tool_kwargs = extract_tool_kwargs(kwargs)
+    wrapper = GraphQLAPIWrapper(graphql_endpoint=kwargs["graphql_endpoint"])
+    return BaseGraphQLTool(graphql_wrapper=wrapper, **tool_kwargs)

--- a/ix/tools/lambda_api.py
+++ b/ix/tools/lambda_api.py
@@ -1,0 +1,16 @@
+from langchain.tools import BaseTool, Tool
+from langchain.utilities import LambdaWrapper
+
+from ix.chains.loaders.tools import extract_tool_kwargs
+from typing import Any
+
+
+def get_lambda_api(**kwargs: Any) -> BaseTool:
+    tool_kwargs = extract_tool_kwargs(kwargs)
+    wrapper = LambdaWrapper(**kwargs)
+    return Tool(
+        name=kwargs["awslambda_tool_name"],
+        description=kwargs["awslambda_tool_description"],
+        func=wrapper.run,
+        **tool_kwargs
+    )

--- a/ix/tools/pubmed.py
+++ b/ix/tools/pubmed.py
@@ -8,4 +8,4 @@ from typing import Any
 def get_pubmed(**kwargs: Any) -> BaseTool:
     tool_kwargs = extract_tool_kwargs(kwargs)
     wrapper = PubMedAPIWrapper(**kwargs)
-    return PubmedQueryRun(api_wrapper=wrapper, **tool_kwargs
+    return PubmedQueryRun(api_wrapper=wrapper, **tool_kwargs)

--- a/ix/tools/pubmed.py
+++ b/ix/tools/pubmed.py
@@ -1,0 +1,11 @@
+from langchain.tools import PubmedQueryRun, BaseTool
+from langchain.utilities import PubMedAPIWrapper
+
+from ix.chains.loaders.tools import extract_tool_kwargs
+from typing import Any
+
+
+def get_pubmed(**kwargs: Any) -> BaseTool:
+    tool_kwargs = extract_tool_kwargs(kwargs)
+    wrapper = PubMedAPIWrapper(**kwargs)
+    return PubmedQueryRun(api_wrapper=wrapper, **tool_kwargs

--- a/ix/tools/wikipedia.py
+++ b/ix/tools/wikipedia.py
@@ -1,0 +1,11 @@
+from langchain import WikipediaAPIWrapper
+from langchain.tools import WikipediaQueryRun, BaseTool
+
+from ix.chains.loaders.tools import extract_tool_kwargs
+from typing import Any
+
+
+def get_wikipedia(**kwargs: Any) -> BaseTool:
+    tool_kwargs = extract_tool_kwargs(kwargs)
+    wrapper = WikipediaAPIWrapper(**kwargs)
+    return WikipediaQueryRun(api_wrapper=wrapper, **tool_kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,6 @@ pytest-mock==3.10.0
 redis==4.5.5
 requests==2.31.0
 tiktoken==0.4.0
-wikpedia==1.4.0
+wikipedia==1.4.0
 wolframalpha==5.0.0
 uvicorn[standard]==0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,5 +34,6 @@ pytest-mock==3.10.0
 redis==4.5.5
 requests==2.31.0
 tiktoken==0.4.0
+wikpedia==1.4.0
 wolframalpha==5.0.0
 uvicorn[standard]==0.22.0


### PR DESCRIPTION
### Description

Adds `NodeType` definitions for a bunch more tools. 

These aren't fully tested beyond creating nodes in UX, but should be 90-95% of the way there for any that don't work. This was a test utilizing `get_fields`  helper (#87) to simplify and speed up the integration process.

New tools:
- ARXIV_SEARCH
- BING_SEARCH
- DUCK_DUCK_GO_SEARCH
- GOOGLE_SERPER
- GRAPHQL_TOOL
- LAMBDA_API
- PUB_MED
- WIKIPEDIA

### Changes
- adds more tool `NodeTypes`

### How Tested
- manually generating nodes in UX

### TODOs
This adds types but doesn't fully test the integrations. Some of these may need additional libraries to be installed to function.
