### PR TITLE
Tools target connectors are now on the right side so execution flow i…

### DIFF
--- a/frontend/chains/flow/ConfigNode.js
+++ b/frontend/chains/flow/ConfigNode.js
@@ -23,6 +23,21 @@ const NODE_COMPONENTS = {
   "ix.chains.functions.FunctionSchema": FunctionSchemaNode,
 };
 
+const CONNECTOR_CONFIG = {
+  agent: {
+    source_position: "left",
+    target_position: "right",
+  },
+  chain: {
+    source_position: "left",
+    target_position: "right",
+  },
+  tool: {
+    source_position: "left",
+    target_position: "right",
+  }
+}
+
 const usePropertyTargets = (type) => {
   return useMemo(() => {
     return type.connectors?.filter((connector) => connector.type === "target");
@@ -35,7 +50,7 @@ export const PropertyTarget = ({ connector }) => {
       <Handle
         id={connector.key}
         type="target"
-        position={connector.sourceType === "chain" ? "right" : "left"}
+        position={CONNECTOR_CONFIG[connector.sourceType]?.target_position || "left"}
       />
       <Box pl={2} m={0}>
         {connector.key}
@@ -153,9 +168,7 @@ export const ConfigNode = ({ data }) => {
       <Handle
         id={type.type}
         type="source"
-        position={
-          type.type === "chain" || type.type === "agent" ? "left" : "right"
-        }
+        position={CONNECTOR_CONFIG[type.type]?.source_position || "right"}
         style={{ top: "15px", transform: "translateX(-2px)" }}
       />
       <Heading


### PR DESCRIPTION
### Description
Tools target connectors were moved to the right so that execution flow is consistently left-to-right.

##### Before
![image](https://github.com/kreneskyp/ix/assets/68635/daed243e-20a8-4082-95c7-76b35007f250)

##### After
![image](https://github.com/kreneskyp/ix/assets/68635/5e139942-6c9f-4c73-a68a-4b062228b40a)



### Changes
- Add configurator for connector types
- Add config for tool connector to move target to right

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
