### PR TITLE
Tools: http requests

### DIFF
--- a/ix/chains/fixture_src/tools.py
+++ b/ix/chains/fixture_src/tools.py
@@ -176,6 +176,47 @@ PUB_MED = {
     ),
 }
 
+REQUESTS_DELETE = {
+    "name": "http_delete",
+    "description": "wrapper around python http requests delete method",
+    "class_path": "ix.tools.requests.get_tools_requests_delete",
+    "type": "tool",
+    "fields": TOOL_BASE_FIELDS,
+}
+
+REQUESTS_GET = {
+    "name": "http_get",
+    "description": "wrapper around python http requests get method. Used to"
+    "fetch response from a URL",
+    "class_path": "ix.tools.requests.get_tools_requests_get",
+    "type": "tool",
+    "fields": TOOL_BASE_FIELDS,
+}
+
+REQUESTS_PATCH = {
+    "name": "http_patch",
+    "description": "wrapper around python http requests patch method",
+    "class_path": "ix.tools.requests.get_tools_requests_patch",
+    "type": "tool",
+    "fields": TOOL_BASE_FIELDS,
+}
+
+REQUESTS_POST = {
+    "name": "http_post",
+    "description": "wrapper around python http requests post method",
+    "class_path": "ix.tools.requests.get_tools_requests_post",
+    "type": "tool",
+    "fields": TOOL_BASE_FIELDS,
+}
+
+REQUESTS_PUT = {
+    "name": "http_put",
+    "description": "wrapper around python http requests put method",
+    "class_path": "ix.tools.requests.get_tools_requests_put",
+    "type": "tool",
+    "fields": TOOL_BASE_FIELDS,
+}
+
 WIKIPEDIA = {
     "name": "Wikipedia",
     "description": "Wikipedia search engine",
@@ -192,7 +233,6 @@ WIKIPEDIA = {
         ],
     ),
 }
-
 
 WOLFRAM = {
     "name": "Wolfram Alpha",
@@ -222,6 +262,11 @@ TOOLS = [
     GRAPHQL_TOOL,
     LAMBDA_API,
     PUB_MED,
+    REQUESTS_DELETE,
+    REQUESTS_GET,
+    REQUESTS_PATCH,
+    REQUESTS_POST,
+    REQUESTS_PUT,
     WIKIPEDIA,
     WOLFRAM,
 ]

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -222,6 +222,48 @@
 },
 {
   "model": "chains.nodetype",
+  "pk": "0f840af2-aaf3-41a2-8a7d-05afd290661a",
+  "fields": {
+    "name": "http_delete",
+    "description": "wrapper around python http requests delete method",
+    "class_path": "ix.tools.requests.get_tools_requests_delete",
+    "type": "tool",
+    "display_type": "node",
+    "connectors": null,
+    "fields": [
+      {
+        "name": "return_direct",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "default": false
+      }
+    ],
+    "child_field": null,
+    "config_schema": {
+      "type": "object",
+      "required": [
+        "return_direct",
+        "verbose"
+      ],
+      "properties": {
+        "verbose": {
+          "type": "boolean",
+          "default": false
+        },
+        "return_direct": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
+  }
+},
+{
+  "model": "chains.nodetype",
   "pk": "151cbfff-6e65-4ed1-9c70-100deee0e873",
   "fields": {
     "name": "Parse JSON",
@@ -2053,6 +2095,90 @@
     ],
     "child_field": null,
     "config_schema": {}
+  }
+},
+{
+  "model": "chains.nodetype",
+  "pk": "7b699786-50ec-47d5-9286-7c793e21e57f",
+  "fields": {
+    "name": "http_put",
+    "description": "wrapper around python http requests put method",
+    "class_path": "ix.tools.requests.get_tools_requests_put",
+    "type": "tool",
+    "display_type": "node",
+    "connectors": null,
+    "fields": [
+      {
+        "name": "return_direct",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "default": false
+      }
+    ],
+    "child_field": null,
+    "config_schema": {
+      "type": "object",
+      "required": [
+        "return_direct",
+        "verbose"
+      ],
+      "properties": {
+        "verbose": {
+          "type": "boolean",
+          "default": false
+        },
+        "return_direct": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
+  }
+},
+{
+  "model": "chains.nodetype",
+  "pk": "7b9cedf1-598d-4852-a88c-293f9f512f8f",
+  "fields": {
+    "name": "http_patch",
+    "description": "wrapper around python http requests patch method",
+    "class_path": "ix.tools.requests.get_tools_requests_patch",
+    "type": "tool",
+    "display_type": "node",
+    "connectors": null,
+    "fields": [
+      {
+        "name": "return_direct",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "default": false
+      }
+    ],
+    "child_field": null,
+    "config_schema": {
+      "type": "object",
+      "required": [
+        "return_direct",
+        "verbose"
+      ],
+      "properties": {
+        "verbose": {
+          "type": "boolean",
+          "default": false
+        },
+        "return_direct": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
   }
 },
 {
@@ -4209,6 +4335,48 @@
 },
 {
   "model": "chains.nodetype",
+  "pk": "eda09bfa-d5ed-423e-91c4-b1544cce1db0",
+  "fields": {
+    "name": "http_post",
+    "description": "wrapper around python http requests post method",
+    "class_path": "ix.tools.requests.get_tools_requests_post",
+    "type": "tool",
+    "display_type": "node",
+    "connectors": null,
+    "fields": [
+      {
+        "name": "return_direct",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "default": false
+      }
+    ],
+    "child_field": null,
+    "config_schema": {
+      "type": "object",
+      "required": [
+        "return_direct",
+        "verbose"
+      ],
+      "properties": {
+        "verbose": {
+          "type": "boolean",
+          "default": false
+        },
+        "return_direct": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
+  }
+},
+{
+  "model": "chains.nodetype",
   "pk": "ef8a1cc4-a26c-4b95-b9f7-2d6ce0f176d0",
   "fields": {
     "name": "Bing Search",
@@ -4524,6 +4692,48 @@
           "default": false
         },
         "add_start_index": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
+  }
+},
+{
+  "model": "chains.nodetype",
+  "pk": "f9b3cc07-6224-4b0d-9970-2fd67b36703b",
+  "fields": {
+    "name": "http_get",
+    "description": "wrapper around python http requests get method. Used tofetch response from a URL",
+    "class_path": "ix.tools.requests.get_tools_requests_get",
+    "type": "tool",
+    "display_type": "node",
+    "connectors": null,
+    "fields": [
+      {
+        "name": "return_direct",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "default": false
+      }
+    ],
+    "child_field": null,
+    "config_schema": {
+      "type": "object",
+      "required": [
+        "return_direct",
+        "verbose"
+      ],
+      "properties": {
+        "verbose": {
+          "type": "boolean",
+          "default": false
+        },
+        "return_direct": {
           "type": "boolean",
           "default": false
         }

--- a/ix/tools/requests.py
+++ b/ix/tools/requests.py
@@ -1,0 +1,41 @@
+from langchain.requests import TextRequestsWrapper
+from langchain.tools import (
+    BaseTool,
+    RequestsDeleteTool,
+    RequestsPutTool,
+    RequestsPatchTool,
+    RequestsPostTool,
+    RequestsGetTool,
+)
+
+from ix.chains.loaders.tools import extract_tool_kwargs
+
+
+def get_tools_requests_get(**kwargs) -> BaseTool:
+    tool_kwargs = extract_tool_kwargs(kwargs)
+    wrapper = TextRequestsWrapper(**kwargs)
+    return RequestsGetTool(requests_wrapper=wrapper, **tool_kwargs)
+
+
+def get_tools_requests_post(**kwargs) -> BaseTool:
+    tool_kwargs = extract_tool_kwargs(kwargs)
+    wrapper = TextRequestsWrapper(**kwargs)
+    return RequestsPostTool(requests_wrapper=wrapper, **tool_kwargs)
+
+
+def get_tools_requests_patch(**kwargs) -> BaseTool:
+    tool_kwargs = extract_tool_kwargs(kwargs)
+    wrapper = TextRequestsWrapper(**kwargs)
+    return RequestsPatchTool(requests_wrapper=wrapper, **tool_kwargs)
+
+
+def get_tools_requests_put(**kwargs) -> BaseTool:
+    tool_kwargs = extract_tool_kwargs(kwargs)
+    wrapper = TextRequestsWrapper(**kwargs)
+    return RequestsPutTool(requests_wrapper=wrapper, **tool_kwargs)
+
+
+def get_tools_requests_delete(**kwargs) -> BaseTool:
+    tool_kwargs = extract_tool_kwargs(kwargs)
+    wrapper = TextRequestsWrapper(**kwargs)
+    return RequestsDeleteTool(requests_wrapper=wrapper, **tool_kwargs)


### PR DESCRIPTION
### Description
Adds tools for http requests via `requests` lib. Includes GET, PATCH, POST, PUT, DELETE.

![image](https://github.com/kreneskyp/ix/assets/68635/982a058d-5045-4d04-8a20-514da2656751)

Raw HTTP requests enable a generic way to interact with the web. Most useful with services that don't offer an OpenAPI compliant interface.

![image](https://github.com/kreneskyp/ix/assets/68635/97e57bf8-e710-4dd8-8f2f-a01b5280646c)

### Changes
- adds individual component definitions for GET, PATCH, POST, PUT, DELETE.


### How Tested
- [ ] new unittests

### TODOs
- [ ] Components can be added to agents but don't appear to work yet. Some conflicting initialization of auth info when used with `OpenAIFunctionAgent`

```
File "/var/app/ix/agents/process.py", line 66, in chat_with_ai
    return await chain.arun(callbacks=[handler], **extra_kwargs, **user_input)
File "/var/app/langchain/libs/langchain/langchain/chains/base.py", line 557, in arun
    await self.acall(
File "/var/app/langchain/libs/langchain/langchain/chains/base.py", line 350, in acall
    raise e
File "/var/app/langchain/libs/langchain/langchain/chains/base.py", line 344, in acall
    await self._acall(inputs, run_manager=run_manager)
File "/var/app/langchain/libs/langchain/langchain/agents/agent.py", line 1085, in _acall
    next_step_output = await self._atake_next_step(
File "/var/app/langchain/libs/langchain/langchain/agents/agent.py", line 1011, in _atake_next_step
    result = await asyncio.gather(
File "/var/app/langchain/libs/langchain/langchain/agents/agent.py", line 989, in _aperform_agent_action
    observation = await tool.arun(
File "/var/app/langchain/libs/langchain/langchain/tools/base.py", line 434, in arun
    raise e
File "/var/app/langchain/libs/langchain/langchain/tools/base.py", line 406, in arun
    await self._arun(*tool_args, run_manager=run_manager, **tool_kwargs)
File "/var/app/langchain/libs/langchain/langchain/tools/requests/tool.py", line 50, in _arun
    return await self.requests_wrapper.aget(_clean_url(url))
File "/var/app/langchain/libs/langchain/langchain/utilities/requests.py", line 161, in aget
    async with self.requests.aget(url, **kwargs) as response:
File "/usr/local/lib/python3.11/contextlib.py", line 204, in __aenter__
    return await anext(self.gen)
File "/var/app/langchain/libs/langchain/langchain/utilities/requests.py", line 75, in aget
    async with self._arequest("GET", url, auth=self.auth, **kwargs) as response:
File "/usr/local/lib/python3.11/contextlib.py", line 204, in __aenter__
    return await anext(self.gen)
File "/var/app/langchain/libs/langchain/langchain/utilities/requests.py", line 60, in _arequest
    async with session.request(


```
![image](https://github.com/kreneskyp/ix/assets/68635/6b5a66b0-3459-4497-8fb5-7d6f6028315d)

