### PR TITLE
Sequence input_variables 

### DIFF
--- a/ix/chains/fixture_src/routing.py
+++ b/ix/chains/fixture_src/routing.py
@@ -22,7 +22,7 @@ SEQUENCE = {
             "default": [],
             "style": {
                 "width": "100%",
-            }
+            },
         },
     ],
 }

--- a/ix/chains/fixture_src/routing.py
+++ b/ix/chains/fixture_src/routing.py
@@ -14,7 +14,14 @@ SEQUENCE = {
     "type": "chain",
     "child_field": "chains",
     "connectors": [MEMORY_TARGET, SEQUENCE_CHAINS_TARGET],
-    "fields": [VERBOSE],
+    "fields": [
+        VERBOSE,
+        {
+            "name": "input_variables",
+            "type": "list",
+            "default": [],
+        },
+    ],
 }
 
 

--- a/ix/chains/fixture_src/routing.py
+++ b/ix/chains/fixture_src/routing.py
@@ -20,6 +20,9 @@ SEQUENCE = {
             "name": "input_variables",
             "type": "list",
             "default": [],
+            "style": {
+                "width": "100%",
+            }
         },
     ],
 }


### PR DESCRIPTION
### Description
Sequence now has `input_variables` field.

### Changes
- `SequentialChain` now has `input_variables` field
- `NodeTypeField` that are `type=list` are converted from string into lists by the graphql mutation.

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
- will follow up on list parsing for the FastAPI endpoint.
