### PR TITLE
ChainTool component

### DIFF
--- a/frontend/chains/flow/TypeAutoFields.js
+++ b/frontend/chains/flow/TypeAutoFields.js
@@ -6,6 +6,7 @@ import {
   HStack,
   Input,
   Select,
+  Textarea,
   VStack,
 } from "@chakra-ui/react";
 import SliderInput from "components/SliderInput";
@@ -47,7 +48,7 @@ const AutoFieldInput = ({ field, value, onChange }) => {
         onChange={handleChange}
         px={1}
         py={2}
-        sx={field.style || {width: 100}}
+        sx={field.style || { width: 100 }}
       />
     </Flex>
   );
@@ -73,7 +74,32 @@ const AutoFieldSecret = ({ field, value, onChange }) => {
         px={1}
         py={2}
         type={"password"}
-        sx={field.style || {width: 100}}
+        sx={field.style || { width: 100 }}
+      />
+    </Flex>
+  );
+};
+
+const AutoFieldTextArea = ({ field, value, onChange }) => {
+  const handleChange = useCallback(
+    (event) => {
+      onChange(field.name, event.target.value);
+    },
+    [field, onChange]
+  );
+
+  return (
+    <Flex justifyContent="space-between" wrap="wrap" width="100%">
+      <FormLabel justify="start" whiteSpace="nowrap">
+        {getLabel(field)}
+      </FormLabel>
+      <Textarea
+        fontSize="sm"
+        value={value}
+        onChange={handleChange}
+        px={1}
+        py={2}
+        sx={field.style || { width: 200 }}
       />
     </Flex>
   );
@@ -133,6 +159,7 @@ const INPUTS = {
   slider: AutoFieldSlider,
   input: AutoFieldInput,
   secret: AutoFieldSecret,
+  textarea: AutoFieldTextArea,
 };
 
 // type specific default inputs

--- a/ix/chains/fixture_src/tools.py
+++ b/ix/chains/fixture_src/tools.py
@@ -1,3 +1,4 @@
+from ix.chains.fixture_src.targets import CHAIN_TARGET
 from langchain import (
     GoogleSearchAPIWrapper,
     GoogleSerperAPIWrapper,
@@ -14,6 +15,13 @@ from langchain.utilities import (
 
 from ix.chains.config import NodeTypeField
 from ix.chains.fixture_src.common import VERBOSE
+
+NAME = {
+    "name": "name",
+    "type": "str",
+    "default": "",
+    "style": {"width": "100%"},
+}
 
 DESCRIPTION = {
     "name": "description",
@@ -67,6 +75,15 @@ BING_SEARCH = {
             },
         },
     ),
+}
+
+CHAIN_AS_TOOL = {
+    "class_path": "ix.chains.tools.chain_as_tool",
+    "type": "tool",
+    "name": "Chain Tool",
+    "description": "Tool that runs a chain. Any chain may be converted into a tool.",
+    "connectors": [CHAIN_TARGET],
+    "fields": [NAME, DESCRIPTION] + TOOL_BASE_FIELDS,
 }
 
 DUCK_DUCK_GO_SEARCH = {
@@ -198,6 +215,7 @@ WOLFRAM = {
 TOOLS = [
     ARXIV_SEARCH,
     BING_SEARCH,
+    CHAIN_AS_TOOL,
     DUCK_DUCK_GO_SEARCH,
     GOOGLE_SEARCH,
     GOOGLE_SERPER,

--- a/ix/chains/fixture_src/tools.py
+++ b/ix/chains/fixture_src/tools.py
@@ -19,6 +19,8 @@ DESCRIPTION = {
     "name": "description",
     "type": "str",
     "default": "",
+    "input": "textarea",
+    "style": {"width": "100%"},
 }
 
 RETURN_DIRECT = {

--- a/ix/chains/fixture_src/tools.py
+++ b/ix/chains/fixture_src/tools.py
@@ -27,7 +27,7 @@ RETURN_DIRECT = {
     "default": False,
 }
 
-TOOL_BASE_FIELDS = [DESCRIPTION, RETURN_DIRECT, VERBOSE]
+TOOL_BASE_FIELDS = [RETURN_DIRECT, VERBOSE]
 
 ARXIV_SEARCH = {
     "class_path": "ix.tools.arxiv.get_arxiv",

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -1123,52 +1123,6 @@
 },
 {
   "model": "chains.nodetype",
-  "pk": "77494e15-9df5-4aaf-a666-49b7ecfb4880",
-  "fields": {
-    "name": "LLM Chain",
-    "description": "Chain that interprets a prompt and executes python code to do math.\n\n    Example:\n        .. code-block:: python\n\n            from langchain import LLMSymbolicMathChain, OpenAI\n            llm_symbolic_math = LLMSymbolicMathChain.from_llm(OpenAI())\n    ",
-    "class_path": "chains.llm_symbolic_math.base.LLMSymbolicMathChain",
-    "type": "chain",
-    "display_type": "node",
-    "connectors": [
-      {
-        "key": "llm",
-        "type": "target",
-        "source_type": "llm"
-      },
-      {
-        "key": "memory",
-        "type": "target",
-        "multiple": true,
-        "source_type": "memory"
-      }
-    ],
-    "fields": [
-      {
-        "name": "verbose",
-        "type": "boolean",
-        "default": false
-      },
-      {
-        "name": "input_key",
-        "type": "str",
-        "label": "Input_key",
-        "default": "question",
-        "required": false
-      },
-      {
-        "name": "output_key",
-        "type": "str",
-        "label": "Output_key",
-        "default": "answer",
-        "required": false
-      }
-    ],
-    "child_field": null
-  }
-},
-{
-  "model": "chains.nodetype",
   "pk": "7d49f24a-18e2-4db9-8be3-bbbe6aa25440",
   "fields": {
     "name": "Mock Memory",

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -328,11 +328,6 @@
     "connectors": null,
     "fields": [
       {
-        "name": "description",
-        "type": "str",
-        "default": ""
-      },
-      {
         "name": "return_direct",
         "type": "boolean",
         "default": false
@@ -696,11 +691,6 @@
     "connectors": null,
     "fields": [
       {
-        "name": "description",
-        "type": "str",
-        "default": ""
-      },
-      {
         "name": "return_direct",
         "type": "boolean",
         "default": false
@@ -938,11 +928,6 @@
     "connectors": null,
     "fields": [
       {
-        "name": "description",
-        "type": "str",
-        "default": ""
-      },
-      {
         "name": "return_direct",
         "type": "boolean",
         "default": false
@@ -995,11 +980,6 @@
     "display_type": "node",
     "connectors": null,
     "fields": [
-      {
-        "name": "description",
-        "type": "str",
-        "default": ""
-      },
       {
         "name": "return_direct",
         "type": "boolean",
@@ -1674,11 +1654,6 @@
     "connectors": null,
     "fields": [
       {
-        "name": "description",
-        "type": "str",
-        "default": ""
-      },
-      {
         "name": "return_direct",
         "type": "boolean",
         "default": false
@@ -2078,11 +2053,6 @@
     "connectors": null,
     "fields": [
       {
-        "name": "description",
-        "type": "str",
-        "default": ""
-      },
-      {
         "name": "return_direct",
         "type": "boolean",
         "default": false
@@ -2300,11 +2270,6 @@
     "connectors": null,
     "fields": [
       {
-        "name": "description",
-        "type": "str",
-        "default": ""
-      },
-      {
         "name": "return_direct",
         "type": "boolean",
         "default": false
@@ -2470,11 +2435,6 @@
     "connectors": null,
     "fields": [
       {
-        "name": "description",
-        "type": "str",
-        "default": ""
-      },
-      {
         "name": "return_direct",
         "type": "boolean",
         "default": false
@@ -2524,11 +2484,6 @@
     "display_type": "node",
     "connectors": null,
     "fields": [
-      {
-        "name": "description",
-        "type": "str",
-        "default": ""
-      },
       {
         "name": "return_direct",
         "type": "boolean",

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -961,6 +961,57 @@
 },
 {
   "model": "chains.nodetype",
+  "pk": "61654ca2-b73b-4dac-b761-adba7d560ef3",
+  "fields": {
+    "name": "Symbolic Math Chain",
+    "description": "Chain that interprets a prompt and executes python code to do math.\n\n    Example:\n        .. code-block:: python\n\n            from langchain import LLMSymbolicMathChain, OpenAI\n            llm_symbolic_math = LLMSymbolicMathChain.from_llm(OpenAI())\n    ",
+    "class_path": "langchain.chains.llm_symbolic_math.base.LLMSymbolicMathChain.from_llm",
+    "type": "chain",
+    "display_type": "node",
+    "connectors": [
+      {
+        "key": "llm",
+        "type": "target",
+        "source_type": "llm"
+      },
+      {
+        "key": "memory",
+        "type": "target",
+        "multiple": true,
+        "source_type": "memory"
+      },
+      {
+        "key": "prompt",
+        "type": "target",
+        "source_type": "prompt"
+      }
+    ],
+    "fields": [
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "input_key",
+        "type": "str",
+        "label": "Input_key",
+        "default": "user_input",
+        "required": false
+      },
+      {
+        "name": "output_key",
+        "type": "str",
+        "label": "Output_key",
+        "default": "answer",
+        "required": false
+      }
+    ],
+    "child_field": null
+  }
+},
+{
+  "model": "chains.nodetype",
   "pk": "62513b96-183d-43cb-a839-b44d024c2101",
   "fields": {
     "name": " search",

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -761,6 +761,54 @@
 },
 {
   "model": "chains.nodetype",
+  "pk": "4bb2e0e3-d030-494d-a8f3-44ea5147bee8",
+  "fields": {
+    "name": "Chain Tool",
+    "description": "Tool that runs a chain. Any chain may be converted into a tool.",
+    "class_path": "ix.chains.tools.chain_as_tool",
+    "type": "tool",
+    "display_type": "node",
+    "connectors": [
+      {
+        "key": "chain",
+        "type": "target",
+        "source_type": "chain"
+      }
+    ],
+    "fields": [
+      {
+        "name": "name",
+        "type": "str",
+        "style": {
+          "width": "100%"
+        },
+        "default": ""
+      },
+      {
+        "name": "description",
+        "type": "str",
+        "input": "textarea",
+        "style": {
+          "width": "100%"
+        },
+        "default": ""
+      },
+      {
+        "name": "return_direct",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "default": false
+      }
+    ],
+    "child_field": null
+  }
+},
+{
+  "model": "chains.nodetype",
   "pk": "4eb6a170-d0e4-428e-be8d-09ca1ca8383d",
   "fields": {
     "name": "GraphQL Tool",
@@ -770,11 +818,6 @@
     "display_type": "node",
     "connectors": null,
     "fields": [
-      {
-        "name": "description",
-        "type": "str",
-        "default": ""
-      },
       {
         "name": "return_direct",
         "type": "boolean",

--- a/ix/chains/tests/test_config_loader.py
+++ b/ix/chains/tests/test_config_loader.py
@@ -390,7 +390,6 @@ class TestExtractToolKwargs:
     @pytest.fixture
     def kwargs(self):
         return {
-            "description": "value1",
             "return_direct": False,
             "verbose": False,
             "tool_key1": "tool_value1",
@@ -406,7 +405,6 @@ class TestExtractToolKwargs:
         tool_kwargs = extract_tool_kwargs(node_kwargs)
         expected_node_kwargs = {"tool_key1": "tool_value1", "tool_key2": "tool_value2"}
         expected_tool_kwargs = {
-            "description": "value1",
             "return_direct": False,
             "verbose": False,
         }

--- a/ix/chains/tools.py
+++ b/ix/chains/tools.py
@@ -1,0 +1,13 @@
+from langchain.chains.base import Chain
+from langchain.tools import Tool, BaseTool
+
+
+def chain_as_tool(chain: Chain, name: str, description: str, **kwargs) -> BaseTool:
+    """Converts a chain into a tool."""
+    return Tool(
+        name=name,
+        description=description,
+        func=chain.run,
+        coroutine=chain.arun,
+        **kwargs
+    )


### PR DESCRIPTION
### Description
This PR introduces the `Chain Tool` component that enables any `Chain` to be converted into a `Tool`


##### Example: IX OpenAPI chain as a tool.
![image](https://github.com/kreneskyp/ix/assets/68635/2b0cdcfa-87a7-4314-b03e-98400e45c40d)


### Changes
- Added `chain_as_tool` wrapper function.
- Added NodeType definition for `chain_as_tool` .

##### misc
- Updated node_types.json
- TypeAutoFields now has a textarea component
- Tool description field now uses textarea
- Description no longer a default field for tools

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
