### PR TITLE
Add SyncToAsync chain mixin to support sync chains.

### DIFF
--- a/ix/chains/asyncio.py
+++ b/ix/chains/asyncio.py
@@ -1,0 +1,22 @@
+from typing import Optional
+from asgiref.sync import sync_to_async
+from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
+
+
+class SyncToAsync:
+    """
+    Mixin to convert a chain or tool to run asynchronously by using
+    sync_to_async to convert the run method to a coroutine.
+
+    This doesn't provide full async support, but it does allow for
+    the chain/tool to work.
+    """
+
+    async def _arun(
+        self,
+        query: str,
+        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
+    ) -> str:
+        """Use the tool asynchronously."""
+        result = await sync_to_async(self._run)(query, run_manager=run_manager)
+        return result

--- a/ix/tools/arxiv.py
+++ b/ix/tools/arxiv.py
@@ -1,21 +1,13 @@
-from asgiref.sync import sync_to_async
 from langchain import ArxivAPIWrapper
-from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
 from langchain.tools import BaseTool, ArxivQueryRun
 
+from ix.chains.asyncio import SyncToAsync
 from ix.chains.loaders.tools import extract_tool_kwargs
-from typing import Any, Optional
+from typing import Any
 
 
-class AsyncArxivQueryRun(ArxivQueryRun):
-    async def _arun(
-        self,
-        query: str,
-        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
-    ) -> str:
-        """Use the tool asynchronously."""
-        result = await sync_to_async(self._run)(query, run_manager=run_manager)
-        return result
+class AsyncArxivQueryRun(SyncToAsync, ArxivQueryRun):
+    pass
 
 
 def get_arxiv(**kwargs: Any) -> BaseTool:

--- a/ix/tools/bing.py
+++ b/ix/tools/bing.py
@@ -1,22 +1,12 @@
-from typing import Optional
-
-from asgiref.sync import sync_to_async
-from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
 from langchain.tools import BaseTool, BingSearchRun
 from langchain.utilities import BingSearchAPIWrapper
 
+from ix.chains.asyncio import SyncToAsync
 from ix.chains.loaders.tools import extract_tool_kwargs
 
 
-class AsyncBingSearchRun(BingSearchRun):
-    async def _arun(
-        self,
-        query: str,
-        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
-    ) -> str:
-        """Use the tool asynchronously."""
-        result = await sync_to_async(self._run)(query, run_manager=run_manager)
-        return result
+class AsyncBingSearchRun(SyncToAsync, BingSearchRun):
+    pass
 
 
 def get_bing_search(**kwargs) -> BaseTool:

--- a/ix/tools/duckduckgo.py
+++ b/ix/tools/duckduckgo.py
@@ -1,22 +1,12 @@
-from typing import Optional
-
-from asgiref.sync import sync_to_async
-from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
 from langchain.tools import DuckDuckGoSearchRun, BaseTool
 from langchain.utilities import DuckDuckGoSearchAPIWrapper
 
+from ix.chains.asyncio import SyncToAsync
 from ix.chains.loaders.tools import extract_tool_kwargs
 
 
-class AsyncDuckDuckGoSearchRun(DuckDuckGoSearchRun):
-    async def _arun(
-        self,
-        query: str,
-        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
-    ) -> str:
-        """Use the tool asynchronously."""
-        result = await sync_to_async(self._run)(query, run_manager=run_manager)
-        return result
+class AsyncDuckDuckGoSearchRun(SyncToAsync, DuckDuckGoSearchRun):
+    pass
 
 
 def get_ddg_search(**kwargs) -> BaseTool:

--- a/ix/tools/google.py
+++ b/ix/tools/google.py
@@ -1,8 +1,6 @@
-from asgiref.sync import sync_to_async
-from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
-
+from ix.chains.asyncio import SyncToAsync
 from ix.chains.loaders.tools import extract_tool_kwargs
-from typing import Any, Optional
+from typing import Any
 
 from langchain import GoogleSerperAPIWrapper, GoogleSearchAPIWrapper
 from langchain.tools import (
@@ -25,15 +23,8 @@ def get_google_serper_results_json(**kwargs: Any) -> BaseTool:
     return GoogleSerperResults(api_wrapper=wrapper, **tool_kwargs)
 
 
-class AsyncGoogleSearchResults(GoogleSearchResults):
-    async def _arun(
-        self,
-        query: str,
-        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
-    ) -> str:
-        """Use the tool asynchronously."""
-        result = await sync_to_async(self._run)(query, run_manager=run_manager)
-        return result
+class AsyncGoogleSearchResults(SyncToAsync, GoogleSearchResults):
+    pass
 
 
 def get_google_search(**kwargs: Any) -> BaseTool:

--- a/ix/tools/graphql.py
+++ b/ix/tools/graphql.py
@@ -1,22 +1,12 @@
-from typing import Optional
-
-from asgiref.sync import sync_to_async
-from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
 from langchain.tools import BaseTool, BaseGraphQLTool
 from langchain.utilities import GraphQLAPIWrapper
 
+from ix.chains.asyncio import SyncToAsync
 from ix.chains.loaders.tools import extract_tool_kwargs
 
 
-class AsyncGraphQLTool(BaseGraphQLTool):
-    async def _arun(
-        self,
-        query: str,
-        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
-    ) -> str:
-        """Use the tool asynchronously."""
-        result = await sync_to_async(self._run)(query, run_manager=run_manager)
-        return result
+class AsyncGraphQLTool(SyncToAsync, BaseGraphQLTool):
+    pass
 
 
 def get_graphql_tool(**kwargs) -> BaseTool:

--- a/ix/tools/pubmed.py
+++ b/ix/tools/pubmed.py
@@ -1,21 +1,13 @@
-from asgiref.sync import sync_to_async
-from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
 from langchain.tools import PubmedQueryRun, BaseTool
 from langchain.utilities import PubMedAPIWrapper
 
+from ix.chains.asyncio import SyncToAsync
 from ix.chains.loaders.tools import extract_tool_kwargs
-from typing import Any, Optional
+from typing import Any
 
 
-class AsyncPubmedQueryRun(PubmedQueryRun):
-    async def _arun(
-        self,
-        query: str,
-        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
-    ) -> str:
-        """Use the tool asynchronously."""
-        result = await sync_to_async(self._run)(query, run_manager=run_manager)
-        return result
+class AsyncPubmedQueryRun(SyncToAsync, PubmedQueryRun):
+    pass
 
 
 def get_pubmed(**kwargs: Any) -> BaseTool:

--- a/ix/tools/wikipedia.py
+++ b/ix/tools/wikipedia.py
@@ -1,21 +1,13 @@
-from asgiref.sync import SyncToAsync, sync_to_async
-from typing import Any, Optional
+from typing import Any
 from langchain import WikipediaAPIWrapper
-from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
 from langchain.tools import WikipediaQueryRun, BaseTool
 
+from ix.chains.asyncio import SyncToAsync
 from ix.chains.loaders.tools import extract_tool_kwargs
 
 
 class AsyncWikipediaQueryRun(SyncToAsync, WikipediaQueryRun):
-    async def _arun(
-        self,
-        query: str,
-        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
-    ) -> str:
-        """Use the tool asynchronously."""
-        result = await sync_to_async(self._run)(query, run_manager=run_manager)
-        return result
+    pass
 
 
 def get_wikipedia(**kwargs: Any) -> BaseTool:

--- a/ix/tools/wolfram_alpha.py
+++ b/ix/tools/wolfram_alpha.py
@@ -1,21 +1,13 @@
-from asgiref.sync import sync_to_async
 from langchain import WolframAlphaAPIWrapper
-from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
 from langchain.tools import BaseTool, WolframAlphaQueryRun
 
+from ix.chains.asyncio import SyncToAsync
 from ix.chains.loaders.tools import extract_tool_kwargs
-from typing import Any, Optional
+from typing import Any
 
 
-class AsyncWolframAlphaQueryRun(WolframAlphaQueryRun):
-    async def _arun(
-        self,
-        query: str,
-        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
-    ) -> str:
-        """Use the tool asynchronously."""
-        result = await sync_to_async(self._run)(query, run_manager=run_manager)
-        return result
+class AsyncWolframAlphaQueryRun(SyncToAsync, WolframAlphaQueryRun):
+    pass
 
 
 def get_wolfram_alpha(**kwargs: Any) -> BaseTool:


### PR DESCRIPTION
### Description
Followup to Async Tools (#100 )

This PR adds `SyncToAsync` mixin for chains to quickly add support for async.  

This isn't full async support but it makes it work.  For now this is ok because the 
agent workers run in a SOLO pool, which limits to one thread per worker.  Eventually
full async support will be needed.

### Changes
- added `SyncToAsync` mixin class 
- converted all sync tools to use `SyncToAsync`

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
