### PR TITLE
Async tools

### DIFF
--- a/ix/chains/fixture_src/tools.py
+++ b/ix/chains/fixture_src/tools.py
@@ -102,7 +102,7 @@ GOOGLE_SEARCH = {
 GOOGLE_SERPER = {
     "class_path": "ix.tools.google.get_google_serper",
     "type": "tool",
-    "name": "Google Search",
+    "name": "Google Serper",
     "description": "Tool that searches Google for a given query.",
     "fields": TOOL_BASE_FIELDS
     + NodeTypeField.get_fields(

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -239,8 +239,8 @@
   "model": "chains.nodetype",
   "pk": "2281566f-0611-4eef-b870-547e39bacc45",
   "fields": {
-    "name": "Google Search",
-    "description": "Tool that searches Google for a given query.",
+    "name": "Google Serper",
+    "description": "Tool that searches Google for a given query with the serper API.",
     "class_path": "ix.tools.google.get_google_serper",
     "type": "tool",
     "display_type": "node",

--- a/ix/chains/models.py
+++ b/ix/chains/models.py
@@ -200,7 +200,7 @@ class ChainNode(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     class_path = models.CharField(max_length=255)
     node_type = models.ForeignKey(NodeType, on_delete=models.CASCADE, null=True)
-    config = models.JSONField(null=True)
+    config = models.JSONField(null=True, default=dict)
     name = models.CharField(max_length=255, null=True)
     description = models.TextField(null=True)
 

--- a/ix/tools/arxiv.py
+++ b/ix/tools/arxiv.py
@@ -1,11 +1,24 @@
+from asgiref.sync import sync_to_async
 from langchain import ArxivAPIWrapper
+from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
 from langchain.tools import BaseTool, ArxivQueryRun
 
 from ix.chains.loaders.tools import extract_tool_kwargs
-from typing import Any
+from typing import Any, Optional
+
+
+class AsyncArxivQueryRun(ArxivQueryRun):
+    async def _arun(
+        self,
+        query: str,
+        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
+    ) -> str:
+        """Use the tool asynchronously."""
+        result = await sync_to_async(self._run)(query, run_manager=run_manager)
+        return result
 
 
 def get_arxiv(**kwargs: Any) -> BaseTool:
     tool_kwargs = extract_tool_kwargs(kwargs)
     wrapper = ArxivAPIWrapper(**kwargs)
-    return ArxivQueryRun(api_wrapper=wrapper, **tool_kwargs)
+    return AsyncArxivQueryRun(api_wrapper=wrapper, **tool_kwargs)

--- a/ix/tools/bing.py
+++ b/ix/tools/bing.py
@@ -1,10 +1,25 @@
+from typing import Optional
+
+from asgiref.sync import sync_to_async
+from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
 from langchain.tools import BaseTool, BingSearchRun
 from langchain.utilities import BingSearchAPIWrapper
 
 from ix.chains.loaders.tools import extract_tool_kwargs
 
 
+class AsyncBingSearchRun(BingSearchRun):
+    async def _arun(
+        self,
+        query: str,
+        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
+    ) -> str:
+        """Use the tool asynchronously."""
+        result = await sync_to_async(self._run)(query, run_manager=run_manager)
+        return result
+
+
 def get_bing_search(**kwargs) -> BaseTool:
     tool_kwargs = extract_tool_kwargs(kwargs)
     wrapper = BingSearchAPIWrapper(**kwargs)
-    return BingSearchRun(api_wrapper=wrapper, **tool_kwargs)
+    return AsyncBingSearchRun(api_wrapper=wrapper, **tool_kwargs)

--- a/ix/tools/duckduckgo.py
+++ b/ix/tools/duckduckgo.py
@@ -1,10 +1,25 @@
+from typing import Optional
+
+from asgiref.sync import sync_to_async
+from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
 from langchain.tools import DuckDuckGoSearchRun, BaseTool
 from langchain.utilities import DuckDuckGoSearchAPIWrapper
 
 from ix.chains.loaders.tools import extract_tool_kwargs
 
 
+class AsyncDuckDuckGoSearchRun(DuckDuckGoSearchRun):
+    async def _arun(
+        self,
+        query: str,
+        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
+    ) -> str:
+        """Use the tool asynchronously."""
+        result = await sync_to_async(self._run)(query, run_manager=run_manager)
+        return result
+
+
 def get_ddg_search(**kwargs) -> BaseTool:
     tool_kwargs = extract_tool_kwargs(kwargs)
     wrapper = DuckDuckGoSearchAPIWrapper(**kwargs)
-    return DuckDuckGoSearchRun(api_wrapper=wrapper, **tool_kwargs)
+    return AsyncDuckDuckGoSearchRun(api_wrapper=wrapper, **tool_kwargs)

--- a/ix/tools/google.py
+++ b/ix/tools/google.py
@@ -26,21 +26,21 @@ def get_google_serper_results_json(**kwargs: Any) -> BaseTool:
     return GoogleSerperResults(api_wrapper=wrapper, **tool_kwargs)
 
 
-class GoogleSearchResults2(GoogleSearchResults):
+class AsyncGoogleSearchResults(GoogleSearchResults):
     async def _arun(
         self,
         query: str,
         run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
     ) -> str:
         """Use the tool asynchronously."""
-        result = await sync_to_async(self.run)(query, run_manager=run_manager)
+        result = await sync_to_async(self._run)(query, run_manager=run_manager)
         return result
 
 
 def get_google_search(**kwargs: Any) -> BaseTool:
     tool_kwargs = extract_tool_kwargs(kwargs)
     wrapper = GoogleSearchAPIWrapper(**kwargs)
-    return GoogleSearchResults2(
+    return AsyncGoogleSearchResults(
         api_wrapper=wrapper, name="google_search", **tool_kwargs
     )
 
@@ -48,7 +48,7 @@ def get_google_search(**kwargs: Any) -> BaseTool:
 def get_google_search_results_json(**kwargs: Any) -> BaseTool:
     tool_kwargs = extract_tool_kwargs(kwargs)
     wrapper = GoogleSearchAPIWrapper(**kwargs)
-    return GoogleSearchResults2(
+    return AsyncGoogleSearchResults(
         api_wrapper=wrapper, name="google_search", **tool_kwargs
     )
 

--- a/ix/tools/google.py
+++ b/ix/tools/google.py
@@ -4,10 +4,9 @@ from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
 from ix.chains.loaders.tools import extract_tool_kwargs
 from typing import Any, Optional
 
-from langchain import GoogleSerperAPIWrapper, GoogleSearchAPIWrapper, SerpAPIWrapper
+from langchain import GoogleSerperAPIWrapper, GoogleSearchAPIWrapper
 from langchain.tools import (
     BaseTool,
-    Tool,
     GoogleSearchResults,
     GoogleSerperRun,
     GoogleSerperResults,
@@ -50,16 +49,4 @@ def get_google_search_results_json(**kwargs: Any) -> BaseTool:
     wrapper = GoogleSearchAPIWrapper(**kwargs)
     return AsyncGoogleSearchResults(
         api_wrapper=wrapper, name="google_search", **tool_kwargs
-    )
-
-
-def get_serpapi(**kwargs: Any) -> BaseTool:
-    tool_kwargs = extract_tool_kwargs(kwargs)
-    return Tool(
-        name="Search",
-        description="A search engine. Useful for when you need to answer questions "
-        "about current events. Input should be a search query.",
-        func=SerpAPIWrapper(**kwargs).run,
-        coroutine=SerpAPIWrapper(**kwargs).arun,
-        **tool_kwargs
     )

--- a/ix/tools/graphql.py
+++ b/ix/tools/graphql.py
@@ -1,10 +1,25 @@
+from typing import Optional
+
+from asgiref.sync import sync_to_async
+from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
 from langchain.tools import BaseTool, BaseGraphQLTool
 from langchain.utilities import GraphQLAPIWrapper
 
 from ix.chains.loaders.tools import extract_tool_kwargs
 
 
+class AsyncGraphQLTool(BaseGraphQLTool):
+    async def _arun(
+        self,
+        query: str,
+        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
+    ) -> str:
+        """Use the tool asynchronously."""
+        result = await sync_to_async(self._run)(query, run_manager=run_manager)
+        return result
+
+
 def get_graphql_tool(**kwargs) -> BaseTool:
     tool_kwargs = extract_tool_kwargs(kwargs)
     wrapper = GraphQLAPIWrapper(graphql_endpoint=kwargs["graphql_endpoint"])
-    return BaseGraphQLTool(graphql_wrapper=wrapper, **tool_kwargs)
+    return AsyncGraphQLTool(graphql_wrapper=wrapper, **tool_kwargs)

--- a/ix/tools/lambda_api.py
+++ b/ix/tools/lambda_api.py
@@ -1,3 +1,4 @@
+from asgiref.sync import sync_to_async
 from langchain.tools import BaseTool, Tool
 from langchain.utilities import LambdaWrapper
 
@@ -12,5 +13,6 @@ def get_lambda_api(**kwargs: Any) -> BaseTool:
         name=kwargs["awslambda_tool_name"],
         description=kwargs["awslambda_tool_description"],
         func=wrapper.run,
+        coroutine=sync_to_async(wrapper.run),
         **tool_kwargs
     )

--- a/ix/tools/pubmed.py
+++ b/ix/tools/pubmed.py
@@ -1,11 +1,24 @@
+from asgiref.sync import sync_to_async
+from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
 from langchain.tools import PubmedQueryRun, BaseTool
 from langchain.utilities import PubMedAPIWrapper
 
 from ix.chains.loaders.tools import extract_tool_kwargs
-from typing import Any
+from typing import Any, Optional
+
+
+class AsyncPubmedQueryRun(PubmedQueryRun):
+    async def _arun(
+        self,
+        query: str,
+        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
+    ) -> str:
+        """Use the tool asynchronously."""
+        result = await sync_to_async(self._run)(query, run_manager=run_manager)
+        return result
 
 
 def get_pubmed(**kwargs: Any) -> BaseTool:
     tool_kwargs = extract_tool_kwargs(kwargs)
     wrapper = PubMedAPIWrapper(**kwargs)
-    return PubmedQueryRun(api_wrapper=wrapper, **tool_kwargs)
+    return AsyncPubmedQueryRun(api_wrapper=wrapper, **tool_kwargs)

--- a/ix/tools/wikipedia.py
+++ b/ix/tools/wikipedia.py
@@ -1,11 +1,24 @@
+from asgiref.sync import SyncToAsync, sync_to_async
+from typing import Any, Optional
 from langchain import WikipediaAPIWrapper
+from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
 from langchain.tools import WikipediaQueryRun, BaseTool
 
 from ix.chains.loaders.tools import extract_tool_kwargs
-from typing import Any
+
+
+class AsyncWikipediaQueryRun(SyncToAsync, WikipediaQueryRun):
+    async def _arun(
+        self,
+        query: str,
+        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
+    ) -> str:
+        """Use the tool asynchronously."""
+        result = await sync_to_async(self._run)(query, run_manager=run_manager)
+        return result
 
 
 def get_wikipedia(**kwargs: Any) -> BaseTool:
     tool_kwargs = extract_tool_kwargs(kwargs)
     wrapper = WikipediaAPIWrapper(**kwargs)
-    return WikipediaQueryRun(api_wrapper=wrapper, **tool_kwargs)
+    return AsyncWikipediaQueryRun(api_wrapper=wrapper, **tool_kwargs)

--- a/ix/tools/wolfram_alpha.py
+++ b/ix/tools/wolfram_alpha.py
@@ -1,11 +1,24 @@
+from asgiref.sync import sync_to_async
 from langchain import WolframAlphaAPIWrapper
+from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
 from langchain.tools import BaseTool, WolframAlphaQueryRun
 
 from ix.chains.loaders.tools import extract_tool_kwargs
-from typing import Any
+from typing import Any, Optional
+
+
+class AsyncWolframAlphaQueryRun(WolframAlphaQueryRun):
+    async def _arun(
+        self,
+        query: str,
+        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
+    ) -> str:
+        """Use the tool asynchronously."""
+        result = await sync_to_async(self._run)(query, run_manager=run_manager)
+        return result
 
 
 def get_wolfram_alpha(**kwargs: Any) -> BaseTool:
     tool_kwargs = extract_tool_kwargs(kwargs)
     wrapper = WolframAlphaAPIWrapper(**kwargs)
-    return WolframAlphaQueryRun(api_wrapper=wrapper, **tool_kwargs)
+    return AsyncWolframAlphaQueryRun(api_wrapper=wrapper, **tool_kwargs)


### PR DESCRIPTION
### Description
Testing tools revealed most of them did not support asyncio.  Added a `sync_to_async` wrapper around them so that it's at least functional for now.

### Changes
- added async support for google, wolfram, wikipedia, graphql, arxiv, bing, lambda, wolfram, duckduckgo
- removed duplicate serper tool
- serper tool is no longer named "Google Search"

### How Tested
Manual testing with tools.

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
