### PR TITLE
Adding DelegateToAgentChain

### DIFF
--- a/ix/chains/agent_interaction.py
+++ b/ix/chains/agent_interaction.py
@@ -1,0 +1,116 @@
+import logging
+from typing import Dict, Any, List, Optional
+
+from ix.agents.models import Agent
+from ix.chains.callbacks import IxHandler
+from langchain import BasePromptTemplate
+
+from ix.chat.models import Chat
+from langchain.callbacks.manager import (
+    AsyncCallbackManagerForChainRun,
+    CallbackManagerForChainRun,
+)
+from langchain.chains.base import Chain
+
+from ix.task_log.models import Task
+from ix.task_log.tasks import start_agent_loop
+
+
+logger = logging.getLogger(__name__)
+
+
+async def adelegate_task(chat: Chat, delegate_to: str, inputs: Dict[str, Any]):
+    """Delegate a task to another agent
+
+    This works by scheduling the worker process directly.
+    TODO: update to use IX API. This temp solution is just MVP
+    """
+    task = await Task.objects.aget(id=chat.task_id)
+    agent = await chat.agents.aget(alias=delegate_to)
+    subtask = await task.adelegate_to_agent(agent)
+    logger.debug(f"Delegated to agent={agent.alias} task={subtask.id} input={inputs}")
+
+    start_agent_loop.delay(
+        task_id=str(subtask.id), chain_id=str(agent.chain_id), inputs=inputs
+    )
+
+
+class DelegateToAgentChain(Chain):
+    """Delegate a task to another aget
+
+    This task does not configure the reply. The agent must also use a `DelegateChain` to
+    reply to the request.
+    """
+
+    # output key that records agent alias that was delegated to
+    output_key: str = "delegate_to"
+
+    # alias of agent to delegate to
+    target_alias: str
+
+    # prompt used to generate message sent to the target agent
+    # The message will be sent as "user_input".  The target agent
+    # will use this input to handle the request.
+    prompt: BasePromptTemplate
+
+    # inputs to include in the message sent to the target agent
+    # along with the prompt generated user_input
+    delegate_inputs: list = None
+
+    @property
+    def _chain_type(self) -> str:
+        return "ix.delegate_chain"  # pragma: no cover
+
+    @property
+    def input_keys(self) -> List[str]:
+        """Will be whatever keys the prompt expects.
+
+        :meta private:
+        """
+        return self.prompt.input_variables
+
+    @property
+    def output_keys(self) -> List[str]:
+        return [self.output_key]
+
+    def _call(
+        self,
+        inputs: Dict[str, Any],
+        run_manager: Optional[CallbackManagerForChainRun] = None,
+    ) -> Dict[str, Any]:
+        raise NotImplementedError("DelegateChain does not support sync calls")  # pragma: no cover
+
+    async def _acall(
+        self,
+        inputs: Dict[str, Any],
+        run_manager: Optional[AsyncCallbackManagerForChainRun] = None,
+    ) -> Dict[str, Any]:
+        """Run chain asynchronously"""
+        # Get chat
+        chat_id = inputs["chat_id"]
+        chat = await Chat.objects.aget(id=chat_id)
+
+        # Summon the agent to the chat if it is not already here
+        is_agent_here = await chat.agents.filter(alias=self.target_alias).aexists()
+        if not is_agent_here:
+            target = await Agent.objects.aget(alias=self.target_alias)
+            await chat.agents.aadd(target)
+
+        # send message to chat to inform user
+        text = f"Delegating to @{self.target_alias}"
+        ix_handler = IxHandler.from_manager(run_manager)
+        await ix_handler.send_agent_msg(text)
+
+        # Generate inputs and send message to agent
+        #    prompt has access to all inputs thus far
+        if self.delegate_inputs is None:
+            delegate_inputs = inputs.copy()
+        else:
+            delegate_inputs = {k: inputs[k] for k in self.delegate_inputs}
+        prompt = self.prompt.format_prompt(**inputs)
+        delegate_inputs["user_input"] = prompt.to_string()
+        delegate_inputs["chat_id"] = inputs["chat_id"]
+        await adelegate_task(chat, self.target_alias, delegate_inputs)
+
+        # return as output_key
+        return {self.output_key: text}

--- a/ix/chains/agent_interaction.py
+++ b/ix/chains/agent_interaction.py
@@ -78,7 +78,9 @@ class DelegateToAgentChain(Chain):
         inputs: Dict[str, Any],
         run_manager: Optional[CallbackManagerForChainRun] = None,
     ) -> Dict[str, Any]:
-        raise NotImplementedError("DelegateChain does not support sync calls")  # pragma: no cover
+        raise NotImplementedError(
+            "DelegateChain does not support sync calls"
+        )  # pragma: no cover
 
     async def _acall(
         self,

--- a/ix/chains/fixture_src/agent_interaction.py
+++ b/ix/chains/fixture_src/agent_interaction.py
@@ -1,0 +1,30 @@
+from ix.api.chains.types import NodeTypeField
+from ix.chains.agent_interaction import DelegateToAgentChain
+from ix.chains.fixture_src.common import CHAIN_BASE_FIELDS
+from ix.chains.fixture_src.targets import MEMORY_TARGET, PROMPT_TARGET
+
+
+DELEGATE_TO_AGENT_CHAIN = {
+    "class_path": "ix.chains.agent_interaction.DelegateToAgentChain",
+    "name": "DelegateToAgent",
+    "description": "Delegate a request to another agent. Does not wait for a response.",
+    "type": "chain",
+    "connectors": [MEMORY_TARGET, PROMPT_TARGET],
+    "fields": CHAIN_BASE_FIELDS
+    + NodeTypeField.get_fields(
+        DelegateToAgentChain,
+        include=[
+            "output_key",
+            "target_alias",
+            "delegate_inputs",
+        ],
+    ),
+}
+
+
+AGENT_INTERACTION_CHAINS = [
+    DELEGATE_TO_AGENT_CHAIN,
+]
+
+
+__all__ = [AGENT_INTERACTION_CHAINS, DELEGATE_TO_AGENT_CHAIN]

--- a/ix/chains/fixture_src/common.py
+++ b/ix/chains/fixture_src/common.py
@@ -3,3 +3,29 @@ VERBOSE = {
     "type": "boolean",
     "default": False,
 }
+
+TAGS = {
+    "name": "tags",
+    "type": "list",
+    "default": [],
+    "style": {
+        "width": "100%",
+    },
+}
+
+METADATA = {
+    "name": "metadata",
+    "type": "dict",
+    "required": False,
+}
+
+INPUT_VARIABLES = {
+    "name": "input_variables",
+    "type": "list",
+    "default": [],
+    "style": {
+        "width": "100%",
+    },
+}
+
+CHAIN_BASE_FIELDS = [VERBOSE, TAGS]

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -1366,7 +1366,7 @@
   "pk": "61654ca2-b73b-4dac-b761-adba7d560ef3",
   "fields": {
     "name": "Symbolic Math Chain",
-    "description": "Chain that interprets a prompt and executes python code to do math.\n\n    Example:\n        .. code-block:: python\n\n            from langchain import LLMSymbolicMathChain, OpenAI\n            llm_symbolic_math = LLMSymbolicMathChain.from_llm(OpenAI())\n    ",
+    "description": "Chain that interprets a prompt and executes python code to do symbolic math.\n\n    Example:\n        .. code-block:: python\n\n            from langchain import LLMSymbolicMathChain, OpenAI\n            llm_symbolic_math = LLMSymbolicMathChain.from_llm(OpenAI())\n    ",
     "class_path": "langchain.chains.llm_symbolic_math.base.LLMSymbolicMathChain.from_llm",
     "type": "chain",
     "display_type": "node",
@@ -2041,6 +2041,97 @@
         "human_prefix": {
           "type": "string",
           "default": "Human"
+        }
+      }
+    }
+  }
+},
+{
+  "model": "chains.nodetype",
+  "pk": "8e6158bc-0061-4959-b056-58d8f38e3347",
+  "fields": {
+    "name": "DelegateToAgent",
+    "description": "Delegate a request to another agent. Does not wait for a response.",
+    "class_path": "ix.chains.agent_interaction.DelegateToAgentChain",
+    "type": "chain",
+    "display_type": "node",
+    "connectors": [
+      {
+        "key": "memory",
+        "type": "target",
+        "multiple": true,
+        "source_type": "memory"
+      },
+      {
+        "key": "prompt",
+        "type": "target",
+        "source_type": "prompt"
+      }
+    ],
+    "fields": [
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "tags",
+        "type": "list",
+        "style": {
+          "width": "100%"
+        },
+        "default": []
+      },
+      {
+        "name": "output_key",
+        "type": "str",
+        "label": "Output_key",
+        "default": "delegate_to",
+        "required": false
+      },
+      {
+        "name": "target_alias",
+        "type": "str",
+        "label": "Target_alias",
+        "default": null,
+        "required": true
+      },
+      {
+        "name": "delegate_inputs",
+        "type": "list",
+        "label": "Delegate_inputs",
+        "default": null,
+        "required": false
+      }
+    ],
+    "child_field": null,
+    "config_schema": {
+      "type": "object",
+      "required": [
+        "verbose",
+        "tags",
+        "target_alias"
+      ],
+      "properties": {
+        "tags": {
+          "type": "object",
+          "default": []
+        },
+        "verbose": {
+          "type": "boolean",
+          "default": false
+        },
+        "output_key": {
+          "type": "string",
+          "default": "delegate_to"
+        },
+        "target_alias": {
+          "type": "string",
+          "default": null
+        },
+        "delegate_inputs": {
+          "type": "object",
+          "default": null
         }
       }
     }

--- a/ix/chains/management/commands/import_langchain.py
+++ b/ix/chains/management/commands/import_langchain.py
@@ -2,6 +2,7 @@ from django.core.management.base import BaseCommand
 
 from ix.api.chains.types import NodeTypeField
 from ix.api.chains.types import NodeType as NodeTypePydantic
+from ix.chains.fixture_src.agent_interaction import AGENT_INTERACTION_CHAINS
 
 from ix.chains.fixture_src.agents import AGENTS
 from ix.chains.fixture_src.artifacts import ARTIFACT_MEMORY, SAVE_ARTIFACT
@@ -112,6 +113,7 @@ COMPONENTS.extend(
 
 # IX Misc
 COMPONENTS.extend([CHAT_MODERATOR_TYPE])
+COMPONENTS.extend(AGENT_INTERACTION_CHAINS)
 
 # IX Artifacts
 COMPONENTS.extend(

--- a/ix/chains/tests/test_agent_interaction.py
+++ b/ix/chains/tests/test_agent_interaction.py
@@ -1,0 +1,115 @@
+import pytest
+
+from ix.chains.agent_interaction import DelegateToAgentChain
+
+
+DELEGATE_TO_AGENT_CHAIN = {
+    "class_path": "ix.chains.agent_interaction.DelegateToAgentChain",
+    "config": {
+        "target_alias": "agent_1",
+        "prompt": {
+            "class_path": "langchain.prompts.chat.ChatPromptTemplate",
+            "config": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "template": "Write a sea shanty for user input: {user_input}.",
+                        "input_variables": ["user_input"],
+                    },
+                ],
+            },
+        },
+    },
+}
+
+
+DELEGATE_TO_AGENT_CHAIN_FILTER_INPUTS = {
+    "class_path": "ix.chains.agent_interaction.DelegateToAgentChain",
+    "config": {
+        "target_alias": "agent_1",
+        "delegate_inputs": ["user_input"],
+        "prompt": {
+            "class_path": "langchain.prompts.chat.ChatPromptTemplate",
+            "config": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "template": "Write a sea shanty for user input: {user_input}.",
+                        "input_variables": ["user_input"],
+                    },
+                ],
+            },
+        },
+    },
+}
+
+
+@pytest.fixture
+def start_agent_loop(mocker):
+    # mock start_agent_loop since the task is async and makes this test flaky
+    yield mocker.patch("ix.chains.agent_interaction.start_agent_loop")
+
+
+@pytest.mark.django_db
+class TestDelegateToAgentChain:
+    async def test_delegate_to_agent(
+        self, aload_chain, aix_handler, achat, start_agent_loop
+    ):
+        """Verify that the chain will delegate to the agent"""
+        chat = achat["chat"]
+        chain = await aload_chain(DELEGATE_TO_AGENT_CHAIN)
+        assert isinstance(chain, DelegateToAgentChain)
+
+        result = await chain.arun(
+            chat_id=str(chat.id),
+            user_input="test task delegation",
+            extra_input="testing extra input",
+            callbacks=[aix_handler],
+        )
+        assert result == "Delegating to @agent_1"
+        assert start_agent_loop.delay.call_args_list[0].kwargs["inputs"] == {
+            "chat_id": str(chat.id),
+            "user_input": "System: Write a sea shanty for user input: test task delegation.",
+            "extra_input": "testing extra input",
+        }
+
+    async def test_delegate_to_agent_summons_agents(
+        self, aload_chain, aix_handler, achat, start_agent_loop
+    ):
+        """Verify that the chain will delegate to the agent"""
+        chat = achat["chat"]
+        chain = await aload_chain(DELEGATE_TO_AGENT_CHAIN)
+        assert isinstance(chain, DelegateToAgentChain)
+
+        # remove agents
+        await chat.agents.all().adelete()
+        assert await chat.agents.aexists() is False
+
+        result = await chain.arun(
+            chat_id=str(chat.id),
+            user_input="test task delegation",
+            callbacks=[aix_handler],
+        )
+        assert result == "Delegating to @agent_1"
+        assert await chat.agents.filter(alias="agent_1").aexists()
+
+    async def test_delegate_to_agent_filter_inputs(
+        self, aload_chain, aix_handler, achat, start_agent_loop
+    ):
+        """Verify that the chain will delegate to the agent"""
+        chat = achat["chat"]
+        chain = await aload_chain(DELEGATE_TO_AGENT_CHAIN_FILTER_INPUTS)
+        assert isinstance(chain, DelegateToAgentChain)
+
+        result = await chain.arun(
+            chat_id=str(chat.id),
+            user_input="test task delegation",
+            excluded_input="this input won't be passed to the agent",
+            callbacks=[aix_handler],
+        )
+        assert result == "Delegating to @agent_1"
+        start_agent_loop.delay.assert_called_once()
+        assert start_agent_loop.delay.call_args_list[0].kwargs["inputs"] == {
+            "chat_id": str(chat.id),
+            "user_input": "System: Write a sea shanty for user input: test task delegation.",
+        }


### PR DESCRIPTION
This PR adds `DelegateToAgentChain` a new chain that delegates a task to another agent. A prompt is used to generate the `user_input` sent to the agent.

##### Example: ToolForge

This example demonstrates delegation with a `@forge` agent that delegates code generation of a LangChain `Tool` to `@code`. The `@forge` agent prompt contains the context for building tools and leaves all coding responsibility to `@code`.  
![image](https://github.com/kreneskyp/ix/assets/68635/127a4f08-c575-4318-aa07-e420d4a725c5)

![image](https://github.com/kreneskyp/ix/assets/68635/1c5389f2-789a-4695-bd9b-dc177dfc365a)



### Changes
- added `DelegateToAgentChain`
- defined common field definitions for 

### How Tested
- new unittests for `DelegateToAgentChain`
- manual tests with `@forge`

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
