### PR TITLE
Implicit Sequences now work from root node.

### DIFF
--- a/ix/chains/loaders/core.py
+++ b/ix/chains/loaders/core.py
@@ -132,7 +132,7 @@ def load_node(node: ChainNode, callback_manager: IxCallbackManager, root=True) -
         # Linked chains but no parent indicates the possible first node in an
         # implicit SequentialChain. Traverse the sequence and create a
         # SequentialChain if there is more than one node in the sequence.
-        sequential_nodes = load_sequence(node, instance)
+        sequential_nodes = load_sequence(node, instance, callback_manager)
         if len(sequential_nodes) > 1:
             input_variables = get_sequence_inputs(sequential_nodes)
             return SequentialChain(

--- a/ix/chains/loaders/core.py
+++ b/ix/chains/loaders/core.py
@@ -128,7 +128,7 @@ def load_node(node: ChainNode, callback_manager: IxCallbackManager, root=True) -
         raise
     logger.debug(f"Loaded node class={node.class_path} in {time.time() - start_time}s")
 
-    if node_type == "chain" and not parent:
+    if node_type.type in {"chain"} and root:
         # Linked chains but no parent indicates the possible first node in an
         # implicit SequentialChain. Traverse the sequence and create a
         # SequentialChain if there is more than one node in the sequence.

--- a/ix/chains/loaders/core.py
+++ b/ix/chains/loaders/core.py
@@ -121,7 +121,11 @@ def load_node(node: ChainNode, callback_manager: IxCallbackManager, root=True) -
     if node_type.type in {"chain", "agent"}:
         config["callback_manager"] = callback_manager
 
-    instance = node_class(**config)
+    try:
+        instance = node_class(**config)
+    except Exception:
+        logger.error(f"Exception loading node class={node.class_path}")
+        raise
     logger.debug(f"Loaded node class={node.class_path} in {time.time() - start_time}s")
 
     if node_type == "chain" and not parent:

--- a/ix/chains/loaders/core.py
+++ b/ix/chains/loaders/core.py
@@ -52,7 +52,7 @@ def get_sequence_inputs(sequence: List[LangchainChain]) -> List[str]:
     return list(input_variables)
 
 
-def load_node(node: ChainNode, callback_manager: IxCallbackManager, parent=None) -> Any:
+def load_node(node: ChainNode, callback_manager: IxCallbackManager, root=True) -> Any:
     """
     Generic loader for loading the Langchain component a ChainNode represents.
 
@@ -88,8 +88,8 @@ def load_node(node: ChainNode, callback_manager: IxCallbackManager, parent=None)
 
         if node_group[0].node_type.type == "chain":
             # load a sequence of linked nodes into a children property
-            # this supports loading as an list of chains or auto-SequentialChain
-            first_instance = load_node(node_group[0], callback_manager, parent=node)
+            # this supports loading as a list of chains or auto-SequentialChain
+            first_instance = load_node(node_group[0], callback_manager, root=False)
             sequence = load_sequence(node_group[0], first_instance, callback_manager)
             connector = node_type.connectors_as_dict[key]
             if connector.get("auto_sequence", True):
@@ -108,12 +108,13 @@ def load_node(node: ChainNode, callback_manager: IxCallbackManager, parent=None)
             # default recursive loading
             if node_type.connectors_as_dict[key].get("multiple", False):
                 config[key] = [
-                    prop_node.load(callback_manager) for prop_node in node_group
+                    prop_node.load(callback_manager, root=False)
+                    for prop_node in node_group
                 ]
             else:
                 if len(node_group) > 1:
                     raise ValueError(f"Multiple values for {key} not allowed")
-                config[key] = load_node(node_group[0], callback_manager)
+                config[key] = load_node(node_group[0], callback_manager, root=False)
 
     node_class = import_node_class(node.class_path)
 
@@ -159,7 +160,7 @@ def load_sequence(
 
     # traverse the sequence
     while outgoing_link:
-        next_instance = outgoing_link.target.load(callback_manager)
+        next_instance = outgoing_link.target.load(callback_manager, root=False)
         sequential_nodes.append(next_instance)
         try:
             outgoing_link = outgoing_link.target.outgoing_edges.select_related(

--- a/ix/chains/loaders/core.py
+++ b/ix/chains/loaders/core.py
@@ -42,8 +42,13 @@ def get_property_loader(name: str) -> Callable:
 def get_sequence_inputs(sequence: List[LangchainChain]) -> List[str]:
     """Aggregate all inputs for a list of chains"""
     input_variables = set()
+    output_variables = set()
     for sequence_chain in sequence:
-        input_variables.update(sequence_chain.input_keys)
+        # Intermediate outputs are excluded from input_variables.
+        # Filter out any inputs that are already in the output variables
+        filtered_inputs = set(sequence_chain.input_keys) - output_variables
+        input_variables.update(filtered_inputs)
+        output_variables.update(sequence_chain.output_keys)
     return list(input_variables)
 
 

--- a/ix/chains/models.py
+++ b/ix/chains/models.py
@@ -224,14 +224,14 @@ class ChainNode(models.Model):
     def __str__(self):
         return f"{str(self.id)[:8]} ({self.class_path})"
 
-    def load(self, callback_manager, parent=None):
+    def load(self, callback_manager, root=True):
         """
         Load this node, traversing the graph and loading all child nodes,
         properties, and downstream nodes.
         """
         from ix.chains.loaders.core import load_node
 
-        return load_node(self, callback_manager, parent=parent)
+        return load_node(self, callback_manager, root=root)
 
 
 class ChainEdge(models.Model):

--- a/ix/chains/tests/test_coder.py
+++ b/ix/chains/tests/test_coder.py
@@ -3,9 +3,8 @@ from django.core.management import call_command
 from langchain.chains import SequentialChain
 
 from ix.chains.artifacts import SaveArtifact
-from ix.chains.json import ParseJSON
 from ix.chains.llm_chain import LLMChain
-from ix.chains.management.commands.create_coder_v1 import CODER_V1_CHAIN
+from ix.chains.management.commands.create_coder_v2 import CODER_V2_CHAIN
 from ix.chains.models import Chain
 from ix.chains.routing import MapSubchain
 
@@ -14,20 +13,18 @@ from ix.chains.routing import MapSubchain
 @pytest.mark.usefixtures("node_types")
 class TestCreateCoder:
     def test_create_coder(self, mock_callback_manager, mock_openai_key):
-        call_command("create_coder_v1")
+        call_command("create_coder_v2")
 
-        model_instance = Chain.objects.get(id=CODER_V1_CHAIN)
+        model_instance = Chain.objects.get(id=CODER_V2_CHAIN)
         chain = model_instance.load_chain(mock_callback_manager)
 
         # assert structure of main sequence
         assert isinstance(chain, SequentialChain)
         assert isinstance(chain.chains[0], LLMChain)
-        assert isinstance(chain.chains[1], ParseJSON)
-        assert isinstance(chain.chains[2], SaveArtifact)
-        assert isinstance(chain.chains[3], MapSubchain)
+        assert isinstance(chain.chains[1], SaveArtifact)
+        assert isinstance(chain.chains[2], MapSubchain)
 
         # assert structure of mapsubchain
-        mapsubchain = chain.chains[3]
+        mapsubchain = chain.chains[2]
         assert isinstance(mapsubchain.chains[0], LLMChain)
-        assert isinstance(mapsubchain.chains[1], ParseJSON)
-        assert isinstance(mapsubchain.chains[2], SaveArtifact)
+        assert isinstance(mapsubchain.chains[1], SaveArtifact)


### PR DESCRIPTION
### Description
Linking `Chain` classes together should create an implicit `SequentialChain`. The chains are automatically wrapped in the `SequentialChain`. This was working for `chains` properties but now for a chain from the root node.

#### Before
The workaround was explicitly declaring a `SequentialChain`
![image](https://github.com/kreneskyp/ix/assets/68635/6d8fbaad-ca41-4c05-a866-e626a5c09d99)


#### After
Now, the `SequentialChain` is created automatically.

![image](https://github.com/kreneskyp/ix/assets/68635/461d53a5-922a-4b16-9dad-bb493bde5545)


### Changes
- `load_node` and related methods now use `root: bool` instead of `parent: ChainNode` to indicate the root node.
- Check for start of root implicit sequence now checks the correct property
- `get_sequence_input` now excludes intermediate outputs.
- better error logging for nodes that fail to load
- `callback_manager` now passed to all recursively loaded nodes.

### How Tested
- updated coder_v2 test 
- existing unittests covered most of code
- manual testing of various agents

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
