### PR TITLE
add build flag to allow for a dev copy of langchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ workspace
 .bak
 *.bak
 workdir
+
+#local copy of langchain if it exists
+langchain

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11
 
+ARG LANGCHAIN_DEV
+
 # System setup
 ENV HOME=/root
 ENV APP=/var/app
@@ -52,6 +54,9 @@ RUN pip install -r requirements.txt
 
 # Copy the rest of the application code to the working directory
 COPY . .
+
+# If LANGCHAIN_DEV is set then install the local dev version of LangChain
+RUN if [ -n "${LANGCHAIN_DEV}" ]; then pip install -e /var/app/langchain; fi
 
 # Set the environment variable for selecting between ASGI and Celery
 ENV APP_MODE=asgi

--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,17 @@ image-url:
 .sentinel:
 	mkdir -p .sentinel
 
+# Set LANGCHAIN_DEV to 1 to enable dev mode in docker build
+# local copy of langchain should be checked out to ix/langchain.
+# (docker desktop on windows doesn't support shares outside the project)
+LANGCHAIN_DEV ?=
+DOCKER_BUILD_ARGS = $(if ${LANGCHAIN_DEV},--build-arg LANGCHAIN_DEV=${LANGCHAIN_DEV},)
+
 # inner build target for sandbox image
 ${IMAGE_SENTINEL}: .sentinel $(HASH_FILES)
 ifneq (${NO_IMAGE_BUILD}, 1)
 	echo building ${IMAGE_URL}
-	docker build -t ${IMAGE_URL} -f $(DOCKERFILE) .
+	docker build -t ${IMAGE_URL} -f ${DOCKERFILE} ${DOCKER_BUILD_ARGS} .
 	docker tag ${IMAGE_URL} ${DOCKER_REPOSITORY}:latest
 	touch $@
 endif


### PR DESCRIPTION

### Description
Adding a make variable to enable the use of a local copy of `Langchain`. This enables testing
LangChain changes alongside Ix changes

### Changes
- added `LANGCHAIN_DEV` flag to makefile
- `LANGCHAIN_DEV=1` will install langchain from `ix/langchain` 

### How Tested
manual testing

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
