### PR TITLE
Agent inputs are only set by default if not already set

### DIFF
--- a/ix/agents/process.py
+++ b/ix/agents/process.py
@@ -131,10 +131,16 @@ class AgentProcess:
 
         logger.info(f"Sending request to chain={self.chain.name} prompt={user_input}")
 
+        # auto-map user_input to input if not provided.
+        # work around until chat input key can be configured per chain
+        extra_kwargs = {}
+        if "input" not in user_input:
+            extra_kwargs["input"] = user_input
+
         start = time.time()
         try:
             # Hax: copy user_input to input to support agents.
-            response = await chain.arun(input=user_input["user_input"], **user_input)
+            response = await chain.arun(**extra_kwargs, **user_input)
         except:  # noqa: E722
             raise
         finally:

--- a/ix/agents/tests/test_process.py
+++ b/ix/agents/tests/test_process.py
@@ -84,6 +84,34 @@ class TestAgentProcessStart:
         #      "total_tokens": 12,
         #  }
 
+    async def test_start_task_with_input(self, mock_openai, mock_embeddings):
+        """
+        Test that if `input` is included in inputs then it will be
+        used instead of the default `user_input -> input` mapping.
+        """
+        await sync_to_async(load_fixture)("node_types")
+        task = await sync_to_async(fake_task)()
+        mock_reply = await sync_to_async(fake_command_reply)(task=task)
+        await mock_reply.adelete()
+        query = TaskLogMessage.objects.filter(task=task)
+        count = await query.acount()
+        assert count == 0
+        agent_process = AgentProcess(task=task, agent=task.agent, chain=task.chain)
+
+        inputs = {"user_input": "hello agent 1", "input": "existing input"}
+        return_value = await agent_process.start(inputs)
+        assert return_value is True
+
+        count = await query.acount()
+        assert count == 2
+        messages = [msg async for msg in query]
+        think_msg = messages[0]
+        thought_msg = messages[1]
+        assert think_msg.content["type"] == "THINK"
+        assert think_msg.content["input"] == inputs
+        assert thought_msg.content["type"] == "THOUGHT"
+        assert isinstance(thought_msg.content["runtime"], float)
+
 
 def msg_to_response(msg: TaskLogMessage):
     """utility for turning model instances back into response json"""


### PR DESCRIPTION
### Description
`@ix` couldn't delegate to tasks because `input` was added twice.

![image](https://github.com/kreneskyp/ix/assets/68635/5d71b52f-1504-406a-84a3-ab66aeb41770)


### Changes
- `input` will only be auto-set once

### How Tested
- unittest
- manual test

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
