### PR TITLE
awrite_to_file now creates the WORKDIR and file path

### DIFF
--- a/ix/commands/filesystem.py
+++ b/ix/commands/filesystem.py
@@ -4,7 +4,7 @@ import os
 import glob
 
 import aiofiles
-
+from asgiref.sync import sync_to_async
 
 WORKDIR = Path("/var/app/workdir")
 
@@ -26,6 +26,7 @@ def write_to_file(file_path: str, content: str) -> None:
 
 
 async def awrite_to_file(file_path, content):
+    await sync_to_async(create_file_path)(WORKDIR / file_path)
     async with aiofiles.open(WORKDIR / file_path, "w") as f:
         await f.write(content)
 

--- a/ix/commands/tests/test_filesystem.py
+++ b/ix/commands/tests/test_filesystem.py
@@ -29,6 +29,18 @@ class TestWriteToFile:
         with open(file_path, "r") as f:
             assert f.read() == content2
 
+    def test_write_to_new_workdir(self, mocker, tmp_path):
+        """Test that workdir is created if it does not exist"""
+        mock_workdir = tmp_path / "workdir"
+        mocker.patch("ix.commands.filesystem.WORKDIR", mock_workdir)
+        content = "Hello, world!"
+        file_path = "test.txt"
+        expected_path = mock_workdir / file_path
+        write_to_file(str(file_path), content)
+        assert expected_path.exists()
+        with open(expected_path, "r") as f:
+            assert f.read() == content
+
 
 class TestAWriteToFile:
     @pytest.mark.asyncio
@@ -49,6 +61,18 @@ class TestAWriteToFile:
         await awrite_to_file(str(file_path), content2)
         async with aiofiles.open(file_path, "r") as f:
             assert await f.read() == content2
+
+    @pytest.mark.asyncio
+    async def test_write_to_new_workdir(self, mocker, tmp_path):
+        """Test that workdir is created if it does not exist"""
+        mock_workdir = tmp_path / "workdir"
+        mocker.patch("ix.commands.filesystem.WORKDIR", mock_workdir)
+        content = "Hello, world!"
+        file_path = "test.txt"
+        expected_path = mock_workdir / file_path
+        await awrite_to_file(str(expected_path), content)
+        async with aiofiles.open(expected_path, "r") as f:
+            assert await f.read() == content
 
 
 class TestAppendToFile:


### PR DESCRIPTION
### Description
`@code` was unable to save files after a clean install. It was discovered that `awrite_to_file` was not creating the directories in the file path the way the synchronous version was.

replaces #135 

### Changes
- `awrite_to_file` now creates all directories in the file's path

### How Tested
- added a test that uses a temp WORKDIR to verify the path will be created.

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
