### PR TITLE
add margin to top of chat message stream

### DIFF
--- a/frontend/chat/ChatMessages.js
+++ b/frontend/chat/ChatMessages.js
@@ -14,7 +14,7 @@ export const ChatMessages = () => {
   useEffect(scrollToBottom, [messages]);
 
   return (
-    <Box>
+    <Box pt={5}>
       {messages.map((messageGroup) => (
         <ChatMessage key={messageGroup.id} messageGroup={messageGroup} />
       ))}


### PR DESCRIPTION
### Description
Add a small amount of paddingto the top of the Chat stream component so that the first message isn't directly next to the top of the page.

![image](https://github.com/kreneskyp/ix/assets/68635/b5ea431a-4533-4d72-ad93-6b334957a10a)

### Changes
- add padding to top of ChatMessages component

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
