### PR TITLE
Add Agent: BotSmith v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ dev_fixtures: compose
 	${DOCKER_COMPOSE_RUN} ./manage.py loaddata node_types
 
  	# initial agents + chains
-	${DOCKER_COMPOSE_RUN} ./manage.py loaddata ix_v2 code_v2 pirate_v1 wikipedia_v1 klarna_v1
+	${DOCKER_COMPOSE_RUN} ./manage.py loaddata ix_v2 code_v2 pirate_v1 wikipedia_v1 klarna_v1 bot_smith_v1
 
 
 # Generate fixture for NodeTypes defined in python fixtures.

--- a/ix/chains/fixtures/bot_smith_v1.json
+++ b/ix/chains/fixtures/bot_smith_v1.json
@@ -1,0 +1,196 @@
+[
+{
+    "model": "chains.chain",
+    "pk": "6cfb45bb-f928-4858-a7c6-113951608671",
+    "fields": {
+        "name": "Bot Smith",
+        "description": "IX API chain. CRUD access for Agents, Chains, and NodeTypes from IX API.",
+        "created_at": "2023-07-07T18:13:04.064Z"
+    }
+},
+{
+    "model": "chains.chainnode",
+    "pk": "31186e84-6b6b-4344-bd91-ee1754a25bf8",
+    "fields": {
+        "class_path": "langchain.prompts.chat.ChatPromptTemplate",
+        "node_type": "b62000d7-9390-491b-af13-9711c4ec8b44",
+        "config": {
+            "messages": [
+                {
+                    "role": "system",
+                    "template": "You are a markdown formatter.\n\nFormat the response from the API as markdown. Consider the user's request when formatting.",
+                    "input_variables": []
+                },
+                {
+                    "role": "user",
+                    "template": "USER_INPUT:\n{user_input}\n\nRESPONSE:\n{response}",
+                    "input_variables": [
+                        "user_input",
+                        "response"
+                    ],
+                    "partial_variables": {}
+                }
+            ]
+        },
+        "name": null,
+        "description": null,
+        "root": false,
+        "position": {
+            "x": 255.61612908821917,
+            "y": 613.0106203239052
+        },
+        "chain": "6cfb45bb-f928-4858-a7c6-113951608671"
+    }
+},
+{
+    "model": "chains.chainnode",
+    "pk": "70a5f508-68ba-4aee-86dd-dab8237e063f",
+    "fields": {
+        "class_path": "langchain.chat_models.openai.ChatOpenAI",
+        "node_type": "bbb7544c-6891-4204-985a-d13d65e02523",
+        "config": {
+            "verbose": false,
+            "max_tokens": "4000",
+            "model_name": "gpt-4-0613",
+            "max_retries": 6,
+            "temperature": 0,
+            "request_timeout": 60
+        },
+        "name": null,
+        "description": null,
+        "root": false,
+        "position": {
+            "x": 28.953561265607107,
+            "y": 444.2973707412899
+        },
+        "chain": "6cfb45bb-f928-4858-a7c6-113951608671"
+    }
+},
+{
+    "model": "chains.chainnode",
+    "pk": "7c748cc7-6a2d-4619-ab5f-73c7b350a5f5",
+    "fields": {
+        "class_path": "ix.chains.openapi.get_openapi_chain_async",
+        "node_type": "2201a903-75cb-4073-a50f-67fc53e628e8",
+        "config": {
+            "spec": "http://172.17.0.1:8000/api/openapi.json",
+            "verbose": true
+        },
+        "name": null,
+        "description": null,
+        "root": true,
+        "position": {
+            "x": 357.0164693828574,
+            "y": 278.2082873447961
+        },
+        "chain": "6cfb45bb-f928-4858-a7c6-113951608671"
+    }
+},
+{
+    "model": "chains.chainnode",
+    "pk": "7f5711ce-9d48-42c9-b2d7-fdee8a6f06ca",
+    "fields": {
+        "class_path": "langchain.chat_models.openai.ChatOpenAI",
+        "node_type": "bbb7544c-6891-4204-985a-d13d65e02523",
+        "config": {
+            "verbose": false,
+            "max_tokens": "2000",
+            "model_name": "gpt-3.5-turbo-16k-0613",
+            "max_retries": 6,
+            "temperature": 0,
+            "request_timeout": 60
+        },
+        "name": null,
+        "description": null,
+        "root": false,
+        "position": {
+            "x": 403.486764634407,
+            "y": 517.7822022421914
+        },
+        "chain": "6cfb45bb-f928-4858-a7c6-113951608671"
+    }
+},
+{
+    "model": "chains.chainnode",
+    "pk": "c96a49c5-64f8-47c5-a27e-561694a4ace2",
+    "fields": {
+        "class_path": "ix.chains.llm_chain.LLMReply",
+        "node_type": "01e26ecf-d02b-46ce-a57c-322e3815035b",
+        "config": {
+            "verbose": true
+        },
+        "name": null,
+        "description": null,
+        "root": false,
+        "position": {
+            "x": 740.7913527507008,
+            "y": 280.54997171930336
+        },
+        "chain": "6cfb45bb-f928-4858-a7c6-113951608671"
+    }
+},
+{
+    "model": "chains.chainedge",
+    "pk": "a8f6beea-a07f-451e-b1ea-f2a19b8fc14f",
+    "fields": {
+        "source": "70a5f508-68ba-4aee-86dd-dab8237e063f",
+        "target": "7c748cc7-6a2d-4619-ab5f-73c7b350a5f5",
+        "key": "llm",
+        "chain": "6cfb45bb-f928-4858-a7c6-113951608671",
+        "input_map": null,
+        "relation": "PROP"
+    }
+},
+{
+    "model": "chains.chainedge",
+    "pk": "de589ddc-9ed7-4e8b-b786-c7920eacc3ff",
+    "fields": {
+        "source": "7c748cc7-6a2d-4619-ab5f-73c7b350a5f5",
+        "target": "c96a49c5-64f8-47c5-a27e-561694a4ace2",
+        "key": "in",
+        "chain": "6cfb45bb-f928-4858-a7c6-113951608671",
+        "input_map": null,
+        "relation": "LINK"
+    }
+},
+{
+    "model": "chains.chainedge",
+    "pk": "f0c4b271-f2a0-4d07-b104-a18098030de4",
+    "fields": {
+        "source": "31186e84-6b6b-4344-bd91-ee1754a25bf8",
+        "target": "c96a49c5-64f8-47c5-a27e-561694a4ace2",
+        "key": "prompt",
+        "chain": "6cfb45bb-f928-4858-a7c6-113951608671",
+        "input_map": null,
+        "relation": "PROP"
+    }
+},
+{
+    "model": "chains.chainedge",
+    "pk": "f1ae332e-6ca2-4ef6-9da3-59b2d1131b35",
+    "fields": {
+        "source": "7f5711ce-9d48-42c9-b2d7-fdee8a6f06ca",
+        "target": "c96a49c5-64f8-47c5-a27e-561694a4ace2",
+        "key": "llm",
+        "chain": "6cfb45bb-f928-4858-a7c6-113951608671",
+        "input_map": null,
+        "relation": "PROP"
+    }
+},
+{
+    "model": "agents.agent",
+    "pk": "7e806fbb-4654-4224-8e59-d8a43aa3f496",
+    "fields": {
+        "name": "Bot Smith",
+        "alias": "smithy",
+        "purpose": "To use the IX API to retrieve information about and edit NodeTypes, Agents, Chains and their component graphs.",
+        "created_at": "2023-07-09T01:26:12.989Z",
+        "model": "gpt-4",
+        "config": {
+            "temperature": 0.05
+        },
+        "agent_class_path": "",
+        "chain": "6cfb45bb-f928-4858-a7c6-113951608671"
+    }
+}
+]


### PR DESCRIPTION
### Description
The PR introduces `@smithy` the Bot Smith.  This new agent has access to the IX chain editor API. It can query information about available components and chains. 

![image](https://github.com/kreneskyp/ix/assets/68635/77828c53-1809-4efe-bdfa-8f86b275401d)

![image](https://github.com/kreneskyp/ix/assets/68635/58e15749-1a5b-4a5e-96f6-29902fd50725)

Bot Smith can also create and edit both component definitions and chains, though this is somewhat limited right now because it only supports single action at a time.  Complex queries (find pirate chain and update it) require adding OpenAPI Function support to an Agent class.

Here is a simple edit using the ID of a `chain`. 

![image](https://github.com/kreneskyp/ix/assets/68635/4cd5ea47-dc06-459f-9d55-f4f6531157d6)


The Bot Smith uses the OpenAPI+OpenAI functions chain (#97) to interact with the FastAPI based API.  (#95 #108)

![image](https://github.com/kreneskyp/ix/assets/68635/c1c7ceed-af17-4222-9617-a1070fba4808)

### Changes
- Add fixture for `Bot Smith v1`
- Add Bot Smith fixture to `dev_fixtures` make target.

### How Tested
- manual testing

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
