### PR TITLE
NodeTypeFields.get_fields improvements

### DIFF
--- a/ix/chains/fixture_src/agent_interaction.py
+++ b/ix/chains/fixture_src/agent_interaction.py
@@ -11,7 +11,7 @@ DELEGATE_TO_AGENT_CHAIN = {
     "type": "chain",
     "connectors": [MEMORY_TARGET, PROMPT_TARGET],
     "fields": CHAIN_BASE_FIELDS
-    + NodeTypeField.get_fields(
+    + NodeTypeField.get_fields_from_model(
         DelegateToAgentChain,
         include=[
             "output_key",

--- a/ix/chains/fixture_src/chains.py
+++ b/ix/chains/fixture_src/chains.py
@@ -55,7 +55,7 @@ LLM_SYMBOLIC_MATH_CHAIN = {
     "fields": [
         VERBOSE,
     ]
-    + NodeTypeField.get_fields(
+    + NodeTypeField.get_fields_from_model(
         LLMSymbolicMathChain,
         include=["input_key", "output_key"],
         field_options={

--- a/ix/chains/fixture_src/llm.py
+++ b/ix/chains/fixture_src/llm.py
@@ -59,7 +59,7 @@ OPENAI_LLM = {
         {
             "name": "streaming",
             "type": "boolean",
-            "default": False,
+            "default": True,
         },
     ],
 }

--- a/ix/chains/fixture_src/tools.py
+++ b/ix/chains/fixture_src/tools.py
@@ -167,10 +167,8 @@ PUB_MED = {
         include=[
             "max_retry",
             "top_k_results",
-            "load_max_docs",
             "ARXIV_MAX_QUERY_LENGTH",
             "doc_content_chars_max",
-            "load_all_available_meta",
             "email",
         ],
     ),

--- a/ix/chains/fixture_src/tools.py
+++ b/ix/chains/fixture_src/tools.py
@@ -45,7 +45,7 @@ ARXIV_SEARCH = {
     "name": " search",
     "description": "Tool that searches Arxiv for a given query.",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields(
+    + NodeTypeField.get_fields_from_model(
         ArxivAPIWrapper,
         include=[
             "top_k_results",
@@ -63,7 +63,7 @@ BING_SEARCH = {
     "name": "Bing Search",
     "description": "Tool that searches Bing for a given query.",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields(
+    + NodeTypeField.get_fields_from_model(
         BingSearchAPIWrapper,
         include=["bing_subscription_key", "bing_search_url", "k"],
         field_options={
@@ -92,7 +92,7 @@ DUCK_DUCK_GO_SEARCH = {
     "name": "DuckDuckGo Search",
     "description": "Tool that searches DuckDuckGo for a given query.",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields(
+    + NodeTypeField.get_fields_from_model(
         DuckDuckGoSearchAPIWrapper,
         include=["k", "region", "safesearch", "time", "max_results"],
     ),
@@ -104,7 +104,7 @@ GOOGLE_SEARCH = {
     "name": "Google Search",
     "description": "Tool that searches Google for a given query.",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields(
+    + NodeTypeField.get_fields_from_model(
         GoogleSearchAPIWrapper,
         include=["google_api_key", "google_cse_id", "k", "siterestrict"],
         field_options={
@@ -124,7 +124,7 @@ GOOGLE_SERPER = {
     "name": "Google Serper",
     "description": "Tool that searches Google for a given query.",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields(
+    + NodeTypeField.get_fields_from_model(
         GoogleSerperAPIWrapper,
         include=["k", "gl", "hl", "type", "tbs", "serper_api_key"],
         field_options={
@@ -141,7 +141,9 @@ GRAPHQL_TOOL = {
     "name": "GraphQL Tool",
     "description": "Tool that searches GraphQL for a given query.",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields(GraphQLAPIWrapper, include=["graphql_endpoint"]),
+    + NodeTypeField.get_fields_from_model(
+        GraphQLAPIWrapper, include=["graphql_endpoint"]
+    ),
 }
 
 LAMBDA_API = {
@@ -150,7 +152,7 @@ LAMBDA_API = {
     "name": "Lambda API",
     "description": "Tool that searches Lambda for a given query.",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields(
+    + NodeTypeField.get_fields_from_model(
         LambdaWrapper,
         include=["function_name", "awslambda_tool_name", "awslambda_tool_description"],
     ),
@@ -162,7 +164,7 @@ PUB_MED = {
     "class_path": "ix.tools.pubmed.get_pubmed",
     "type": "tool",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields(
+    + NodeTypeField.get_fields_from_model(
         PubMedAPIWrapper,
         include=[
             "max_retry",
@@ -180,7 +182,7 @@ WIKIPEDIA = {
     "class_path": "ix.tools.wikipedia.get_wikipedia",
     "type": "tool",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields(
+    + NodeTypeField.get_fields_from_model(
         WikipediaAPIWrapper,
         include=[
             "top_k_results",

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -2611,24 +2611,10 @@
         "required": false
       },
       {
-        "name": "load_max_docs",
-        "type": "int",
-        "label": "Load_max_docs",
-        "default": 25,
-        "required": false
-      },
-      {
         "name": "doc_content_chars_max",
         "type": "int",
         "label": "Doc_content_chars_max",
         "default": 2000,
-        "required": false
-      },
-      {
-        "name": "load_all_available_meta",
-        "type": "boolean",
-        "label": "Load_all_available_meta",
-        "default": false,
         "required": false
       },
       {
@@ -2655,10 +2641,6 @@
           "type": "boolean",
           "default": false
         },
-        "load_max_docs": {
-          "type": "number",
-          "default": 25
-        },
         "return_direct": {
           "type": "boolean",
           "default": false
@@ -2670,10 +2652,6 @@
         "doc_content_chars_max": {
           "type": "number",
           "default": 2000
-        },
-        "load_all_available_meta": {
-          "type": "boolean",
-          "default": false
         }
       }
     }

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -750,6 +750,9 @@
       ],
       "properties": {
         "model_name": {
+          "enum": [
+            "textembedding-gecko"
+          ],
           "type": "string",
           "default": "textembedding-gecko"
         }
@@ -2258,6 +2261,9 @@
           "default": false
         },
         "model_name": {
+          "enum": [
+            "models/chat-bison-001"
+          ],
           "type": "string",
           "default": "gpt-4"
         },
@@ -3025,6 +3031,12 @@
           "default": 256
         },
         "model_name": {
+          "enum": [
+            "gpt-4",
+            "gpt-4-0613",
+            "gpt-3.5-turbo",
+            "gpt-3.5-turbo-16k-0613"
+          ],
           "type": "string",
           "default": "gpt-4-0613"
         },
@@ -3480,6 +3492,12 @@
           "default": "session_id"
         },
         "session_scope": {
+          "enum": [
+            "chat",
+            "agent",
+            "task",
+            "user"
+          ],
           "type": "string",
           "default": null
         },

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -2246,15 +2246,24 @@
       "properties": {
         "n": {
           "type": "number",
-          "default": 1
+          "default": 1,
+          "maximum": 5.0,
+          "minimum": 1.0,
+          "multipleOf": 1.0
         },
         "top_k": {
           "type": "number",
-          "default": 0
+          "default": 0,
+          "maximum": 2.0,
+          "minimum": 0.0,
+          "multipleOf": 0.05
         },
         "top_p": {
           "type": "number",
-          "default": 0
+          "default": 0,
+          "maximum": 2.0,
+          "minimum": 0.0,
+          "multipleOf": 0.05
         },
         "verbose": {
           "type": "boolean",
@@ -2269,7 +2278,10 @@
         },
         "temperature": {
           "type": "number",
-          "default": 0
+          "default": 0,
+          "maximum": 2.0,
+          "minimum": 0.0,
+          "multipleOf": 0.05
         },
         "google_api_key": {
           "type": "string",
@@ -2330,7 +2342,10 @@
       "properties": {
         "temperature": {
           "type": "number",
-          "default": 0
+          "default": 0,
+          "maximum": 2.0,
+          "minimum": 0.0,
+          "multipleOf": 0.05
         },
         "anthropic_api_key": {
           "type": "string",
@@ -3042,11 +3057,17 @@
         },
         "max_retries": {
           "type": "number",
-          "default": 6
+          "default": 6,
+          "maximum": 6.0,
+          "minimum": 0.0,
+          "multipleOf": 1.0
         },
         "temperature": {
           "type": "number",
-          "default": 0
+          "default": 0,
+          "maximum": 2.0,
+          "minimum": 0.0,
+          "multipleOf": 0.05
         },
         "request_timeout": {
           "type": "number",

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -511,7 +511,8 @@
           }
         ],
         "default": "search",
-        "required": false
+        "required": false,
+        "input_type": "select"
       },
       {
         "name": "tbs",
@@ -554,6 +555,12 @@
           "default": null
         },
         "type": {
+          "enum": [
+            "news",
+            "search",
+            "places",
+            "images"
+          ],
           "type": "string",
           "default": "search"
         },

--- a/ix/chains/tests/test_config.py
+++ b/ix/chains/tests/test_config.py
@@ -12,29 +12,41 @@ class TestModel(BaseModel):
     literal: Literal["foo", "bar"] = "bar"
     optional: Optional[str] = None
 
+    @staticmethod
+    def loader(
+        field1: str,
+        field2: int,
+        field3: bool = False,
+        literal: Literal["foo", "bar"] = "bar",
+        optional: Optional[str] = None,
+    ):
+        pass
+
+
+@pytest.fixture
+def field_overrides():
+    return {
+        "field1": {
+            "name": "field1",
+            "label": "Custom Field 1",
+            "type": "str",
+            "default": "custom_default",
+        }
+    }
+
+
+@pytest.fixture
+def valid_field_config():
+    return {
+        "name": "test_field",
+        "label": "Test Field",
+        "type": "int",
+        "default": 0,
+        "required": True,
+    }
+
 
 class TestFieldConfig:
-    @pytest.fixture
-    def field_overrides(self):
-        return {
-            "field1": {
-                "name": "field1",
-                "label": "Custom Field 1",
-                "type": "str",
-                "default": "custom_default",
-            }
-        }
-
-    @pytest.fixture
-    def valid_field_config(self):
-        return {
-            "name": "test_field",
-            "label": "Test Field",
-            "type": "int",
-            "default": 0,
-            "required": True,
-        }
-
     def test_slider_without_min_max(self, valid_field_config):
         valid_field_config["input_type"] = InputType.SLIDER
         with pytest.raises(
@@ -58,6 +70,13 @@ class TestFieldConfig:
         ):
             NodeTypeField(**valid_field_config)
 
+
+class GetFieldsBase:
+    """Base for common tests for getting fields from a model or method"""
+
+    def get_fields(self, *args, **kwargs):
+        raise NotImplementedError
+
     def test_get_fields_overrides_include(self, field_overrides):
         expected_fields_include = [
             {
@@ -77,7 +96,7 @@ class TestFieldConfig:
         ]
 
         assert (
-            NodeTypeField.get_fields(
+            self.get_fields(
                 TestModel,
                 include=["field1", "field2"],
                 field_options=field_overrides,
@@ -101,7 +120,7 @@ class TestFieldConfig:
         ]
 
         assert (
-            NodeTypeField.get_fields(
+            self.get_fields(
                 TestModel,
                 include=["literal"],
             )
@@ -120,7 +139,7 @@ class TestFieldConfig:
         ]
 
         assert (
-            NodeTypeField.get_fields(
+            self.get_fields(
                 TestModel,
                 include=["optional"],
             )
@@ -146,7 +165,7 @@ class TestFieldConfig:
         ]
 
         assert (
-            NodeTypeField.get_fields(
+            self.get_fields(
                 TestModel,
                 include=["field1", "field2", "field3"],
                 exclude=["field1"],
@@ -154,6 +173,11 @@ class TestFieldConfig:
             )
             == expected_fields_exclude
         )
+
+
+class TestGetFieldsFromModel(GetFieldsBase):
+    def get_fields(self, *args, **kwargs):
+        return NodeTypeField.get_fields_from_model(*args, **kwargs)
 
     def test_exclude_non_allowed_type(self, field_overrides):
         # Extend TestModel with a field of non-allowed type
@@ -181,6 +205,11 @@ class TestFieldConfig:
         ]
 
         assert (
-            NodeTypeField.get_fields(TestModel2, include=["field1", "field2", "field4"])
+            self.get_fields(TestModel2, include=["field1", "field2", "field4"])
             == expected_fields
         )
+
+
+class TestGetFieldsFromMethod(GetFieldsBase):
+    def get_fields(self, *args, **kwargs):
+        return NodeTypeField.get_fields_from_method(*args, **kwargs)

--- a/ix/chains/tests/test_config.py
+++ b/ix/chains/tests/test_config.py
@@ -1,8 +1,14 @@
+from enum import Enum
 from typing import Literal, Optional
 
 import pytest
 from pydantic import BaseModel
 from ix.api.chains.types import NodeTypeField, InputType
+
+
+class ChoicesEnum(str, Enum):
+    CPP = "cpp"
+    GO = "go"
 
 
 class TestModel(BaseModel):
@@ -11,6 +17,7 @@ class TestModel(BaseModel):
     field3: bool = False
     literal: Literal["foo", "bar"] = "bar"
     optional: Optional[str] = None
+    choices_enum: ChoicesEnum
 
     @staticmethod
     def loader(
@@ -110,6 +117,7 @@ class GetFieldsBase:
                 "name": "literal",
                 "label": "Literal",
                 "type": "str",
+                "input_type": "select",
                 "default": "bar",
                 "required": False,
                 "choices": [
@@ -173,6 +181,28 @@ class GetFieldsBase:
             )
             == expected_fields_exclude
         )
+
+    def test_get_enum_choices(self, field_overrides):
+        expected = [
+            {
+                "name": "choices_enum",
+                "label": "Choices_enum",
+                "default": None,
+                "type": "str",
+                "input_type": "select",
+                "required": True,
+                "choices": [
+                    {"label": "CPP", "value": "cpp"},
+                    {"label": "GO", "value": "go"},
+                ],
+            },
+        ]
+
+        fields = self.get_fields(
+            TestModel,
+            include=["choices_enum"],
+        )
+        assert fields == expected
 
 
 class TestGetFieldsFromModel(GetFieldsBase):


### PR DESCRIPTION
### Description
This PR expands the functionality of `NodeTypeFields.get_fields` helper.  

Primary update is to support parsing fields from methods.  Many retrieval components do not define expected types on the pydantic models. Rather they are only defined in `__init__` and other methods.  The updated helper allows the same easy extraction regardless of which source they are defined on.

### Changes
- `NodeTypeFields.get_fields` split into helpers for models and methods.
- `NodeTypeFields.get_fields` now parses choices from Enums
- `NodeTypeFields.get_fields` now sets `field.input_type` to `select` for fields with choices.

### How Tested
- new and updated unittests

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
