### PR TITLE
ChainEditor converted to FastAPI

### DIFF
--- a/frontend/agents/AgentEditorView.js
+++ b/frontend/agents/AgentEditorView.js
@@ -15,13 +15,14 @@ export const useChains = () => {
 export const AgentEditorView = () => {
   const { id } = useParams();
   const {
-    data: agent,
-    load,
+    response,
+    call,
     error: agentError,
-  } = useDetailAPI(`/api/agents/${id}`, { load: false });
+  } = useDetailAPI(`/api/agents/${id}`);
   const { page: chainsPage, error: chainsError } = useChains();
   const chains = chainsPage?.objects;
-  const { isNew, idRef } = useObjectEditorView(id, load);
+  const { isNew, idRef } = useObjectEditorView(id, call);
+  const agent = response?.data;
 
   let content;
   if (!chains) {

--- a/frontend/chains/ChainEditorView.js
+++ b/frontend/chains/ChainEditorView.js
@@ -1,73 +1,29 @@
-import React, { useEffect, useState } from "react";
-import { v4 as uuid4 } from "uuid";
-import { usePreloadedQuery } from "react-relay/hooks";
-import { useQueryLoader } from "react-relay";
+import React from "react";
 import { useParams } from "react-router-dom";
 import { Spinner, VStack } from "@chakra-ui/react";
 
 import { Layout, LayoutContent, LayoutLeftPane } from "site/Layout";
-import { ChainGraphByIdQuery } from "chains/graphql/ChainGraphByIdQuery";
 import ChainGraphEditor from "chains/ChainGraphEditor";
 import { ChainGraphEditorSideBar } from "chains/editor/ChainGraphEditorSideBar";
-
-const ChainEditorShim = ({ chainQueryRef }) => {
-  const { graph } = usePreloadedQuery(ChainGraphByIdQuery, chainQueryRef);
-  return <ChainGraphEditor graph={graph} />;
-};
+import { useDetailAPI } from "utils/hooks/useDetailAPI";
+import { useObjectEditorView } from "utils/hooks/useObjectEditorView";
 
 export const ChainEditorView = () => {
-  const [chainQueryRef, loadChainQuery] = useQueryLoader(ChainGraphByIdQuery);
   const { id } = useParams();
-
-  // state for handling whether how to load the data (new vs existing)
-  // and when to reset the editor when opened. The cached state does not
-  // reset when the url changes as protection against reloading when
-  // creating new chains. This state tracks when to reset the cache.
-  const [idRef, setIdRef] = useState(null);
-  const [isNew, setIsNew] = useState(null);
-  const [wasCreated, setWasCreated] = useState(null);
-  useEffect(() => {
-    const firstRender = isNew === null;
-    if (firstRender) {
-      // first render caches whether this started as a new chain
-      setIsNew(id === undefined);
-    } else {
-      // switch from existing to new
-      if (id === undefined && !isNew) {
-        setIsNew(true);
-        setWasCreated(false);
-      }
-      // a new chain was created
-      if (id !== undefined && isNew) {
-        setWasCreated(true);
-      }
-      // switch from created to new
-      if (id === undefined && wasCreated) {
-        setIsNew(true);
-        setWasCreated(false);
-        setIdRef(uuid4());
-      }
-    }
-  }, [id]);
-
-  useEffect(() => {
-    // load chain if id is provided on view load
-    // otherwise state will be handled internally by the editor
-    if (isNew === false) {
-      loadChainQuery({ id }, { fetchPolicy: "network-only" });
-      setIdRef(id);
-    } else {
-      setIdRef(uuid4());
-    }
-  }, [isNew]);
+  const {
+    data: graph,
+    load,
+    isLoading,
+  } = useDetailAPI(`/api/chains/${id}/graph`);
+  const { isNew, idRef } = useObjectEditorView(id, load);
 
   let content;
   if (isNew) {
     content = <ChainGraphEditor key={idRef} />;
-  } else if (!chainQueryRef) {
+  } else if (isLoading || !graph) {
     content = <Spinner />;
   } else {
-    content = <ChainEditorShim chainQueryRef={chainQueryRef} />;
+    content = <ChainGraphEditor graph={graph} />;
   }
 
   return (

--- a/frontend/chains/ChainEditorView.js
+++ b/frontend/chains/ChainEditorView.js
@@ -10,12 +10,9 @@ import { useObjectEditorView } from "utils/hooks/useObjectEditorView";
 
 export const ChainEditorView = () => {
   const { id } = useParams();
-  const {
-    data: graph,
-    load,
-    isLoading,
-  } = useDetailAPI(`/api/chains/${id}/graph`);
-  const { isNew, idRef } = useObjectEditorView(id, load);
+  const { response, call, isLoading } = useDetailAPI(`/api/chains/${id}/graph`);
+  const { isNew, idRef } = useObjectEditorView(id, call);
+  const graph = response?.data;
 
   let content;
   if (isNew) {

--- a/frontend/chains/flow/ConfigNode.js
+++ b/frontend/chains/flow/ConfigNode.js
@@ -110,7 +110,7 @@ const DeleteIcon = ({ node }) => {
 
   const onClick = useCallback(
     (event) => {
-      api.deleteNode({ id: node.id });
+      api.deleteNode(node.id);
     },
     [node.id, api]
   );
@@ -138,13 +138,12 @@ export const ConfigNode = ({ data }) => {
   const handleConfigChange = useMemo(() => {
     function all(newConfig, delay = 0) {
       const data = {
-        id: node.id,
-        classPath: node.classPath,
+        class_path: node.class_path,
         description: node.description,
         position: node.position,
         config: newConfig,
       };
-      debouncedUpdateNode({ data });
+      debouncedUpdateNode(node.id, data);
       setConfig(newConfig);
     }
 
@@ -158,8 +157,8 @@ export const ConfigNode = ({ data }) => {
 
   // node type specific content
   let NodeComponent = null;
-  if (NODE_COMPONENTS[node.classPath]) {
-    NodeComponent = NODE_COMPONENTS[node.classPath];
+  if (NODE_COMPONENTS[node.class_path]) {
+    NodeComponent = NODE_COMPONENTS[node.class_path];
   } else if (styles?.component) {
     NodeComponent = styles.component;
   }
@@ -214,7 +213,7 @@ export const ConfigNode = ({ data }) => {
           <Flex alignItems="center" justifyContent="space-between" width="100%">
             <Box pr={5}>
               <FontAwesomeIcon icon={styles?.icon} />{" "}
-              {node.name || type?.name || node.classPath.split(".").pop()}
+              {node.name || type?.name || node.class_path.split(".").pop()}
             </Box>
             <DeleteIcon node={node} />
           </Flex>

--- a/frontend/chains/hooks/useChain.js
+++ b/frontend/chains/hooks/useChain.js
@@ -1,5 +1,5 @@
 import { useDetailAPI } from "utils/hooks/useDetailAPI";
 
 export const useChain = (id) => {
-  return useDetailAPI(`/api/chains/${id}`);
+  return useDetailAPI(`/api/chains/${id}`, { auto: true });
 };

--- a/frontend/chains/hooks/useGraphForReactFlow.js
+++ b/frontend/chains/hooks/useGraphForReactFlow.js
@@ -16,7 +16,7 @@ export const getEdgeStyle = (colorMode, type) => {
 export const toReactFlowNode = (node, nodeType) => {
   return {
     id: node.id,
-    type: nodeType.displayType,
+    type: nodeType.display_type,
     dragHandle: ".drag-handle",
     position: node.position,
     data: {
@@ -33,6 +33,14 @@ export const toReactFlowNode = (node, nodeType) => {
 export const useGraphForReactFlow = (graph) => {
   const { colorMode } = useColorMode();
 
+  const nodeTypes = useMemo(() => {
+    const nodeTypes = {};
+    graph?.types?.forEach((type) => {
+      nodeTypes[type.id] = type;
+    });
+    return nodeTypes;
+  }, [graph]);
+
   return useMemo(() => {
     let root = null;
     const nodeMap = {};
@@ -45,7 +53,7 @@ export const useGraphForReactFlow = (graph) => {
         if (node.root) {
           root = node;
         }
-        return toReactFlowNode(node, node.nodeType);
+        return toReactFlowNode(node, nodeTypes[node.node_type_id]);
       }) || [];
 
     const chainPropEdgeStyle = getEdgeStyle(colorMode, "chain");
@@ -53,12 +61,12 @@ export const useGraphForReactFlow = (graph) => {
 
     const edges =
       graph?.edges?.map((edge) => {
-        const sourceType = nodeMap[edge.source.id].nodeType.type;
+        const sourceType = nodeTypes[nodeMap[edge.source_id].node_type_id].type;
         return {
           id: edge.id,
           type: "default",
-          source: edge.source.id,
-          target: edge.target.id,
+          source: edge.source_id,
+          target: edge.target_id,
           sourceHandle: edge.relation === "PROP" ? sourceType : "out",
           targetHandle: edge.relation === "PROP" ? edge.key : "in",
           style: sourceType === "chain" ? chainPropEdgeStyle : defaultEdgeStyle,

--- a/frontend/chat/ChatView.js
+++ b/frontend/chat/ChatView.js
@@ -67,7 +67,8 @@ export const useChatGraph = (id) => {
 
 export const ChatView = () => {
   const { id } = useParams();
-  const { data: graph, load: loadGraph, isLoading } = useChatGraph(id);
+  const { response, call: loadGraph, isLoading } = useChatGraph(id);
+  const graph = response?.data;
 
   useEffect(() => {
     loadGraph();

--- a/frontend/chat/ChatView.js
+++ b/frontend/chat/ChatView.js
@@ -62,7 +62,7 @@ export const ChatLeftPaneShim = ({ graph, loadGraph }) => {
 };
 
 export const useChatGraph = (id) => {
-  return useDetailAPI(`/api/chats/${id}/graph`, { load: false });
+  return useDetailAPI(`/api/chats/${id}/graph`);
 };
 
 export const ChatView = () => {

--- a/frontend/chat/agents/AddAgentModalTrigger.js
+++ b/frontend/chat/agents/AddAgentModalTrigger.js
@@ -14,7 +14,14 @@ import { AddAgentCard } from "chat/agents/AddAgentCard";
 import { AgentToggleButton } from "chat/agents/AgentToggleButton";
 import { usePaginatedAPI } from "utils/hooks/usePaginatedAPI";
 
-const AddAgentModal = ({ graph, chatAgents, agents, isOpen, onClose, onSuccess }) => {
+const AddAgentModal = ({
+  graph,
+  chatAgents,
+  agents,
+  isOpen,
+  onClose,
+  onSuccess,
+}) => {
   const [search, setSearch] = useState("");
   const { chat } = graph;
 
@@ -61,7 +68,12 @@ const AddAgentModal = ({ graph, chatAgents, agents, isOpen, onClose, onSuccess }
   );
 };
 
-export const AddAgentModalTrigger = ({ graph, chatAgents, onSuccess, children }) => {
+export const AddAgentModalTrigger = ({
+  graph,
+  chatAgents,
+  onSuccess,
+  children,
+}) => {
   const [isOpen, setIsOpen] = useState(false);
   const { page, load } = usePaginatedAPI("/api/agents/", {
     limit: 1000,

--- a/frontend/chat/input/ChatInput.js
+++ b/frontend/chat/input/ChatInput.js
@@ -30,7 +30,6 @@ import { clear_editor, INITIAL_EDITOR_CONTENT } from "utils/slate";
 import { useChatColorMode } from "chains/editor/useColorMode";
 import { usePaginatedAPI } from "utils/hooks/usePaginatedAPI";
 
-
 export const ChatInput = ({ chat }) => {
   const focusRef = useRef();
   const [target, setTarget] = useState(null);
@@ -55,7 +54,7 @@ export const ChatInput = ({ chat }) => {
   }, []);
 
   const searchArtifacts = useCallback((search) => {
-    loadArtifacts({ search, chat_id: chat.id});
+    loadArtifacts({ search, chat_id: chat.id });
   }, []);
 
   useEffect(() => {
@@ -226,11 +225,7 @@ export const ChatInput = ({ chat }) => {
       maxH="400px"
       overflowY="auto"
     >
-      <Popover
-        isOpen={isOpen}
-        placement="top-start"
-        initialFocusRef={focusRef}
-      >
+      <Popover isOpen={isOpen} placement="top-start" initialFocusRef={focusRef}>
         <PopoverAnchor>
           <Box ref={focusRef} width={1}></Box>
         </PopoverAnchor>

--- a/frontend/chat/input/ChatInput.js
+++ b/frontend/chat/input/ChatInput.js
@@ -45,13 +45,10 @@ export const ChatInput = ({ chat }) => {
     []
   );
 
-  const { load: loadAgents, page: agentPage } = usePaginatedAPI(`/api/agents/`, {
-    load: false,
-  });
+  const { load: loadAgents, page: agentPage } = usePaginatedAPI(`/api/agents/`);
 
-  const { load: loadArtifacts, page: artifactPage } = usePaginatedAPI(`/api/artifacts/`, {
-    load: false,
-  });
+  const { load: loadArtifacts, page: artifactPage } =
+    usePaginatedAPI(`/api/artifacts/`);
 
   const searchAgents = useCallback((search) => {
     loadAgents({ search, chat_id: chat.id });

--- a/frontend/chat/sidebar/SideBarAgentList.js
+++ b/frontend/chat/sidebar/SideBarAgentList.js
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect} from "react";
+import React, { useCallback, useEffect } from "react";
 import { HStack, VStack, Text, Box, useColorModeValue } from "@chakra-ui/react";
 import AssistantAvatar from "chat/AssistantAvatar";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -6,7 +6,7 @@ import { faSquareMinus, faUserPlus } from "@fortawesome/free-solid-svg-icons";
 import RemoveAgentModalTrigger from "chat/agents/RemoveAgentModalTrigger";
 import AddAgentModalTrigger from "chat/agents/AddAgentModalTrigger";
 import { useColorMode } from "@chakra-ui/color-mode";
-import {usePaginatedAPI} from "utils/hooks/usePaginatedAPI";
+import { usePaginatedAPI } from "utils/hooks/usePaginatedAPI";
 
 const AgentListItem = ({ chat, agent, onUpdateAgents }) => {
   const avatarColor = useColorModeValue("gray.700", "gray.400");
@@ -42,14 +42,19 @@ const AgentListItem = ({ chat, agent, onUpdateAgents }) => {
 const SideBarAgentList = ({ graph }) => {
   const { colorMode } = useColorMode();
   const lead = graph.lead;
-  const { load: loadAgents, page: agentPage } = usePaginatedAPI(`/api/agents/`, {limit: 10000, load: false})
+  const { load: loadAgents, page: agentPage } = usePaginatedAPI(
+    `/api/agents/`,
+    { limit: 10000, load: false }
+  );
   const agents = agentPage?.objects;
-  const queryArgs = {chat_id: graph.chat.id};
+  const queryArgs = { chat_id: graph.chat.id };
   const onUpdateAgents = useCallback(() => {
     loadAgents(queryArgs);
   }, [loadAgents]);
 
-  useEffect(() => {loadAgents(queryArgs)}, [loadAgents, graph.chat.id])
+  useEffect(() => {
+    loadAgents(queryArgs);
+  }, [loadAgents, graph.chat.id]);
 
   return (
     <Box
@@ -72,7 +77,11 @@ const SideBarAgentList = ({ graph }) => {
           Agents
         </Text>
         <Box width="100%" align="right">
-          <AddAgentModalTrigger graph={graph} chatAgents={agents} onSuccess={onUpdateAgents}>
+          <AddAgentModalTrigger
+            graph={graph}
+            chatAgents={agents}
+            onSuccess={onUpdateAgents}
+          >
             <FontAwesomeIcon icon={faUserPlus} />
           </AddAgentModalTrigger>
         </Box>

--- a/frontend/components/Pagination.js
+++ b/frontend/components/Pagination.js
@@ -16,7 +16,7 @@ export const Pagination = ({
 }) => {
   const handleClick = (page) => {
     const offset = (page - 1) * 10;
-    load(10, offset);
+    load({limit: 10, offset});
   };
 
   return (

--- a/frontend/utils/hooks/useAxios.js
+++ b/frontend/utils/hooks/useAxios.js
@@ -1,0 +1,48 @@
+import { useCallback, useState } from "react";
+import axios from "axios";
+
+export const useAxios = (
+  { onSuccess, onError, method = "get" } = {},
+  dependencies = []
+) => {
+  const [response, setResponse] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const onSuccessGlobal = onSuccess;
+  const onErrorGlobal = onError;
+
+  const call = useCallback(async (url, { data, onSuccess, onError } = {}) => {
+    setIsLoading(true);
+
+    try {
+      const args = data ? [url, data] : [url];
+      const _response = await axios[method](...args);
+      if (onSuccessGlobal) {
+        onSuccessGlobal(_response);
+      }
+      if (onSuccess) {
+        onSuccess(_response);
+      }
+      setResponse(_response);
+      return _response;
+    } catch (err) {
+      setError(err);
+      if (onErrorGlobal) {
+        onErrorGlobal(err);
+      }
+      if (onError) {
+        onError(err);
+      }
+      throw error;
+    } finally {
+      setIsLoading(false);
+    }
+  }, dependencies);
+
+  return {
+    call,
+    response,
+    isLoading,
+    error,
+  };
+};

--- a/frontend/utils/hooks/useAxiosDelete.js
+++ b/frontend/utils/hooks/useAxiosDelete.js
@@ -1,0 +1,8 @@
+import { useAxios } from "utils/hooks/useAxios";
+
+export const useAxiosDelete = (
+  { onSuccess, onError } = {},
+  dependencies = []
+) => {
+  return useAxios({ onSuccess, onError, method: "delete" }, dependencies);
+};

--- a/frontend/utils/hooks/useCreateUpdateAPI.js
+++ b/frontend/utils/hooks/useCreateUpdateAPI.js
@@ -9,7 +9,7 @@ import useUpdateAPI from "utils/hooks/useUpdateAPI";
  */
 export const useCreateUpdateAPI = (createURL, updateURL) => {
   const { create, isLoading: isCreateLoading } = useCreateAPI(createURL);
-  const { update, isLoading: isUpdateLoading } = useUpdateAPI(updateURL);
+  const { call: update, isLoading: isUpdateLoading } = useUpdateAPI(updateURL);
 
   const save = async (data) => {
     if (data.id) {

--- a/frontend/utils/hooks/useDetailAPI.js
+++ b/frontend/utils/hooks/useDetailAPI.js
@@ -1,32 +1,26 @@
-import { useState, useEffect, useCallback } from "react";
-import axios from "axios";
+import { useAxios } from "utils/hooks/useAxios";
+import { useCallback } from "react";
 
-export const useDetailAPI = (endpoint, { load = true } = {}) => {
-  const [data, setData] = useState(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState(null);
+export const useDetailAPI = (
+  url,
+  { onSuccess, onError, auto = false } = {},
+  dependencies = []
+) => {
+  const { call, isLoading, error, response } = useAxios(
+    { onSuccess, onError, method: "get" },
+    dependencies
+  );
 
-  const loadData = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const response = await axios.get(endpoint);
-      setData(response.data);
-    } catch (err) {
-      setError(err);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [endpoint]);
-
-  useEffect(() => {
-    if (load) {
-      loadData();
-    }
-  }, [endpoint, load]);
+  const get = useCallback(
+    (args) => {
+      return call(url, ...(args || []));
+    },
+    [url, call]
+  );
 
   return {
-    data,
-    load: loadData,
+    response,
+    call: get,
     isLoading,
     error,
   };

--- a/frontend/utils/hooks/useUpdateAPI.js
+++ b/frontend/utils/hooks/useUpdateAPI.js
@@ -1,28 +1,25 @@
-import { useCallback, useState } from "react";
-import axios from "axios";
+import { useCallback } from "react";
+import { useAxios } from "utils/hooks/useAxios";
 
-const useUpdateAPI = (url, { onSuccess, onError } = {}) => {
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState(null);
+const useUpdateAPI = (
+  url,
+  { onSuccess, onError, method = "put", dependencies = [] } = {}
+) => {
+  const { call, isLoading, error, response } = useAxios(
+    { onSuccess, onError, method },
+    dependencies
+  );
 
   const update = useCallback(
-    async (data) => {
-      setIsLoading(true);
-      try {
-        const response = await axios.put(url, data);
-        setIsLoading(false);
-        return response.data;
-      } catch (err) {
-        setIsLoading(false);
-        setError(err);
-        throw err;
-      }
+    (data, config = {}) => {
+      return call(url, { data, ...config });
     },
-    [url]
+    [url, call]
   );
 
   return {
-    update,
+    call: update,
+    response,
     isLoading,
     error,
   };

--- a/ix/api/chains/endpoints.py
+++ b/ix/api/chains/endpoints.py
@@ -240,9 +240,9 @@ async def update_chain_node(node_id: UUID, data: UpdateNode):
     response_model=NodePydantic,
     tags=["Chain Editor"],
 )
-async def update_chain_node_position(node_id: UUID, position: Position):
+async def update_chain_node_position(node_id: UUID, data: PositionUpdate):
     node = await ChainNode.objects.aget(id=node_id)
-    node.position = position.dict()
+    node.position = data.dict()
     await node.asave(update_fields=["position"])
     return NodePydantic.from_orm(node)
 
@@ -260,8 +260,8 @@ async def delete_chain_node(node_id: UUID):
 
 
 @router.post("/chains/edges", response_model=EdgePydantic, tags=["Chain Editor"])
-async def add_chain_edge(edge: EdgePydantic):
-    new_edge = ChainEdge(**edge.dict())
+async def add_chain_edge(data: EdgePydantic):
+    new_edge = ChainEdge(**data.dict())
     await new_edge.asave()
     return EdgePydantic.from_orm(new_edge)
 
@@ -277,12 +277,12 @@ class UpdateEdge(BaseModel):
 @router.put(
     "/chains/edges/{edge_id}", response_model=EdgePydantic, tags=["Chain Editor"]
 )
-async def update_chain_edge(edge_id: UUID, edge: UpdateEdge):
+async def update_chain_edge(edge_id, data: UpdateEdge):
     try:
         existing_edge = await ChainEdge.objects.aget(id=edge_id)
     except ChainEdge.DoesNotExist:
         raise HTTPException(status_code=404, detail="Edge not found")
-    as_dict = edge.dict()
+    as_dict = data.dict()
     for field, value in as_dict.items():
         setattr(existing_edge, field, value)
     await existing_edge.asave(update_fields=as_dict.keys())

--- a/ix/api/chains/endpoints.py
+++ b/ix/api/chains/endpoints.py
@@ -168,7 +168,7 @@ class UpdateRoot(BaseModel):
 
 
 @router.post(
-    "/chains/{chain_id}/set_root/", response_model=UpdatedRoot, tags=["Chain Editor"]
+    "/chains/{chain_id}/set_root", response_model=UpdatedRoot, tags=["Chain Editor"]
 )
 async def set_chain_root(chain_id: UUID, update_root: UpdateRoot):
     # update old roots:

--- a/ix/api/chains/endpoints.py
+++ b/ix/api/chains/endpoints.py
@@ -14,6 +14,7 @@ from ix.api.chains.types import (
     ChainQueryPage,
     PositionUpdate,
     NodeTypePage,
+    CreateChain,
 )
 from ix.api.chains.types import NodeType as NodeTypePydantic
 from ix.api.chains.types import Node as NodePydantic
@@ -45,7 +46,7 @@ async def get_chains(search: Optional[str] = None, limit: int = 10, offset: int 
 
 
 @router.post("/chains/", response_model=ChainPydantic, tags=["Chains"])
-async def create_chain(chain: ChainPydantic):
+async def create_chain(chain: CreateChain):
     new_chain = Chain(**chain.dict())
     await new_chain.asave()
     return ChainPydantic.from_orm(new_chain)

--- a/ix/api/chains/endpoints.py
+++ b/ix/api/chains/endpoints.py
@@ -194,8 +194,8 @@ class AddNode(BaseModel):
     id: Optional[UUID]
     chain_id: Optional[UUID]
     class_path: str
-    name: str
-    description: str
+    name: Optional[str]
+    description: Optional[str]
     config: Optional[dict]
     position: Optional[Position]
 

--- a/ix/api/chains/endpoints.py
+++ b/ix/api/chains/endpoints.py
@@ -269,9 +269,6 @@ async def add_chain_edge(data: EdgePydantic):
 class UpdateEdge(BaseModel):
     source_id: UUID
     target_id: UUID
-    key: str
-    relation: Literal["LINK", "PROP"]
-    input_map: Optional[dict]
 
 
 @router.put(

--- a/ix/api/chains/types.py
+++ b/ix/api/chains/types.py
@@ -280,3 +280,8 @@ class Edge(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class PositionUpdate(BaseModel):
+    x: float
+    y: float

--- a/ix/api/chains/types.py
+++ b/ix/api/chains/types.py
@@ -249,6 +249,11 @@ class NodeType(BaseModel):
         return schema
 
 
+class NodeTypePage(QueryPage[NodeType]):
+    # override objects, FastAPI isn't detecting QueryPage type
+    objects: List[NodeType]
+
+
 class Node(BaseModel):
     id: UUID = Field(default_factory=uuid4)
     chain_id: UUID

--- a/ix/api/chains/types.py
+++ b/ix/api/chains/types.py
@@ -39,6 +39,11 @@ class Chain(BaseModel):
         orm_mode = True
 
 
+class CreateChain(BaseModel):
+    name: str
+    description: Optional[str]
+
+
 class ChainQueryPage(QueryPage[Chain]):
     # override objects, FastAPI isn't detecting QueryPage type
     objects: List[Chain]

--- a/ix/api/chains/types.py
+++ b/ix/api/chains/types.py
@@ -264,6 +264,7 @@ class Node(BaseModel):
     chain_id: UUID
     class_path: str = Field(..., title="The path to the class")
     node_type_id: Optional[UUID]
+    root: bool = False
 
     config: dict = Field(default_factory=dict)
     name: Optional[str]

--- a/ix/api/tests/test_chains.py
+++ b/ix/api/tests/test_chains.py
@@ -524,9 +524,6 @@ class TestChainEdge:
         data = {
             "source_id": str(node1.id),
             "target_id": str(node2.id),
-            "key": "Updated Key",
-            "relation": "LINK",
-            "input_map": {"param1": "value1", "param2": "value2"},
         }
 
         async with AsyncClient(app=app, base_url="http://test") as ac:
@@ -536,8 +533,6 @@ class TestChainEdge:
         assert response.status_code == 200, response.json()
         edge_data = response.json()
         assert edge_data["id"] == str(edge.id)
-        assert edge_data["key"] == "Updated Key"
-        assert edge_data["input_map"] == {"param1": "value1", "param2": "value2"}
 
     async def test_delete_chain_edge(self, anode_types):
         # Create a chain edge to delete

--- a/ix/api/tests/test_chains.py
+++ b/ix/api/tests/test_chains.py
@@ -28,10 +28,11 @@ class TestNodeType:
             response = await ac.get("/node_types/")
 
         assert response.status_code == 200, response.content
-        result = response.json()
+        page = response.json()
 
         # Check that we got a list of node types
-        assert len(result) >= 2
+        objects = page["objects"]
+        assert len(objects) >= 2
 
     async def test_search_node_types(self, anode_types):
         search_term = "mock"
@@ -40,13 +41,14 @@ class TestNodeType:
             response = await ac.get(f"/node_types/?search={search_term}")
 
         assert response.status_code == 200, response.content
-        result = response.json()
-        assert len(result) > 0
+        page = response.json()
+        objects = page["objects"]
+        assert len(objects) > 0
         assert (
-            search_term in result[0]["name"]
-            or search_term in result[0]["description"]
-            or search_term in result[0]["type"]
-            or search_term in result[0]["class_path"]
+            search_term in objects[0]["name"]
+            or search_term in objects[0]["description"]
+            or search_term in objects[0]["type"]
+            or search_term in objects[0]["class_path"]
         )
 
     async def test_get_node_type_detail(self, amock_node_type):

--- a/ix/api/tests/test_chains.py
+++ b/ix/api/tests/test_chains.py
@@ -229,20 +229,6 @@ class TestChain:
         result = response.json()
         assert result["name"] == "New Chain"
 
-    async def test_create_chain_with_id(self, anode_types):
-        chain_data = {
-            "id": str(uuid4()),
-            "name": "New Chain",
-            "description": "A new chain",
-        }
-
-        async with AsyncClient(app=app, base_url="http://test") as ac:
-            response = await ac.post("/chains/", json=chain_data)
-
-        assert response.status_code == 200, response.content
-        result = response.json()
-        assert result["id"] == str(chain_data["id"])
-
     async def test_update_chain(self, anode_types):
         # Create a chain to update
         chain = await afake_chain()

--- a/ix/api/tests/test_chains.py
+++ b/ix/api/tests/test_chains.py
@@ -309,7 +309,7 @@ class TestChainRoot:
         data = {"node_id": str(node.id)}
 
         async with AsyncClient(app=app, base_url="http://test") as ac:
-            response = await ac.post(f"/chains/{chain.id}/set_root/", json=data)
+            response = await ac.post(f"/chains/{chain.id}/set_root", json=data)
 
         assert response.status_code == 200
         result = response.json()
@@ -325,7 +325,7 @@ class TestChainRoot:
 
         data = {"node_id": str(new_root.id), "chain_id": str(chain.id)}
         async with AsyncClient(app=app, base_url="http://test") as ac:
-            response = await ac.post(f"/chains/{chain.id}/set_root/", json=data)
+            response = await ac.post(f"/chains/{chain.id}/set_root", json=data)
 
         assert response.status_code == 200
         result = response.json()
@@ -342,7 +342,7 @@ class TestChainRoot:
         data = {"node_id": None, "chain_id": str(chain.id)}
 
         async with AsyncClient(app=app, base_url="http://test") as ac:
-            response = await ac.post(f"/chains/{chain.id}/set_root/", json=data)
+            response = await ac.post(f"/chains/{chain.id}/set_root", json=data)
 
         assert response.status_code == 200, response.content
         result = response.json()


### PR DESCRIPTION
### Description
This converts the chain editor to use FastAPI endpoints.  All API should now route through FastAPI.

### Changes
#### Chain Editor now uses FastAPI:
- graph load
- node add/update/delete/position
- edge add/update/delete
- chain name

#### API
- refined axios hooks to reduce duplicate code


### How Tested
- manual tested all features of chain editor

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
