### PR TITLE
Hide ConfigNode connectors except when hovering near/over a node

### DIFF
--- a/frontend/chains/flow/ConfigNode.js
+++ b/frontend/chains/flow/ConfigNode.js
@@ -175,46 +175,52 @@ export const ConfigNode = ({ data }) => {
   ) : (
     <DefaultNodeContent {...node_component_props} />
   );
+  const position = CONNECTOR_CONFIG[type.type]?.source_position || "right";
 
   return (
-    <Box
-      borderWidth="0px"
-      borderRadius={8}
-      padding="0"
-      border="1px solid"
-      borderColor={border}
-      backgroundColor={bg}
-      minWidth={styles?.width || 250}
-      color={color}
-      boxShadow="md"
-    >
-      <Handle
-        id={type.type}
-        type="source"
-        position={CONNECTOR_CONFIG[type.type]?.source_position || "right"}
-        style={{ top: "15px", transform: "translateX(-2px)" }}
-      />
-      <Heading
-        as="h4"
-        size="xs"
-        color={highlightColor}
-        borderTopLeftRadius={7}
-        borderTopRightRadius={7}
-        bg={highlight[type.type]}
-        px={1}
-        py={2}
-        className="drag-handle"
+    <Box p={5} className="config-node">
+      <Box
+        borderWidth="0px"
+        borderRadius={8}
+        padding="0"
+        border="1px solid"
+        borderColor={border}
+        backgroundColor={bg}
+        minWidth={styles?.width || 250}
+        color={color}
+        boxShadow="md"
       >
-        <Flex alignItems="center" justifyContent="space-between" width="100%">
-          <Box pr={5}>
-            <FontAwesomeIcon icon={styles?.icon} />{" "}
-            {node.name || type?.name || node.classPath.split(".").pop()}
-          </Box>
-          <DeleteIcon node={node} />
-        </Flex>
-      </Heading>
-      <Box minHeight={25} cursor="default">
-        {content}
+        <Handle
+          id={type.type}
+          type="source"
+          position={position}
+          style={{
+            top: "38px",
+            transform: (position === 'left') ? "translateX(23px)" : "translateX(-23px)"
+          }}
+        />
+        <Heading
+          as="h4"
+          size="xs"
+          color={highlightColor}
+          borderTopLeftRadius={7}
+          borderTopRightRadius={7}
+          bg={highlight[type.type]}
+          px={1}
+          py={2}
+          className="drag-handle"
+        >
+          <Flex alignItems="center" justifyContent="space-between" width="100%">
+            <Box pr={5}>
+              <FontAwesomeIcon icon={styles?.icon} />{" "}
+              {node.name || type?.name || node.classPath.split(".").pop()}
+            </Box>
+            <DeleteIcon node={node} />
+          </Flex>
+        </Heading>
+        <Box minHeight={25} cursor="default">
+          {content}
+        </Box>
       </Box>
     </Box>
   );

--- a/frontend/chains/styles.css
+++ b/frontend/chains/styles.css
@@ -4,6 +4,10 @@
   }
 }
 
+.react-flow__edges {
+    z-index: 10 !important;
+}
+
 .edgePath {
   stroke: #000;
   stroke-width: 2;
@@ -27,12 +31,27 @@
   border-radius: 10px;
 }
 
+.config-node:hover .react-flow__handle {
+  background-color: #000;
+  border-color: #fff;
+}
+
+.config-node .react-flow__handle {
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.config-node .react-flow__handle:hover {
+  background-color: #e2e8f0;
+  border-color: #e2e8f0;
+}
+
 .react-flow__handle-connecting {
-  background-color: #ff6060;
-  border-color: #ff6060;
+  background-color: #ff6060 !important ;
+  border-color: #ff6060 !important ;
 }
 
 .react-flow__handle-valid {
-  background-color: #55dd99;
-  border-color: #55dd99;
+  background-color: #55dd99 !important ;
+  border-color: #55dd99 !important ;
 }


### PR DESCRIPTION
### Description
This PR simplifies ConfigNode presentation by hiding connectors (ReactFlow Handles) except when hoving near the ConfigNode.

##### default style
![image](https://github.com/kreneskyp/ix/assets/68635/70a195ae-b5d2-4fbf-ad36-628ef781cf11)


##### Hover
![image](https://github.com/kreneskyp/ix/assets/68635/b4050a43-44dd-465f-b77f-07baad733c03)



### Changes
- Added a 10px wide buffer around `ConfigNode` to trigger hover events
- updates css for connectors to make them show when hovering over the related ConfigNode

### How Tested
- manual testing

### TODOs
- After moving a `ConfigNode` the `ConfigNode` is placed above the edges making them unclickable.  Need to reset this in a followup
- To make connectors editable, the edges must be above the ConfigNode's new margin box.  Couldn't figure out how to get the edges above just that box.  Should revisit this since it would be nice for edges to flow behind nodes.