### PR TITLE
Improved node connector positions in chain editor

### DIFF
--- a/frontend/chains/flow/ChainNode.js
+++ b/frontend/chains/flow/ChainNode.js
@@ -1,53 +1,38 @@
 import React from "react";
 import { Handle } from "reactflow";
-import { Box, VStack, Heading, Text, HStack } from "@chakra-ui/react";
+import { Box, VStack, Heading, Flex } from "@chakra-ui/react";
 import { TypeAutoFields } from "chains/flow/TypeAutoFields";
 import { CollapsibleSection } from "chains/flow/CollapsibleSection";
 import { NodeProperties } from "chains/flow/ConfigNode";
 
 export const ChainNode = ({ type, node, config, onFieldChange }) => {
-  const inputs = null;
-  const outputs = null;
-
   return (
     <VStack spacing={0} alignItems="stretch" fontSize="xs">
-      <Box position="relative">
-        <Handle
-          id="in"
-          type="target"
-          position="left"
-          style={{ top: "50%", transform: "translateY(-50%)" }}
-        />
-        <Heading fontSize="xs" px={2}>
-          Inputs
-        </Heading>
-      </Box>
-      <VStack alignItems="stretch">
-        {inputs?.map((input, index) => (
-          <HStack key={index} spacing="2">
-            <Text>{input}</Text>
-          </HStack>
-        ))}
-      </VStack>
-      <Box position="relative">
-        <Handle
-          id="out"
-          type="source"
-          position="right"
-          style={{ top: "50%", transform: "translateY(-50%)" }}
-        />
-        <Heading fontSize="xs" px={2}>
-          Output
-        </Heading>
-      </Box>
-      <VStack alignItems="stretch" pb={2}>
-        {outputs?.map((output, index) => (
-          <HStack key={index} spacing="2">
-            <Text>{output}</Text>
-            <Handle type="source" position="bottom" id={`output-${index}`} />
-          </HStack>
-        ))}
-      </VStack>
+      <Flex mt={1} mb={3} justify={"space-between"}>
+        <Box position="relative">
+          <Handle
+            id="in"
+            type="target"
+            position="left"
+            style={{ top: "50%", transform: "translateY(-50%)" }}
+          />
+          <Heading fontSize="xs" px={2}>
+            Inputs
+          </Heading>
+        </Box>
+
+        <Box position="relative">
+          <Handle
+            id="out"
+            type="source"
+            position="right"
+            style={{ top: "50%", transform: "translateY(-50%)" }}
+          />
+          <Heading fontSize="xs" px={2}>
+            Output
+          </Heading>
+        </Box>
+      </Flex>
       <NodeProperties type={type} />
       <CollapsibleSection title="Config">
         <TypeAutoFields type={type} config={config} onChange={onFieldChange} />

--- a/frontend/chains/flow/ConfigNode.js
+++ b/frontend/chains/flow/ConfigNode.js
@@ -35,8 +35,8 @@ const CONNECTOR_CONFIG = {
   tool: {
     source_position: "left",
     target_position: "right",
-  }
-}
+  },
+};
 
 const usePropertyTargets = (type) => {
   return useMemo(() => {
@@ -50,9 +50,11 @@ export const PropertyTarget = ({ connector }) => {
       <Handle
         id={connector.key}
         type="target"
-        position={CONNECTOR_CONFIG[connector.sourceType]?.target_position || "left"}
+        position={
+          CONNECTOR_CONFIG[connector.sourceType]?.target_position || "left"
+        }
       />
-      <Box pl={2} m={0}>
+      <Box px={2} m={0}>
         {connector.key}
       </Box>
     </Box>
@@ -61,12 +63,33 @@ export const PropertyTarget = ({ connector }) => {
 
 export const NodeProperties = ({ type }) => {
   const propertyTargets = usePropertyTargets(type);
+
+  // sort properties into left and right
+  const left = [];
+  const right = [];
+  propertyTargets?.forEach((connector) => {
+    const position =
+      CONNECTOR_CONFIG[connector.sourceType]?.target_position || "left";
+    if (position === "right") {
+      right.push(connector);
+    } else {
+      left.push(connector);
+    }
+  });
+
   return (
-    <VStack spacing={0} cursor="default">
-      {propertyTargets?.map((connector, index) => (
-        <PropertyTarget key={index} connector={connector} />
-      ))}
-    </VStack>
+    <Flex justify={"space-between"}>
+      <VStack spacing={0} cursor="default">
+        {left?.map((connector, index) => (
+          <PropertyTarget key={index} connector={connector} />
+        ))}
+      </VStack>
+      <VStack spacing={0} cursor="default">
+        {right?.map((connector, index) => (
+          <PropertyTarget key={index} connector={connector} />
+        ))}
+      </VStack>
+    </Flex>
   );
 };
 


### PR DESCRIPTION
### Description
Node connectors and their labels are now positioned on the left or right side of the node. This makes the node a bit easier to read. 
![image](https://github.com/kreneskyp/ix/assets/68635/dbb33fad-7cb3-46b1-8099-3944a503a73b)

### Changes
- `ChainNode` in/out connectors aligned and positioned left/right
- Property connectors grouped and positioned left/right 

### How Tested
Manual testing.

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
