### PR TITLE
Fastapi link edge validation

### DIFF
--- a/ix/api/chains/types.py
+++ b/ix/api/chains/types.py
@@ -280,13 +280,20 @@ class Edge(BaseModel):
     id: UUID = Field(default_factory=uuid4)
     source_id: UUID
     target_id: UUID
-    key: str
+    key: Optional[str]
     chain_id: UUID
     relation: Literal["LINK", "PROP"]
     input_map: Optional[dict]
 
     class Config:
         orm_mode = True
+
+    @root_validator
+    def validate_edge(cls, values):
+        if values.get("relation") == "PROP" and not values.get("key"):
+            raise ValueError("'key' is required for 'PROP' relation type.")
+
+        return values
 
 
 class PositionUpdate(BaseModel):

--- a/ix/chains/fixtures/pirate_v1.json
+++ b/ix/chains/fixtures/pirate_v1.json
@@ -87,7 +87,7 @@
     "fields": {
         "class_path": "ix.memory.artifacts.ArtifactMemory",
         "node_type": "98af8724-a765-490a-bfb6-2adf54102186",
-        "config": null,
+        "config": {},
         "name": null,
         "description": null,
         "root": false,


### PR DESCRIPTION
### Description
Fixing a bug with `@code` and `@pirate` due to pydantic validation errors. Both agents could respond to tasks but couldn't be opened in the chain editor.

### Changes
- Edges between chains now pass validation (`key` is allowed to be `None`)
- `@pirate` memory component was had a null `config` property.

### How Tested
- manual tests 

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
