### PR TITLE
Simplified worker tracebacks

### DIFF
--- a/ix/agents/process.py
+++ b/ix/agents/process.py
@@ -5,7 +5,7 @@ from asgiref.sync import sync_to_async
 from ix.agents.models import Agent
 from ix.chains.callbacks import IxHandler
 from ix.chains.models import Chain as ChainModel
-from ix.task_log.models import Task, TaskLogMessage
+from ix.task_log.models import Task
 
 
 # logging
@@ -42,22 +42,25 @@ class AgentProcess:
         logger.debug(f"Response from model, task_id={self.task.id} response={response}")
         return True
 
-    async def chat_with_ai(self, user_input: Dict[str, Any]) -> TaskLogMessage:
+    async def chat_with_ai(self, user_input: Dict[str, Any]) -> Any:
         handler = IxHandler(agent=self.agent, chain=self.chain, task=self.task)
 
-        # TODO: chain loading needs to be made async
-        chain = await sync_to_async(self.chain.load_chain)(handler)
-
-        logger.info(f"Sending request to chain={self.chain.name} prompt={user_input}")
-
-        # auto-map user_input to input if not provided.
-        # work around until chat input key can be configured per chain
-        extra_kwargs = {}
-        if "input" not in user_input:
-            extra_kwargs["input"] = user_input["user_input"]
-
-        # Hax: copy user_input to input to support agents.
         try:
+            # TODO: chain loading needs to be made async
+            chain = await sync_to_async(self.chain.load_chain)(handler)
+
+            logger.info(
+                f"Sending request to chain={self.chain.name} prompt={user_input}"
+            )
+
+            # auto-map user_input to input if not provided.
+            # work around until chat input key can be configured per chain
+            extra_kwargs = {}
+            if "input" not in user_input:
+                extra_kwargs["input"] = user_input["user_input"]
+
+            # Hax: copy user_input to input to support agents.
+
             return await chain.arun(callbacks=[handler], **extra_kwargs, **user_input)
         except Exception as e:
             # validation errors aren't caught by callbacks.

--- a/ix/agents/process.py
+++ b/ix/agents/process.py
@@ -57,5 +57,9 @@ class AgentProcess:
             extra_kwargs["input"] = user_input["user_input"]
 
         # Hax: copy user_input to input to support agents.
-        response = await chain.arun(callbacks=[handler], **extra_kwargs, **user_input)
-        return response
+        try:
+            return await chain.arun(callbacks=[handler], **extra_kwargs, **user_input)
+        except Exception as e:
+            # validation errors aren't caught by callbacks.
+            await handler.send_error_msg(e)
+            return None


### PR DESCRIPTION
### Description
This PR improves tracebacks for the worker process. 

Tracebacks from the worker process were painful to read. They included a 100+ lines of traces from the celery process.  It required lots of scrolling to find the part of the trace that mattered.

This PR reports tracebacks with most of the celery traces truncated, leaving only the bits relevant to working with IX.

![image](https://github.com/kreneskyp/ix/assets/68635/c1bc468a-2fd6-4bdf-adc5-c4b5548877ea)


### Changes
- added `IxHandler.send_error_msg` from existing code
- `IxHandler.send_error_msg` now logs a truncated traceback
- `AgentProcess` now squashes errors rather than letting celery report it.
- `AgentProcess` once again logs exceptions that aren't handled by callbacks

### How Tested
- manually broke some things to test it

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
