### PR TITLE
Moving ConfigNodes in the editor now send only the position.

### DIFF
--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -137,15 +137,12 @@ const ChainGraphEditor = ({ graph }) => {
 
   const onNodeDragStop = useCallback((event, node) => {
     // update node with new position
-    const data = {
-      id: node.id,
-      classPath: node.data.node.classPath,
-      name: node.data.node.name,
-      description: node.data.node.description,
-      config: node.data.node.config,
-      position: node.position,
-    };
-    api.updateNode({ data });
+    api.updateNodePosition({
+      data: {
+        id: node.id,
+        position: node.position,
+      },
+    });
   }, []);
 
   // new edges
@@ -207,7 +204,10 @@ const ChainGraphEditor = ({ graph }) => {
       // connection types must match
       // HAX: adding a special case for chain-agent connections until expectedType can be
       //      expanded to be a set of types
-      if (expectedType === providedType || (expectedType === "chain" && providedType === "agent")) {
+      if (
+        expectedType === providedType ||
+        (expectedType === "chain" && providedType === "agent")
+      ) {
         const instanceEdges = reactFlowInstance.getEdges();
         const targetEdges = instanceEdges.filter(
           (e) =>

--- a/frontend/chains/flow/ConfigNode.js
+++ b/frontend/chains/flow/ConfigNode.js
@@ -153,7 +153,9 @@ export const ConfigNode = ({ data }) => {
       <Handle
         id={type.type}
         type="source"
-        position={type.type === "chain" || type.type === "agent" ? "left" : "right"}
+        position={
+          type.type === "chain" || type.type === "agent" ? "left" : "right"
+        }
         style={{ top: "15px", transform: "translateX(-2px)" }}
       />
       <Heading

--- a/frontend/chains/graphql/UpdateChainNodePositionMutation.js
+++ b/frontend/chains/graphql/UpdateChainNodePositionMutation.js
@@ -1,0 +1,15 @@
+import { graphql } from "react-relay";
+
+export const UpdateChainNodePositionMutation = graphql`
+  mutation UpdateChainNodePositionMutation($data: ChainNodePositionInput!) {
+    updateChainNodePosition(data: $data) {
+      node {
+        id
+        position {
+          x
+          y
+        }
+      }
+    }
+  }
+`;

--- a/frontend/chains/hooks/useChainEditorAPI.js
+++ b/frontend/chains/hooks/useChainEditorAPI.js
@@ -8,6 +8,7 @@ import { DeleteChainEdgeMutation } from "chains/graphql/DeleteChainEdgeMutation"
 import { AddChainNodeMutation } from "chains/graphql/AddChainNodeMutation";
 import { useCallback, useMemo } from "react";
 import { SetChainRootMutation } from "chains/graphql/SetChainRootMutation";
+import { UpdateChainNodePositionMutation } from "chains/graphql/UpdateChainNodePositionMutation";
 
 // utility for wrapping default onCompleted with onCompleted arg
 const useNestedCallback = (func, callback) => {
@@ -59,6 +60,17 @@ export const useChainEditorAPI = ({
       query: UpdateChainNodeMutation,
       reactFlowInstance,
     });
+
+  const {
+    callback: updateNodePosition,
+    isInFlight: updateNodePositionInFlight,
+  } = useChainEditorMutation({
+    chain,
+    onCompleted,
+    onError,
+    query: UpdateChainNodePositionMutation,
+    reactFlowInstance,
+  });
 
   const onDeleteNode = useCallback(
     useNestedCallback((response) => {
@@ -114,6 +126,7 @@ export const useChainEditorAPI = ({
       setRootInFlight ||
       addNodeInFlight ||
       updateNodeInFlight ||
+      updateNodePositionInFlight ||
       deleteNodeInFlight ||
       addEdgeInFlight ||
       updateEdgeInFlight ||
@@ -124,6 +137,7 @@ export const useChainEditorAPI = ({
       updateChain,
       setRoot,
       updateNode,
+      updateNodePosition,
       addNode,
       deleteNode,
       addEdge,

--- a/ix/schema/mutations/chains.py
+++ b/ix/schema/mutations/chains.py
@@ -120,6 +120,28 @@ class UpdateChainNodeMutation(graphene.Mutation):
         return UpdateChainNodeMutation(node=node)
 
 
+class ChainNodePositionInput(graphene.InputObjectType):
+    id = graphene.UUID()
+    position = PositionInput()
+
+
+class UpdateChainNodePositionMutation(graphene.Mutation):
+    class Arguments:
+        data = ChainNodePositionInput(required=True)
+
+    node = graphene.Field(ChainNodeType)
+
+    @staticmethod
+    def mutate(root, info, data):
+        # don't allow updating the chain
+        data.pop("chain_id", None)
+
+        node = ChainNode.objects.get(id=data["id"])
+        node.position = data["position"]
+        node.save(update_fields=["position"])
+        return UpdateChainNodeMutation(node=node)
+
+
 class DeleteChainNodeMutation(graphene.Mutation):
     class Arguments:
         id = graphene.UUID(required=True)
@@ -211,6 +233,7 @@ class Mutation(graphene.ObjectType):
     set_chain_root = SetChainRootMutation.Field()
     add_chain_node = AddChainNodeMutation.Field()
     update_chain_node = UpdateChainNodeMutation.Field()
+    update_chain_node_position = UpdateChainNodePositionMutation.Field()
     delete_chain_node = DeleteChainNodeMutation.Field()
     add_chain_edge = AddChainEdgeMutation.Field()
     update_chain_edge = UpdateChainEdgeMutation.Field()

--- a/ix/schema/tests/test_chain_mutations.py
+++ b/ix/schema/tests/test_chain_mutations.py
@@ -46,6 +46,20 @@ UPDATE_CHAIN_NODE = """
     }
 """
 
+UPDATE_CHAIN_NODE_POSITION = """
+    mutation UpdateChainNodePosition($data: ChainNodePositionInput!) {
+        updateChainNodePosition(data: $data) {
+            node {
+                id
+                position {
+                    x
+                    y
+                }
+            }
+        }
+    }
+"""
+
 DELETE_CHAIN_NODE = """
     mutation DeleteChainNode($id: UUID!) {
         deleteChainNode(id: $id) {
@@ -258,6 +272,89 @@ class TestChainNodeMutation:
         assert ChainNode.objects.filter(id=node.id).count() == 0
         assert ChainEdge.objects.filter(id=edge_in.id).count() == 0
         assert ChainEdge.objects.filter(id=edge_out.id).count() == 0
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("node_types")
+class TestChainNodePositionMutation:
+    def test_add_first_chain_node_mutation(self):
+        """
+        The first node will create the chain
+        """
+        # Create a Graphene client
+        client = Client(schema)
+
+        assert not Chain.objects.filter(name="Custom Node").exists()
+
+        node = fake_chain_node()
+
+        # Prepare variables for the GraphQL query
+        # exclude chain here
+        variables = {
+            "data": {
+                "id": str(node.id),
+                "position": {
+                    "x": 100,
+                    "y": 200,
+                },
+            }
+        }
+
+        # Execute the GraphQL query
+        result = client.execute(UPDATE_CHAIN_NODE_POSITION, variables=variables)
+
+        print(result)
+
+        # Assert the result
+        assert "errors" not in result
+        node_data = result["data"]["updateChainNodePosition"]["node"]
+        assert node_data["id"] is not None
+        assert node_data["position"] == {
+            "x": 100,
+            "y": 200,
+        }
+
+    def test_add_chain_node_mutation(self):
+        """
+        subsequent nodes will use the existing chain
+        """
+        # Create a Graphene client
+        client = Client(schema)
+
+        chain = fake_chain()
+
+        # Prepare variables for the GraphQL query
+        variables = {
+            "data": {
+                "chainId": str(chain.id),
+                "classPath": "ix.chains.llm_chain.LLMChain",
+                "config": {},
+                "name": "Custom Node",
+                "description": "Custom Description",
+                "position": {
+                    "x": 10,
+                    "y": 20,
+                },
+            }
+        }
+
+        # Execute the GraphQL query
+        result = client.execute(ADD_CHAIN_NODE, variables=variables)
+
+        # Assert the result
+        assert "errors" not in result
+        node_data = result["data"]["addChainNode"]["node"]
+        assert node_data["id"] is not None
+        assert node_data["name"] == "Custom Node"
+        assert node_data["description"] == "Custom Description"
+        assert node_data["position"] == {
+            "x": 10,
+            "y": 20,
+        }
+
+        # assert models
+        node = ChainNode.objects.get(id=node_data["id"])
+        assert node.chain_id == chain.id
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Description
Node position changes now send only the position. 

Position updates were reverting config to the initial rendered state of the node. It had a stale copy of the `node` object. Position updates were isolated rather than attempting to maintain shared state for the full object.

### Changes
- added `UpdateChainNodePositionMutation`
- chain editor now uses `UpdateChainNodePositionMutation`

### How Tested
- new unittest
- manual testing

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
