### PR TITLE
Add OpenAPI chain with OpenAI functions

### DIFF
--- a/ix/chains/asyncio.py
+++ b/ix/chains/asyncio.py
@@ -1,9 +1,9 @@
-from typing import Optional
+from typing import Optional, Any, Dict
 from asgiref.sync import sync_to_async
-from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
+from langchain.callbacks.manager import AsyncCallbackManagerForToolRun, CallbackManagerForChainRun
 
 
-class SyncToAsync:
+class SyncToAsyncRun:
     """
     Mixin to convert a chain or tool to run asynchronously by using
     sync_to_async to convert the run method to a coroutine.

--- a/ix/chains/asyncio.py
+++ b/ix/chains/asyncio.py
@@ -1,6 +1,9 @@
 from typing import Optional, Any, Dict
 from asgiref.sync import sync_to_async
-from langchain.callbacks.manager import AsyncCallbackManagerForToolRun, CallbackManagerForChainRun
+from langchain.callbacks.manager import (
+    AsyncCallbackManagerForToolRun,
+    CallbackManagerForChainRun,
+)
 
 
 class SyncToAsyncRun:
@@ -19,4 +22,23 @@ class SyncToAsyncRun:
     ) -> str:
         """Use the tool asynchronously."""
         result = await sync_to_async(self._run)(query, run_manager=run_manager)
+        return result
+
+
+class SyncToAsyncCall:
+    """
+    Mixin to convert a chain or tool to run asynchronously by using
+    sync_to_async to convert the _call method to a coroutine.
+
+    This doesn't provide full async support, but it does allow for
+    the chain/tool to work.
+    """
+
+    async def _acall(
+        self,
+        inputs: Dict[str, Any],
+        run_manager: Optional[CallbackManagerForChainRun] = None,
+    ) -> str:
+        """Use the tool asynchronously."""
+        result = await sync_to_async(self._call)(inputs, run_manager=run_manager)
         return result

--- a/ix/chains/fixture_src/openai_functions.py
+++ b/ix/chains/fixture_src/openai_functions.py
@@ -45,7 +45,7 @@ FUNCTION_CALL = {
 }
 
 OPENAPI_CHAIN = {
-    "class_path": "langchain.chains.openai_functions.openapi.get_openapi_chain",
+    "class_path": "ix.chains.openapi.get_openapi_chain_async",
     "type": "chain",
     "name": "OpenAPI with OpenAI Functions",
     "description": "Chain that uses OpenAI Functions to call OpenAPI endpoints.",

--- a/ix/chains/fixture_src/openai_functions.py
+++ b/ix/chains/fixture_src/openai_functions.py
@@ -1,3 +1,6 @@
+from ix.chains.fixture_src.common import VERBOSE
+from ix.chains.fixture_src.targets import LLM_TARGET, MEMORY_TARGET, PROMPT_TARGET
+
 FUNCTION_SCHEMA = {
     "class_path": "ix.chains.functions.FunctionSchema",
     "type": "tool",
@@ -39,4 +42,23 @@ FUNCTION_OUTPUT_PARSER = {
 FUNCTION_CALL = {
     "name": "function_call",
     "type": "string",
+}
+
+OPENAPI_CHAIN = {
+    "class_path": "langchain.chains.openai_functions.openapi.get_openapi_chain",
+    "type": "chain",
+    "name": "OpenAPI with OpenAI Functions",
+    "description": "Chain that uses OpenAI Functions to call OpenAPI endpoints.",
+    "connectors": [LLM_TARGET, MEMORY_TARGET, PROMPT_TARGET],
+    "fields": [
+        VERBOSE,
+        {
+            "name": "spec",
+            "type": "string",
+            "label": "OpenAPI URL",
+            "style": {
+                "width": "500px",
+            },
+        },
+    ],
 }

--- a/ix/chains/management/commands/import_langchain.py
+++ b/ix/chains/management/commands/import_langchain.py
@@ -2,7 +2,11 @@ from django.core.management.base import BaseCommand
 
 from ix.chains.fixture_src.agents import AGENTS
 from ix.chains.fixture_src.artifacts import ARTIFACT_MEMORY, SAVE_ARTIFACT
-from ix.chains.fixture_src.chains import LLM_CHAIN, LLM_TOOL_CHAIN, LLM_REPLY
+from ix.chains.fixture_src.chains import (
+    LLM_CHAIN,
+    LLM_TOOL_CHAIN,
+    LLM_REPLY,
+)
 from ix.chains.fixture_src.chat_memory_backend import (
     FILESYSTEM_MEMORY_BACKEND,
     REDIS_MEMORY_BACKEND,
@@ -26,6 +30,7 @@ from ix.chains.fixture_src.memory import (
 from ix.chains.fixture_src.openai_functions import (
     FUNCTION_SCHEMA,
     FUNCTION_OUTPUT_PARSER,
+    OPENAPI_CHAIN,
 )
 from ix.chains.fixture_src.prompts import CHAT_PROMPT_TEMPLATE
 from ix.chains.fixture_src.routing import SEQUENCE, MAP_SUBCHAIN
@@ -77,6 +82,7 @@ COMPONENTS.extend(
     [
         FUNCTION_SCHEMA,
         FUNCTION_OUTPUT_PARSER,
+        OPENAPI_CHAIN,
     ]
 )
 

--- a/ix/chains/openapi.py
+++ b/ix/chains/openapi.py
@@ -26,7 +26,7 @@ def get_openapi_chain_async(**kwargs):
     ):
         # modified to use `user_input` for consistency with other chains
         if "prompt" not in kwargs:
-            kwargs['prompt'] = ChatPromptTemplate.from_template(
+            kwargs["prompt"] = ChatPromptTemplate.from_template(
                 "Use the provided API's to respond to this user query:\n\n{user_input}"
             )
 

--- a/ix/chains/openapi.py
+++ b/ix/chains/openapi.py
@@ -1,0 +1,26 @@
+import logging
+from unittest import mock
+from langchain.chains.openai_functions.openapi import (
+    get_openapi_chain,
+    SimpleRequestChain,
+)
+from ix.chains.asyncio import SyncToAsyncCall
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncSimpleRequestChainRun(SyncToAsyncCall, SimpleRequestChain):
+    pass
+
+
+def get_openapi_chain_async(**kwargs):
+    """
+    Extremely hacky way of injecting asyncio support into LangChain's function.
+    Done within this wrapper function to limit the scope of the patch.
+    """
+    with mock.patch(
+        "langchain.chains.openai_functions.openapi.SimpleRequestChain",
+        new=AsyncSimpleRequestChainRun,
+    ):
+        chain = get_openapi_chain(**kwargs)
+        return chain

--- a/ix/chains/openapi.py
+++ b/ix/chains/openapi.py
@@ -4,6 +4,8 @@ from langchain.chains.openai_functions.openapi import (
     get_openapi_chain,
     SimpleRequestChain,
 )
+from langchain.prompts import ChatPromptTemplate
+
 from ix.chains.asyncio import SyncToAsyncCall
 
 logger = logging.getLogger(__name__)
@@ -22,5 +24,11 @@ def get_openapi_chain_async(**kwargs):
         "langchain.chains.openai_functions.openapi.SimpleRequestChain",
         new=AsyncSimpleRequestChainRun,
     ):
+        # modified to use `user_input` for consistency with other chains
+        if "prompt" not in kwargs:
+            kwargs['prompt'] = ChatPromptTemplate.from_template(
+                "Use the provided API's to respond to this user query:\n\n{user_input}"
+            )
+
         chain = get_openapi_chain(**kwargs)
         return chain

--- a/ix/tools/arxiv.py
+++ b/ix/tools/arxiv.py
@@ -1,12 +1,12 @@
 from langchain import ArxivAPIWrapper
 from langchain.tools import BaseTool, ArxivQueryRun
 
-from ix.chains.asyncio import SyncToAsync
+from ix.chains.asyncio import SyncToAsyncRun
 from ix.chains.loaders.tools import extract_tool_kwargs
 from typing import Any
 
 
-class AsyncArxivQueryRun(SyncToAsync, ArxivQueryRun):
+class AsyncArxivQueryRun(SyncToAsyncRun, ArxivQueryRun):
     pass
 
 

--- a/ix/tools/bing.py
+++ b/ix/tools/bing.py
@@ -1,11 +1,11 @@
 from langchain.tools import BaseTool, BingSearchRun
 from langchain.utilities import BingSearchAPIWrapper
 
-from ix.chains.asyncio import SyncToAsync
+from ix.chains.asyncio import SyncToAsyncRun
 from ix.chains.loaders.tools import extract_tool_kwargs
 
 
-class AsyncBingSearchRun(SyncToAsync, BingSearchRun):
+class AsyncBingSearchRun(SyncToAsyncRun, BingSearchRun):
     pass
 
 

--- a/ix/tools/duckduckgo.py
+++ b/ix/tools/duckduckgo.py
@@ -1,11 +1,11 @@
 from langchain.tools import DuckDuckGoSearchRun, BaseTool
 from langchain.utilities import DuckDuckGoSearchAPIWrapper
 
-from ix.chains.asyncio import SyncToAsync
+from ix.chains.asyncio import SyncToAsyncRun
 from ix.chains.loaders.tools import extract_tool_kwargs
 
 
-class AsyncDuckDuckGoSearchRun(SyncToAsync, DuckDuckGoSearchRun):
+class AsyncDuckDuckGoSearchRun(SyncToAsyncRun, DuckDuckGoSearchRun):
     pass
 
 

--- a/ix/tools/google.py
+++ b/ix/tools/google.py
@@ -1,4 +1,4 @@
-from ix.chains.asyncio import SyncToAsync
+from ix.chains.asyncio import SyncToAsyncRun
 from ix.chains.loaders.tools import extract_tool_kwargs
 from typing import Any
 
@@ -23,7 +23,7 @@ def get_google_serper_results_json(**kwargs: Any) -> BaseTool:
     return GoogleSerperResults(api_wrapper=wrapper, **tool_kwargs)
 
 
-class AsyncGoogleSearchResults(SyncToAsync, GoogleSearchResults):
+class AsyncGoogleSearchResults(SyncToAsyncRun, GoogleSearchResults):
     pass
 
 

--- a/ix/tools/graphql.py
+++ b/ix/tools/graphql.py
@@ -1,11 +1,11 @@
 from langchain.tools import BaseTool, BaseGraphQLTool
 from langchain.utilities import GraphQLAPIWrapper
 
-from ix.chains.asyncio import SyncToAsync
+from ix.chains.asyncio import SyncToAsyncRun
 from ix.chains.loaders.tools import extract_tool_kwargs
 
 
-class AsyncGraphQLTool(SyncToAsync, BaseGraphQLTool):
+class AsyncGraphQLTool(SyncToAsyncRun, BaseGraphQLTool):
     pass
 
 

--- a/ix/tools/pubmed.py
+++ b/ix/tools/pubmed.py
@@ -1,12 +1,12 @@
 from langchain.tools import PubmedQueryRun, BaseTool
 from langchain.utilities import PubMedAPIWrapper
 
-from ix.chains.asyncio import SyncToAsync
+from ix.chains.asyncio import SyncToAsyncRun
 from ix.chains.loaders.tools import extract_tool_kwargs
 from typing import Any
 
 
-class AsyncPubmedQueryRun(SyncToAsync, PubmedQueryRun):
+class AsyncPubmedQueryRun(SyncToAsyncRun, PubmedQueryRun):
     pass
 
 

--- a/ix/tools/wikipedia.py
+++ b/ix/tools/wikipedia.py
@@ -2,11 +2,11 @@ from typing import Any
 from langchain import WikipediaAPIWrapper
 from langchain.tools import WikipediaQueryRun, BaseTool
 
-from ix.chains.asyncio import SyncToAsync
+from ix.chains.asyncio import SyncToAsyncRun
 from ix.chains.loaders.tools import extract_tool_kwargs
 
 
-class AsyncWikipediaQueryRun(SyncToAsync, WikipediaQueryRun):
+class AsyncWikipediaQueryRun(SyncToAsyncRun, WikipediaQueryRun):
     pass
 
 

--- a/ix/tools/wolfram_alpha.py
+++ b/ix/tools/wolfram_alpha.py
@@ -1,12 +1,12 @@
 from langchain import WolframAlphaAPIWrapper
 from langchain.tools import BaseTool, WolframAlphaQueryRun
 
-from ix.chains.asyncio import SyncToAsync
+from ix.chains.asyncio import SyncToAsyncRun
 from ix.chains.loaders.tools import extract_tool_kwargs
 from typing import Any
 
 
-class AsyncWolframAlphaQueryRun(SyncToAsync, WolframAlphaQueryRun):
+class AsyncWolframAlphaQueryRun(SyncToAsyncRun, WolframAlphaQueryRun):
     pass
 
 


### PR DESCRIPTION
### Description
This integrates the OpenAPI Functions chain described here: https://python.langchain.com/docs/modules/chains/additional/openapi_openai

The OpenAPI Functions chain reads an API spec and passes it to an OpenAI LLM as functions. The chain then executes the call against the API.

![image](https://github.com/kreneskyp/ix/assets/68635/e77bd946-d480-4055-adc4-8f3f547cc621)

Tested with `klarna` api

![image](https://github.com/kreneskyp/ix/assets/68635/b33ab0d8-ae07-4438-8239-75a01c21266a)



### Changes
- adds NodeType definitions for `get_openapi_chain`

### How Tested
- [x] manual tests

### TODOs
- [x] Currently blocked as `get_openapi_chain` uses `SimpleRequestChain` which does not support async. Need a workaround or upstream fix.  

        Fixed: Hacked around this by patching `asyncio` support into `SimpleRequestRouter` used by the OpenAPI chain.
        
- [x] API requests are working but needs further work to format output for the user.

Discovered and fixed bugs or worked around them  #104  #105  #106 

