### PR TITLE
LangChain 0.0.243

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ipython==8.13.2
 isort==5.12.0
 jsonpath-ng==1.5.3
 jsonschema==4.0.1
-langchain==0.0.238
+langchain==0.0.243
 openai==0.27.8
 pinecone-client==2.2.1
 pyright==1.1.301


### PR DESCRIPTION
### Description
LangChain 0.0.243

Upstream breaking changes: LangChain was split into multiple libraries. No changes were required within Ix. Downstream users will need to install the optional LangChain libraries to use experimental components.

More details: https://github.com/langchain-ai/langchain/discussions/8043

### Changes
- updated to langchain 0.0.243

### How Tested
- unittests
- manual tests

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
