### PR TITLE
Support for Chroma vector database

### DIFF
--- a/ix/chains/components/vectorstores.py
+++ b/ix/chains/components/vectorstores.py
@@ -3,7 +3,7 @@ from typing import Any, List, Iterable, Optional
 from asgiref.sync import sync_to_async
 from langchain.callbacks.manager import AsyncCallbackManagerForRetrieverRun
 from langchain.schema import Document
-from langchain.vectorstores import Redis, VectorStore
+from langchain.vectorstores import Redis, Chroma, VectorStore
 from langchain.vectorstores.redis import RedisVectorStoreRetriever
 
 
@@ -45,3 +45,7 @@ class AsyncRedisVectorstore(AsyncAddTextsMixin, Redis):
         tags = kwargs.pop("tags", None) or []
         tags.extend(self._get_retriever_tags())
         return AsyncRedisVectorStoreRetriever(vectorstore=self, **kwargs, tags=tags)
+
+
+class AsyncChromaVectorstore(AsyncAddTextsMixin, Chroma):
+    """Extension of Langchain Chroma vectorstore implementation to add async support"""

--- a/ix/chains/fixture_src/vectorstores.py
+++ b/ix/chains/fixture_src/vectorstores.py
@@ -1,3 +1,4 @@
+from langchain.vectorstores import Chroma
 from langchain.vectorstores.base import VectorStoreRetriever
 from langchain.vectorstores.redis import RedisVectorStoreRetriever
 
@@ -77,6 +78,24 @@ REDIS_VECTORSTORE = {
     + REDIS_VECTORSTORE_RETRIEVER_FIELDS,
 }
 
+CHROMA_CLASS_PATH = "ix.chains.components.vectorstores.AsyncChromaVectorstore"
+CHROMA = {
+    "class_path": CHROMA_CLASS_PATH,
+    "type": "vectorstore",
+    "name": "Chroma",
+    "description": "Chroma vector database",
+    "connectors": VECTORSTORE_CONNECTORS,
+    "fields": NodeTypeField.get_fields_from_method(
+        Chroma,
+        include=[
+            "collection_name",
+            "persist_directory",
+            "persist_directory",
+        ],
+    )
+    + VECTORSTORE_RETRIEVER_FIELDS,
+}
+
 
 def get_vectorstore_retriever_fieldnames(class_path: str):
     fields = {REDIS_VECTORSTORE_CLASS_PATH: REDIS_VECTORSTORE_RETRIEVER_FIELDS}.get(
@@ -85,5 +104,5 @@ def get_vectorstore_retriever_fieldnames(class_path: str):
     return [field["name"] for field in fields]
 
 
-VECTORSTORES = [REDIS_VECTORSTORE]
+VECTORSTORES = [REDIS_VECTORSTORE, CHROMA]
 __all__ = ["VECTORSTORES"]

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -2821,6 +2821,91 @@
 },
 {
   "model": "chains.nodetype",
+  "pk": "9e8d970a-55ba-4afd-add9-bd33a52fc30c",
+  "fields": {
+    "name": "Chroma",
+    "description": "Chroma vector database",
+    "class_path": "ix.chains.components.vectorstores.AsyncChromaVectorstore",
+    "type": "vectorstore",
+    "display_type": "node",
+    "connectors": [
+      {
+        "key": "embedding",
+        "type": "target",
+        "source_type": "embeddings"
+      },
+      {
+        "key": "documents",
+        "type": "target",
+        "source_type": "text_splitter"
+      }
+    ],
+    "fields": [
+      {
+        "name": "collection_name",
+        "type": "str",
+        "label": "Collection_name",
+        "default": "langchain",
+        "required": false
+      },
+      {
+        "name": "persist_directory",
+        "type": "Optional[str]",
+        "label": "Persist_directory",
+        "default": null,
+        "required": false
+      },
+      {
+        "name": "allowed_search_types",
+        "type": "list",
+        "default": [
+          "similarity",
+          "similarity_score_threshold",
+          "mmr"
+        ],
+        "required": true
+      },
+      {
+        "name": "search_type",
+        "type": "str",
+        "label": "Search_type",
+        "default": "similarity",
+        "required": false
+      }
+    ],
+    "child_field": null,
+    "config_schema": {
+      "type": "object",
+      "required": [
+        "allowed_search_types"
+      ],
+      "properties": {
+        "search_type": {
+          "type": "string",
+          "default": "similarity"
+        },
+        "collection_name": {
+          "type": "string",
+          "default": "langchain"
+        },
+        "persist_directory": {
+          "type": "object",
+          "default": null
+        },
+        "allowed_search_types": {
+          "type": "object",
+          "default": [
+            "similarity",
+            "similarity_score_threshold",
+            "mmr"
+          ]
+        }
+      }
+    }
+  }
+},
+{
+  "model": "chains.nodetype",
   "pk": "a3dd72e8-1554-47dd-8f42-0dda58c06f7c",
   "fields": {
     "name": "Chat Conversational React Description Agent",

--- a/ix/chains/tests/components/test_vectorstores.py
+++ b/ix/chains/tests/components/test_vectorstores.py
@@ -1,0 +1,134 @@
+import pytest
+from langchain.vectorstores import Chroma, VectorStore
+
+from ix.chains.fixture_src.document_loaders import GENERIC_LOADER_CLASS_PATH
+from ix.chains.fixture_src.text_splitter import RECURSIVE_CHARACTER_SPLITTER_CLASS_PATH
+from ix.chains.fixture_src.vectorstores import (
+    CHROMA_CLASS_PATH,
+)
+from ix.chains.tests.test_config_loader import (
+    EMBEDDINGS,
+    TEXT_SPLITTER,
+    LANGUAGE_PARSER,
+)
+
+
+DOCUMENT_LOADER_EMPTY = {
+    "class_path": GENERIC_LOADER_CLASS_PATH,
+    "config": {
+        "parser": LANGUAGE_PARSER,
+        "path": "/var/doesnotexist",
+        "suffixes": [".does.not.exist"],
+        "glob": "doesnotexist",
+    },
+}
+
+TEXT_SPLITTER_EMPTY = {
+    "class_path": RECURSIVE_CHARACTER_SPLITTER_CLASS_PATH,
+    "config": {"language": "python", "document_loader": DOCUMENT_LOADER_EMPTY},
+}
+
+TEST_TEXTS = [
+    "def foo1():\n    print('hello world foo1')",
+    "def foo2():\n    print('hello world foo2')",
+    "def bar3():\n    print('hello world bar3')",
+    "def bar4():\n    print('hello world bar4')",
+    "def bar5():\n    print('hello world bar5')",
+]
+
+TEXT_KWARGS = {
+    "texts": TEST_TEXTS,
+    "ids": ["foo1", "foo2", "bar3", "bar4", "bar5"],
+    "metadatas": [{"foo": "bar"}] * len(TEST_TEXTS),
+}
+
+
+class VectorStoreTestMixin:
+    """Test loading retrieval components.
+
+    This is a test of loading mechanism for the various retrieval components.
+    It is not an exhaustive test that all retrieval components work as expected.
+    The tests verify that any special loading logic for the components is working.
+    """
+
+    CLASS = None
+    CONFIG = None
+    CONFIG_WITH_DOCUMENTS = None
+    CONFIG_WITH_EMPTY_DOCUMENTS = None
+
+    async def test_load_vectorstore(self, aload_chain, mock_openai_embeddings):
+        vectorstore: VectorStore = await aload_chain(self.CONFIG)
+        assert isinstance(vectorstore, self.CLASS)
+
+        ids = await vectorstore.aadd_texts(**TEXT_KWARGS)
+        results = await vectorstore.asearch("foo", "similarity")
+        assert len(results) == 4
+        assert results[0].metadata["foo"] == "bar"
+
+        vectorstore.delete(ids)
+        vectorstore.delete_collection()
+
+    async def test_load_vectorstore_with_document_source(
+        self, mock_import_class, aload_chain, mock_openai_embeddings
+    ):
+        vectorstore: VectorStore = await aload_chain(self.CONFIG_WITH_DOCUMENTS)
+        assert isinstance(vectorstore, self.CLASS)
+
+        ids = await vectorstore.aadd_texts(**TEXT_KWARGS)
+
+        results = await vectorstore.asearch("foo", "similarity")
+        assert len(results) == 4
+
+        vectorstore.delete(ids)
+        vectorstore.delete_collection()
+
+    async def test_load_vectorstore_with_empty_document_source(
+        self, aload_chain, mock_openai_embeddings
+    ):
+        vectorstore: VectorStore = await aload_chain(self.CONFIG_WITH_EMPTY_DOCUMENTS)
+        assert isinstance(vectorstore, self.CLASS)
+
+        ids = await vectorstore.aadd_texts(**TEXT_KWARGS)
+        results = await vectorstore.asearch("foo", "similarity")
+        assert len(results) == 4
+        assert results[0].metadata["foo"] == "bar"
+
+        vectorstore.delete(ids)
+        vectorstore.delete_collection()
+
+
+CHROMA_VECTORSTORE_WITH_EMPTY_DOCUMENTS = {
+    "class_path": CHROMA_CLASS_PATH,
+    "config": {
+        "embedding": EMBEDDINGS,
+        "documents": TEXT_SPLITTER_EMPTY,
+        "collection_name": "tests",
+    },
+}
+
+CHROMA_VECTORSTORE_WITH_DOCUMENTS = {
+    "class_path": CHROMA_CLASS_PATH,
+    "config": {
+        "embedding": EMBEDDINGS,
+        "documents": TEXT_SPLITTER,
+        "collection_name": "tests",
+    },
+}
+
+CHROMA_VECTORSTORE = {
+    "class_path": CHROMA_CLASS_PATH,
+    "config": {
+        "embedding": EMBEDDINGS,
+        "collection_name": "tests",
+    },
+}
+
+
+@pytest.mark.django_db
+class TestChroma(VectorStoreTestMixin):
+    """Test Chroma vectorstore component."""
+
+    CLASS = Chroma
+    CONFIG = CHROMA_VECTORSTORE
+    CONFIG_WITH_DOCUMENTS = CHROMA_VECTORSTORE_WITH_DOCUMENTS
+    CONFIG_WITH_EMPTY_DOCUMENTS = CHROMA_VECTORSTORE_WITH_EMPTY_DOCUMENTS

--- a/ix/conftest.py
+++ b/ix/conftest.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Any
+from typing import Dict, Any, List
 from unittest.mock import MagicMock
 
 import pytest
@@ -167,6 +167,11 @@ def mock_openai_streaming(mocker, mock_openai_key):
     yield mock_llm
 
 
+def fake_embeddings(n: int = 1) -> List[List[float]]:
+    """Fake a list of embeddings."""
+    return [[0.5 for x in range(1536)] for n in range(n)]
+
+
 @pytest.fixture
 def mock_openai_embeddings(mock_import_class, mock_openai_key):
     """Mocks OpenAIEmbeddings to return a mock response
@@ -174,12 +179,12 @@ def mock_openai_embeddings(mock_import_class, mock_openai_key):
     The mock embedding was generated for files test_data/documents
     with the real OpenAIEmbeddings component
     """
-    mock_instance = MagicMock()
-    mock_instance().embed_documents.return_value = MOCK_VECTORSTORE_EMBEDDINGS
-    mock_import_class(
-        OPENAI_EMBEDDINGS_CLASS_PATH,
-        mock_instance,
-    )
+    mock_class = MagicMock()
+    mock_class.instance = mock_class()
+    mock_class.instance.embed_documents.return_value = MOCK_VECTORSTORE_EMBEDDINGS
+    mock_class.instance.embed_query.return_value = fake_embeddings(n=1)[0]
+    mock_import_class(OPENAI_EMBEDDINGS_CLASS_PATH, mock_class)
+    yield mock_class.instance
 
 
 @pytest.fixture

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ celery==5.2.7
 celery-singleton==0.3.1
 channels==4.0.0
 channels_redis==4.1.0
+chromadb==0.4.6
 colorlog==6.7.0
 daphne==4.0.0
 django==4.2.2


### PR DESCRIPTION
### Description
Adds support for Chroma vector database. Compatible with `ConversationalRetrievalChain` and other components requiring a `vectorstore` or `retriever`

![image](https://github.com/kreneskyp/ix/assets/68635/bc74597f-fa3d-4574-aa79-dad28093e885)


### Changes
- Adds `Chroma` vectorstore component

### How Tested
- unittests for write/search/delete against local chromadb
- tested manually via editor + chat. Swapped out Redis for Chroma in a test agent.

### TODOs
Only local in-memory chroma tested. Need to support configuring connection + auth for dockerized and hosted chroma.