### PR TITLE
Langsmith trace links in messages

### DIFF
--- a/frontend/chat/ChatMessage.js
+++ b/frontend/chat/ChatMessage.js
@@ -16,7 +16,10 @@ import CommandContent from "chat/CommandContent";
 
 import { useMemo } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCheck } from "@fortawesome/free-solid-svg-icons";
+import {
+  faArrowUpRightFromSquare,
+  faCheck,
+} from "@fortawesome/free-solid-svg-icons";
 import HighlightText from "components/HighlightText";
 import { ArtifactContent } from "chat/messages/ArtifactContent";
 
@@ -111,6 +114,25 @@ const ChatMessageAuthorizations = ({ authorizations }) => {
   );
 };
 
+const LangSmithLink = ({ thought }) => {
+  const { colorMode } = useColorMode();
+  if (thought?.content?.run_id === undefined || !thought?.content?.langsmith) {
+    return null;
+  }
+
+  return (
+    <Text
+      fontSize="xs"
+      color={colorMode === "light" ? "gray.800" : "gray.500"}
+      as={"span"}
+    >
+      <a target="_langsmith" href={`/langsmith/${thought.content.run_id}/`}>
+        <b>LangSmith</b> <FontAwesomeIcon icon={faArrowUpRightFromSquare} />
+      </a>
+    </Text>
+  );
+};
+
 const ChatMessageFooter = ({ groupedMessages }) => {
   const { colorMode } = useColorMode();
   const { thought, authorizations } = groupedMessages;
@@ -130,7 +152,8 @@ const ChatMessageFooter = ({ groupedMessages }) => {
           fontSize="xs"
           color={colorMode === "light" ? "gray.800" : "gray.500"}
         >
-          <b>Runtime:</b> {thought?.content.runtime?.toFixed(2)} seconds.
+          <b>Runtime:</b> {thought?.content.runtime?.toFixed(2)} seconds.{" "}
+          <LangSmithLink thought={thought} />
         </Text>
       )}
     </Flex>

--- a/ix/server/urls.py
+++ b/ix/server/urls.py
@@ -3,7 +3,7 @@ from django.urls import path, re_path, include
 from django.views.decorators.csrf import csrf_exempt
 from graphene_django.views import GraphQLView
 
-from ix.server.views import index, status
+from ix.server.views import index, status, langsmith
 
 urlpatterns = [
     path("", index, name="index"),
@@ -11,5 +11,6 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("task_log>/", include("ix.task_log.urls")),
     path("graphql", csrf_exempt(GraphQLView.as_view(graphiql=True))),
+    re_path(r"^langsmith/(?P<run_id>[0-9a-f-]+)/$", langsmith, name="langsmith"),
     re_path(r".*", index, name="index"),
 ]

--- a/ix/server/views.py
+++ b/ix/server/views.py
@@ -1,5 +1,6 @@
 from django.http import HttpResponse
-from django.shortcuts import render
+from django.shortcuts import render, redirect
+from langsmith import Client as LangsmithClient
 
 
 def status(request):
@@ -8,3 +9,10 @@ def status(request):
 
 def index(request):
     return render(request, "index.html")
+
+
+def langsmith(request, run_id):
+    """Redirect to the Langsmith run details for the given run_id."""
+    client = LangsmithClient()
+    run = client.read_run(run_id)
+    return redirect(run.url)


### PR DESCRIPTION
### Description
This PR adds a LangSmith link to the `ChatMessageFooter` when a trace has been logged.

![LangSmithLink_V1](https://github.com/kreneskyp/ix/assets/68635/8be64af2-2696-4f0b-965e-f1c20cadc897)

![image](https://github.com/kreneskyp/ix/assets/68635/909689a0-d531-403b-bf16-0079c300ef6f)


### Changes
- log `run_id` and `langsmith` (was traced) to `THOUGHT` messages
- adds redirect route to redirect to a LangSmith run page. 
- adds link to LangSmith to `ChatMessageFooter` when traces are logged.

### How Tested
- existing unittests
- manual testing

### TODOs
This PR also includes an update to add the `run_id` to `THOUGHT` messages.  This implementation conflicts with the LangChain callbacks added in #130. That PR (#130) deprecates the code that was modified here and adds `run_id` in a different way.  #130 needs more testing before it can merge, will reconcile these two PRs in #130.
