### PR TITLE
LangChain 0.0.238

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -21,6 +21,12 @@ OPENAI_API_KEY=
 # features.
 # ==================================================================
 
+# LangSmith logging (requires a LangSmith account)
+# LANGCHAIN_TRACING_V2=true
+# LANGCHAIN_ENDPOINT=https://api.smith.langchain.com
+# LANGCHAIN_API_KEY=
+# LANGCHAIN_PROJECT=default
+
 # llms
 GOOGLE_API_KEY=
 ANTHROPIC_API_KEY=

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ipython==8.13.2
 isort==5.12.0
 jsonpath-ng==1.5.3
 jsonschema==4.0.1
-langchain==0.0.234
+langchain==0.0.238
 openai==0.27.8
 pinecone-client==2.2.1
 pyright==1.1.301


### PR DESCRIPTION
### Description
Updating to LangChain 0.0.238 for the updated LangSmith client.

### Changes
- LangChain 0.0.238

### How Tested
- unittests

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
