### PR TITLE
Get fields simplify

### DIFF
--- a/ix/api/chains/types.py
+++ b/ix/api/chains/types.py
@@ -200,6 +200,9 @@ class NodeTypeField(BaseModel):
         fields = []
         signature = inspect.signature(method)
 
+        # TODO: does not support @staticmethod, which drops first argument
+        #       when using inspect.signature.
+
         for param_name, param in signature.parameters.items():
             if include and param_name not in include:
                 continue

--- a/ix/api/chains/types.py
+++ b/ix/api/chains/types.py
@@ -187,7 +187,7 @@ class NodeTypeField(BaseModel):
                 )
             )
 
-        return cls.get_fields(field_objs, field_options)
+        return cls._get_fields(field_objs, field_options)
 
     @classmethod
     def get_fields_from_method(
@@ -212,7 +212,6 @@ class NodeTypeField(BaseModel):
             else:
                 is_required = False
                 default = param.default
-
             fields.append(
                 ParsedField(
                     name=param_name,
@@ -222,10 +221,10 @@ class NodeTypeField(BaseModel):
                 )
             )
 
-        return cls.get_fields(fields, field_options)
+        return cls._get_fields(fields, field_options)
 
     @staticmethod
-    def get_fields(
+    def _get_fields(
         fields: List[ParsedField],
         field_options: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> List[Dict[str, Any]]:
@@ -275,6 +274,25 @@ class NodeTypeField(BaseModel):
             results.append(field_info)
 
         return results
+
+    @classmethod
+    def get_fields(
+        cls,
+        obj: Callable | Type[BaseModel] | Type[ABC],
+        include: Optional[List[str]] = None,
+        exclude: Optional[List[str]] = None,
+        field_options: Optional[Dict[str, Dict[str, Any]]] = None,
+    ):
+        if isinstance(obj, type) and issubclass(obj, BaseModel | ABC):
+            return cls.get_fields_from_model(
+                obj, include=include, exclude=exclude, field_options=field_options
+            )
+        elif isinstance(obj, Callable):
+            return cls.get_fields_from_method(
+                obj, include=include, exclude=exclude, field_options=field_options
+            )
+
+        raise ValueError(f"Invalid object type: {type(obj)}")
 
 
 NodeTypes = Literal[

--- a/ix/chains/fixture_src/agent_interaction.py
+++ b/ix/chains/fixture_src/agent_interaction.py
@@ -11,7 +11,7 @@ DELEGATE_TO_AGENT_CHAIN = {
     "type": "chain",
     "connectors": [MEMORY_TARGET, PROMPT_TARGET],
     "fields": CHAIN_BASE_FIELDS
-    + NodeTypeField.get_fields_from_model(
+    + NodeTypeField.get_fields(
         DelegateToAgentChain,
         include=[
             "output_key",

--- a/ix/chains/fixture_src/chains.py
+++ b/ix/chains/fixture_src/chains.py
@@ -60,7 +60,7 @@ LLM_SYMBOLIC_MATH_CHAIN = {
     "fields": [
         VERBOSE,
     ]
-    + NodeTypeField.get_fields_from_model(
+    + NodeTypeField.get_fields(
         LLMSymbolicMathChain,
         include=["input_key", "output_key"],
         field_options={
@@ -71,7 +71,7 @@ LLM_SYMBOLIC_MATH_CHAIN = {
     ),
 }
 
-BASE_CONVERSATIONAL_RETRIEVAL_CHAIN_FIELDS = NodeTypeField.get_fields_from_model(
+BASE_CONVERSATIONAL_RETRIEVAL_CHAIN_FIELDS = NodeTypeField.get_fields(
     BaseConversationalRetrievalChain,
     include=[
         "output_key",
@@ -98,7 +98,7 @@ CONVERSATIONAL_RETRIEVAL_CHAIN = {
         VERBOSE,
     ]
     + BASE_CONVERSATIONAL_RETRIEVAL_CHAIN_FIELDS
-    + NodeTypeField.get_fields_from_model(
+    + NodeTypeField.get_fields(
         ConversationalRetrievalChain,
         include=["max_tokens_limit"],
     ),

--- a/ix/chains/fixture_src/document_loaders.py
+++ b/ix/chains/fixture_src/document_loaders.py
@@ -30,7 +30,7 @@ GENERIC_LOADER = {
     "name": "Filesystem Loader",
     "description": "Load documents from the filesystem.",
     "fields": [PATH_FIELD, FILE_SUFFIXES_FIELD]
-    + NodeTypeField.get_fields_from_method(
+    + NodeTypeField.get_fields(
         GenericLoader.from_filesystem,
         include=[
             "glob",

--- a/ix/chains/fixture_src/parsers.py
+++ b/ix/chains/fixture_src/parsers.py
@@ -23,7 +23,7 @@ LANGUAGE_PARSER = {
     "name": "Language Parser",
     "description": "Parse code for various programming languages.",
     "fields": []
-    + NodeTypeField.get_fields_from_method(
+    + NodeTypeField.get_fields(
         LanguageParser.__init__,
         include=["parser_threshold", "language"],
     ),

--- a/ix/chains/fixture_src/retriever.py
+++ b/ix/chains/fixture_src/retriever.py
@@ -18,7 +18,7 @@ VECTORSTORE_RETRIEVER = {
             "default": ["similarity", "similarity_score_threshold", "mmr"],
         }
     ]
-    + NodeTypeField.get_fields_from_model(
+    + NodeTypeField.get_fields(
         VectorStoreRetriever,
         include=[
             "search_type",

--- a/ix/chains/fixture_src/text_splitter.py
+++ b/ix/chains/fixture_src/text_splitter.py
@@ -15,7 +15,7 @@ RECURSIVE_CHARACTER_SPLITTER = {
     "name": "RecursiveCharacterTextSplitter",
     "description": RecursiveCharacterTextSplitter.__doc__,
     "fields": [LANGUAGE]
-    + NodeTypeField.get_fields_from_method(
+    + NodeTypeField.get_fields(
         TextSplitter.__init__,
         include=[
             "chunk_size",

--- a/ix/chains/fixture_src/tools.py
+++ b/ix/chains/fixture_src/tools.py
@@ -45,7 +45,7 @@ ARXIV_SEARCH = {
     "name": " search",
     "description": "Tool that searches Arxiv for a given query.",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields_from_model(
+    + NodeTypeField.get_fields(
         ArxivAPIWrapper,
         include=[
             "top_k_results",
@@ -63,7 +63,7 @@ BING_SEARCH = {
     "name": "Bing Search",
     "description": "Tool that searches Bing for a given query.",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields_from_model(
+    + NodeTypeField.get_fields(
         BingSearchAPIWrapper,
         include=["bing_subscription_key", "bing_search_url", "k"],
         field_options={
@@ -92,7 +92,7 @@ DUCK_DUCK_GO_SEARCH = {
     "name": "DuckDuckGo Search",
     "description": "Tool that searches DuckDuckGo for a given query.",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields_from_model(
+    + NodeTypeField.get_fields(
         DuckDuckGoSearchAPIWrapper,
         include=["k", "region", "safesearch", "time", "max_results"],
     ),
@@ -104,7 +104,7 @@ GOOGLE_SEARCH = {
     "name": "Google Search",
     "description": "Tool that searches Google for a given query.",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields_from_model(
+    + NodeTypeField.get_fields(
         GoogleSearchAPIWrapper,
         include=["google_api_key", "google_cse_id", "k", "siterestrict"],
         field_options={
@@ -124,7 +124,7 @@ GOOGLE_SERPER = {
     "name": "Google Serper",
     "description": "Tool that searches Google for a given query.",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields_from_model(
+    + NodeTypeField.get_fields(
         GoogleSerperAPIWrapper,
         include=["k", "gl", "hl", "type", "tbs", "serper_api_key"],
         field_options={
@@ -141,7 +141,7 @@ GRAPHQL_TOOL = {
     "name": "GraphQL Tool",
     "description": "Tool that searches GraphQL for a given query.",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields_from_model(
+    + NodeTypeField.get_fields(
         GraphQLAPIWrapper, include=["graphql_endpoint"]
     ),
 }
@@ -152,7 +152,7 @@ LAMBDA_API = {
     "name": "Lambda API",
     "description": "Tool that searches Lambda for a given query.",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields_from_model(
+    + NodeTypeField.get_fields(
         LambdaWrapper,
         include=["function_name", "awslambda_tool_name", "awslambda_tool_description"],
     ),
@@ -164,7 +164,7 @@ PUB_MED = {
     "class_path": "ix.tools.pubmed.get_pubmed",
     "type": "tool",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields_from_model(
+    + NodeTypeField.get_fields(
         PubMedAPIWrapper,
         include=[
             "max_retry",
@@ -182,7 +182,7 @@ WIKIPEDIA = {
     "class_path": "ix.tools.wikipedia.get_wikipedia",
     "type": "tool",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields_from_model(
+    + NodeTypeField.get_fields(
         WikipediaAPIWrapper,
         include=[
             "top_k_results",

--- a/ix/chains/fixture_src/tools.py
+++ b/ix/chains/fixture_src/tools.py
@@ -141,9 +141,7 @@ GRAPHQL_TOOL = {
     "name": "GraphQL Tool",
     "description": "Tool that searches GraphQL for a given query.",
     "fields": TOOL_BASE_FIELDS
-    + NodeTypeField.get_fields(
-        GraphQLAPIWrapper, include=["graphql_endpoint"]
-    ),
+    + NodeTypeField.get_fields(GraphQLAPIWrapper, include=["graphql_endpoint"]),
 }
 
 LAMBDA_API = {

--- a/ix/chains/fixture_src/vectorstores.py
+++ b/ix/chains/fixture_src/vectorstores.py
@@ -16,7 +16,7 @@ VECTORSTORE_RETRIEVER_FIELDS = [
         "required": True,
         "default": ["similarity", "similarity_score_threshold", "mmr"],
     }
-] + NodeTypeField.get_fields_from_model(
+] + NodeTypeField.get_fields(
     VectorStoreRetriever,
     include=[
         "search_type",
@@ -28,7 +28,7 @@ REDIS_VECTORSTORE_CLASS_PATH = "ix.chains.components.vectorstores.AsyncRedisVect
 
 REDIS_VECTORSTORE_RETRIEVER_FIELDS = (
     VECTORSTORE_RETRIEVER_FIELDS
-    + NodeTypeField.get_fields_from_model(
+    + NodeTypeField.get_fields(
         RedisVectorStoreRetriever,
         include=[
             "k",
@@ -85,7 +85,7 @@ CHROMA = {
     "name": "Chroma",
     "description": "Chroma vector database",
     "connectors": VECTORSTORE_CONNECTORS,
-    "fields": NodeTypeField.get_fields_from_method(
+    "fields": NodeTypeField.get_fields(
         Chroma,
         include=[
             "collection_name",

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -2842,20 +2842,6 @@
     ],
     "fields": [
       {
-        "name": "collection_name",
-        "type": "str",
-        "label": "Collection_name",
-        "default": "langchain",
-        "required": false
-      },
-      {
-        "name": "persist_directory",
-        "type": "Optional[str]",
-        "label": "Persist_directory",
-        "default": null,
-        "required": false
-      },
-      {
         "name": "allowed_search_types",
         "type": "list",
         "default": [
@@ -2883,14 +2869,6 @@
         "search_type": {
           "type": "string",
           "default": "similarity"
-        },
-        "collection_name": {
-          "type": "string",
-          "default": "langchain"
-        },
-        "persist_directory": {
-          "type": "object",
-          "default": null
         },
         "allowed_search_types": {
           "type": "object",

--- a/ix/chains/management/commands/import_langchain.py
+++ b/ix/chains/management/commands/import_langchain.py
@@ -156,7 +156,7 @@ class Command(BaseCommand):
             class_path = component.get("class_path")
             if NodeType.objects.filter(class_path=class_path).exists():
                 # updating existing node type
-                print(f"Updating component: {component['class_path']}")
+                print(f"Updating component: {class_path}")
                 node_type = NodeType.objects.get(class_path=class_path)
                 for key, value in component.items():
                     if key == "class_path":

--- a/ix/chains/tests/test_config.py
+++ b/ix/chains/tests/test_config.py
@@ -20,10 +20,12 @@ class TestModel(BaseModel):
     optional: Optional[str] = None
     choices_enum: ChoicesEnum
 
-    @staticmethod
+    @classmethod
     def loader(
+        cls,
         field1: str,
         field2: int,
+        choices_enum: ChoicesEnum,
         field3: bool = False,
         literal: Literal["foo", "bar"] = "bar",
         optional: Optional[str] = None,
@@ -91,8 +93,7 @@ class TestFieldConfig:
 class GetFieldsBase:
     """Base for common tests for getting fields from a model or method"""
 
-    def get_fields(self, *args, **kwargs):
-        raise NotImplementedError
+    field_source = None
 
     def test_get_fields_overrides_include(self, field_overrides):
         expected_fields_include = [
@@ -113,8 +114,8 @@ class GetFieldsBase:
         ]
 
         assert (
-            self.get_fields(
-                TestModel,
+            NodeTypeField.get_fields(
+                self.field_source,
                 include=["field1", "field2"],
                 field_options=field_overrides,
             )
@@ -138,8 +139,8 @@ class GetFieldsBase:
         ]
 
         assert (
-            self.get_fields(
-                TestModel,
+            NodeTypeField.get_fields(
+                self.field_source,
                 include=["literal"],
             )
             == expected
@@ -157,8 +158,8 @@ class GetFieldsBase:
         ]
 
         assert (
-            self.get_fields(
-                TestModel,
+            NodeTypeField.get_fields(
+                self.field_source,
                 include=["optional"],
             )
             == expected
@@ -183,8 +184,8 @@ class GetFieldsBase:
         ]
 
         assert (
-            self.get_fields(
-                TestModel,
+            NodeTypeField.get_fields(
+                self.field_source,
                 include=["field1", "field2", "field3"],
                 exclude=["field1"],
                 field_options=field_overrides,
@@ -208,16 +209,15 @@ class GetFieldsBase:
             },
         ]
 
-        fields = self.get_fields(
-            TestModel,
+        fields = NodeTypeField.get_fields(
+            self.field_source,
             include=["choices_enum"],
         )
         assert fields == expected
 
 
 class TestGetFieldsFromModel(GetFieldsBase):
-    def get_fields(self, *args, **kwargs):
-        return NodeTypeField.get_fields_from_model(*args, **kwargs)
+    field_source = TestModel
 
     def test_exclude_non_allowed_type(self, field_overrides):
         # Extend TestModel with a field of non-allowed type
@@ -245,7 +245,7 @@ class TestGetFieldsFromModel(GetFieldsBase):
         ]
 
         assert (
-            self.get_fields(TestModel2, include=["field1", "field2", "field4"])
+            NodeTypeField.get_fields(TestModel2, include=["field1", "field2", "field4"])
             == expected_fields
         )
 

--- a/ix/chains/tests/test_config.py
+++ b/ix/chains/tests/test_config.py
@@ -1,3 +1,4 @@
+from abc import ABC
 from enum import Enum
 from typing import Literal, Optional
 
@@ -28,6 +29,15 @@ class TestModel(BaseModel):
         optional: Optional[str] = None,
     ):
         pass
+
+
+class TestABC(ABC):
+    field1: str
+    field2: int
+    field3: bool = False
+    literal: Literal["foo", "bar"] = "bar"
+    optional: Optional[str] = None
+    choices_enum: ChoicesEnum
 
 
 @pytest.fixture
@@ -241,5 +251,8 @@ class TestGetFieldsFromModel(GetFieldsBase):
 
 
 class TestGetFieldsFromMethod(GetFieldsBase):
-    def get_fields(self, *args, **kwargs):
-        return NodeTypeField.get_fields_from_method(*args, **kwargs)
+    field_source = TestModel.loader
+
+
+class TestGetFieldsFromABC(GetFieldsBase):
+    field_source = TestABC

--- a/ix/utils/importlib.py
+++ b/ix/utils/importlib.py
@@ -1,12 +1,23 @@
 import importlib
+import logging
 from typing import Type
+
+
+logger = logging.getLogger(__name__)
 
 
 def _import_class(class_path: str) -> Type:
     """
     inner class to facilitate test mocking across all uses of `import_class`
     """
-    module_path, class_name = class_path.rsplit(".", 1)
+    try:
+        module_path, class_name = class_path.rsplit(".", 1)
+    except Exception as e:
+        logger.error(
+            f"Error splitting class_path={class_path} into module and class name: {e}"
+        )
+        raise e
+
     try:
         module = importlib.import_module(module_path)
     except ModuleNotFoundError:


### PR DESCRIPTION
### Description
Simplifying `NodeTypeField.get_fields` helper to accept all valid source types. Downstream consumer now only need to know this one method for importing fields from BaseModels, ABCs, and methods.

This was blocking usage of some `BaseLoader` subclasses like `WebBaseLoader`

### Changes
- `NodeTypeField.getFields` now dispatches to handle all field source types
- `NodeTypeField.get_fields` now supports ABCs
- fixed tests for `get_fields` source types

### How Tested
- updated unittests

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
