### PR TITLE
Implicit SequentialChains now work when the root is an Agent

### DIFF
--- a/ix/chains/loaders/core.py
+++ b/ix/chains/loaders/core.py
@@ -86,7 +86,7 @@ def load_node(node: ChainNode, callback_manager: IxCallbackManager, root=True) -
         node_group = [edge.source for edge in edges]
         logger.debug(f"Loading property key={key} node_group={node_group}")
 
-        if node_group[0].node_type.type == "chain":
+        if node_group[0].node_type.type in {"chain", "agent"}:
             # load a sequence of linked nodes into a children property
             # this supports loading as a list of chains or auto-SequentialChain
             first_instance = load_node(node_group[0], callback_manager, root=False)


### PR DESCRIPTION
### Description
Implicit `SequentialChain` now work when the root node is an `Agent`.

![image](https://github.com/kreneskyp/ix/assets/68635/89428e31-c121-4e3e-b90e-345b72d75008)

### Changes
Checks for starting implicit chains now check for agents.

### How Tested
- manual testing

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
