### PR TITLE
Agent auto-reply can now be disabled via config

### DIFF
--- a/ix/chains/agents.py
+++ b/ix/chains/agents.py
@@ -20,6 +20,7 @@ class AgentReply(Chain):
 
     agent_executor: AgentExecutor
     output_key: str = "output"
+    reply: bool = True
 
     @property
     def _chain_type(self) -> str:
@@ -47,16 +48,17 @@ class AgentReply(Chain):
     ) -> Dict[str, Any]:
         result = await self.agent_executor.acall(inputs, callbacks=run_manager)
 
-        await TaskLogMessage.objects.acreate(
-            task_id=self.callbacks.task.id,
-            role="assistant",
-            parent=self.callbacks.think_msg,
-            content={
-                "type": "ASSISTANT",
-                "text": result[self.output_key],
-                # "agent": str(self.callback_manager.task.agent.id),
-                "agent": self.callbacks.agent.alias,
-            },
-        )
+        if self.reply:
+            await TaskLogMessage.objects.acreate(
+                task_id=self.callbacks.task.id,
+                role="assistant",
+                parent=self.callbacks.think_msg,
+                content={
+                    "type": "ASSISTANT",
+                    "text": result[self.output_key],
+                    # "agent": str(self.callback_manager.task.agent.id),
+                    "agent": self.callbacks.agent.alias,
+                },
+            )
 
         return result

--- a/ix/chains/fixture_src/agents.py
+++ b/ix/chains/fixture_src/agents.py
@@ -22,6 +22,13 @@ EXECUTOR_BASE_FIELDS = [
         "type": "float",
         "nullable": True,
     },
+    # included until there is a better way to deal with connecting agent to chat output
+    {
+        "name": "reply",
+        "type": "boolean",
+        "label": "Reply to user",
+        "default": True,
+    },
 ]
 
 

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -85,6 +85,12 @@
         "name": "max_execution_time",
         "type": "float",
         "nullable": true
+      },
+      {
+        "name": "reply",
+        "type": "boolean",
+        "label": "Reply to user",
+        "default": true
       }
     ],
     "child_field": null
@@ -139,6 +145,12 @@
         "name": "max_execution_time",
         "type": "float",
         "nullable": true
+      },
+      {
+        "name": "reply",
+        "type": "boolean",
+        "label": "Reply to user",
+        "default": true
       }
     ],
     "child_field": null
@@ -218,6 +230,12 @@
         "name": "max_execution_time",
         "type": "float",
         "nullable": true
+      },
+      {
+        "name": "reply",
+        "type": "boolean",
+        "label": "Reply to user",
+        "default": true
       }
     ],
     "child_field": null
@@ -595,6 +613,12 @@
         "name": "max_execution_time",
         "type": "float",
         "nullable": true
+      },
+      {
+        "name": "reply",
+        "type": "boolean",
+        "label": "Reply to user",
+        "default": true
       }
     ],
     "child_field": null
@@ -649,6 +673,12 @@
         "name": "max_execution_time",
         "type": "float",
         "nullable": true
+      },
+      {
+        "name": "reply",
+        "type": "boolean",
+        "label": "Reply to user",
+        "default": true
       }
     ],
     "child_field": null
@@ -825,6 +855,12 @@
         "name": "max_execution_time",
         "type": "float",
         "nullable": true
+      },
+      {
+        "name": "reply",
+        "type": "boolean",
+        "label": "Reply to user",
+        "default": true
       }
     ],
     "child_field": null
@@ -879,6 +915,12 @@
         "name": "max_execution_time",
         "type": "float",
         "nullable": true
+      },
+      {
+        "name": "reply",
+        "type": "boolean",
+        "label": "Reply to user",
+        "default": true
       }
     ],
     "child_field": null
@@ -1570,6 +1612,12 @@
         "name": "max_execution_time",
         "type": "float",
         "nullable": true
+      },
+      {
+        "name": "reply",
+        "type": "boolean",
+        "label": "Reply to user",
+        "default": true
       }
     ],
     "child_field": null
@@ -1777,6 +1825,12 @@
         "name": "max_execution_time",
         "type": "float",
         "nullable": true
+      },
+      {
+        "name": "reply",
+        "type": "boolean",
+        "label": "Reply to user",
+        "default": true
       }
     ],
     "child_field": null

--- a/ix/chains/loaders/agents.py
+++ b/ix/chains/loaders/agents.py
@@ -8,7 +8,7 @@ from langchain.chains.base import Chain
 from ix.chains.agents import AgentReply
 
 
-def initialize_agent(agent: AgentType, **kwargs) -> Chain:
+def initialize_agent(agent: AgentType, reply: int = True, **kwargs) -> Chain:
     """
     Extended version of the initialize_agent function from ix.chains.agents.
 
@@ -29,6 +29,7 @@ def initialize_agent(agent: AgentType, **kwargs) -> Chain:
     return AgentReply(
         agent_executor=agent_executor,
         callback_manager=kwargs.get("callback_manager", None),
+        reply=reply,
     )
 
 


### PR DESCRIPTION
### Description
This PR makes Agent auto-reply configurable.  Agents currently auto-reply with their response. Auto-reply simplifies using agents until a better output config mechanism can be created.

![image](https://github.com/kreneskyp/ix/assets/68635/4556fd5b-d589-423b-a13b-578fbca241dd)

Disabling auto-reply is useful when the Agent is an intermediate step and not the final output that will be sent to the chat.

**Example**: formatting output as markdown before sending back.
![image](https://github.com/kreneskyp/ix/assets/68635/a0d4f79f-0426-4552-aef5-f322e6ab9079)



### Changes
- add `reply` config field to agent loader and all agents.

### How Tested
- manual testing

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
