### PR TITLE
LangChain 271

### DIFF
--- a/ix/agents/process.py
+++ b/ix/agents/process.py
@@ -2,6 +2,8 @@ import logging
 from typing import TypedDict, Optional, Any, Dict
 
 from asgiref.sync import sync_to_async
+from langchain.schema.runnable import RunnableConfig
+
 from ix.agents.models import Agent
 from ix.chains.callbacks import IxHandler
 from ix.chains.models import Chain as ChainModel
@@ -55,13 +57,13 @@ class AgentProcess:
 
             # auto-map user_input to other input keys if not provided.
             # work around until chat input key can be configured per chain
-            extra_kwargs = {}
-            if "input" not in user_input:
-                extra_kwargs["input"] = user_input["user_input"]
-            if "question" not in user_input:
-                extra_kwargs["question"] = user_input["user_input"]
+            inputs = user_input.copy()
+            if "input" not in inputs:
+                inputs["input"] = user_input["user_input"]
+            if "question" not in inputs:
+                inputs["question"] = user_input["user_input"]
 
-            return await chain.arun(callbacks=[handler], **extra_kwargs, **user_input)
+            return await chain.ainvoke(inputs, RunnableConfig(callbacks=[handler]))
         except Exception as e:
             # validation errors aren't caught by callbacks.
             await handler.send_error_msg(e)

--- a/ix/chains/fixture_src/openai_functions.py
+++ b/ix/chains/fixture_src/openai_functions.py
@@ -44,8 +44,9 @@ FUNCTION_CALL = {
     "type": "string",
 }
 
+OPENAPI_CHAIN_CLASS_PATH = "ix.chains.openapi.get_openapi_chain_async"
 OPENAPI_CHAIN = {
-    "class_path": "ix.chains.openapi.get_openapi_chain_async",
+    "class_path": OPENAPI_CHAIN_CLASS_PATH,
     "type": "chain",
     "name": "OpenAPI with OpenAI Functions",
     "description": "Chain that uses OpenAI Functions to call OpenAPI endpoints.",

--- a/ix/chains/openapi.py
+++ b/ix/chains/openapi.py
@@ -1,4 +1,7 @@
 import logging
+from unittest import mock
+
+from langchain.chains import SequentialChain
 from langchain.chains.openai_functions.openapi import (
     get_openapi_chain,
     SimpleRequestChain,
@@ -14,16 +17,20 @@ class AsyncSimpleRequestChainRun(SyncToAsyncCall, SimpleRequestChain):
     pass
 
 
-def get_openapi_chain_async(**kwargs):
+def get_openapi_chain_async(**kwargs) -> SequentialChain:
     """
     Extremely hacky way of injecting asyncio support into LangChain's function.
     Done within this wrapper function to limit the scope of the patch.
     """
-    # modified to use `user_input` for consistency with other chains
-    if "prompt" not in kwargs:
-        kwargs["prompt"] = ChatPromptTemplate.from_template(
-            "Use the provided API's to respond to this user query:\n\n{user_input}"
-        )
+    with mock.patch(
+        "langchain.chains.openai_functions.openapi.SimpleRequestChain",
+        new=AsyncSimpleRequestChainRun,
+    ):
+        # modified to use `user_input` for consistency with other chains
+        if "prompt" not in kwargs:
+            kwargs["prompt"] = ChatPromptTemplate.from_template(
+                "Use the provided API's to respond to this user query:\n\n{user_input}"
+            )
 
-    chain = get_openapi_chain(**kwargs)
-    return chain
+        chain = get_openapi_chain(**kwargs)
+        return chain

--- a/ix/chains/openapi.py
+++ b/ix/chains/openapi.py
@@ -1,5 +1,4 @@
 import logging
-from unittest import mock
 from langchain.chains.openai_functions.openapi import (
     get_openapi_chain,
     SimpleRequestChain,
@@ -20,15 +19,11 @@ def get_openapi_chain_async(**kwargs):
     Extremely hacky way of injecting asyncio support into LangChain's function.
     Done within this wrapper function to limit the scope of the patch.
     """
-    with mock.patch(
-        "langchain.chains.openai_functions.openapi.SimpleRequestChain",
-        new=AsyncSimpleRequestChainRun,
-    ):
-        # modified to use `user_input` for consistency with other chains
-        if "prompt" not in kwargs:
-            kwargs["prompt"] = ChatPromptTemplate.from_template(
-                "Use the provided API's to respond to this user query:\n\n{user_input}"
-            )
+    # modified to use `user_input` for consistency with other chains
+    if "prompt" not in kwargs:
+        kwargs["prompt"] = ChatPromptTemplate.from_template(
+            "Use the provided API's to respond to this user query:\n\n{user_input}"
+        )
 
-        chain = get_openapi_chain(**kwargs)
-        return chain
+    chain = get_openapi_chain(**kwargs)
+    return chain

--- a/ix/chains/tests/components/test_chains.py
+++ b/ix/chains/tests/components/test_chains.py
@@ -1,0 +1,20 @@
+import pytest
+from langchain.chains import SequentialChain
+
+from ix.chains.fixture_src.openai_functions import OPENAPI_CHAIN_CLASS_PATH
+from ix.chains.tests.test_config_loader import OPENAI_LLM
+
+OPENAPI_CHAIN = {
+    "class_path": OPENAPI_CHAIN_CLASS_PATH,
+    "config": {
+        "llm": OPENAI_LLM,
+        "spec": "https://www.klarna.com/us/shopping/public/openai/v0/api-docs/",
+    },
+}
+
+
+@pytest.mark.django_db
+class TestOpenAPIChain:
+    async def test_load(self, aload_chain):
+        component = await aload_chain(OPENAPI_CHAIN)
+        assert isinstance(component, SequentialChain)

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ jsonpath-ng==1.5.3
 jsonschema==4.0.1
 langchain==0.0.271
 openai==0.27.8
+openapi-schema-pydantic==1.2.4
 pinecone-client==2.2.1
 pyright==1.1.301
 # Note: django reset_db requires psycopg2 to be installed

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ ipython==8.13.2
 isort==5.12.0
 jsonpath-ng==1.5.3
 jsonschema==4.0.1
-langchain==0.0.262
+langchain==0.0.268
 openai==0.27.8
 pinecone-client==2.2.1
 pyright==1.1.301

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ ipython==8.13.2
 isort==5.12.0
 jsonpath-ng==1.5.3
 jsonschema==4.0.1
-langchain==0.0.268
+langchain==0.0.271
 openai==0.27.8
 pinecone-client==2.2.1
 pyright==1.1.301


### PR DESCRIPTION
### Description
Update to LangChain 0.0.268 for Conversational Retrieval Chain and other features.

### Changes
- updated to langchain==0.0.271
- `AgentProcess` now calls `chain.ainvoke` instead of `chain.arun`

### How Tested
- unittests
- [x] manual test of agents
- [x] added unittest for `OpenAPIFunctionChain`

### TODOs
- [x] `OpenAPIFunctionsChain` isn't initializing. It's failing to parse the spec from url. stacktrace for `OpenAPISpec.from_url`. Breaks `@smithy` and  `@klarna` agents.

    - Tracked regression to change near `langchain==0.0.268`. 
    - Workaround applied in https://github.com/kreneskyp/ix/pull/175/commits/86b9b8061e9d6155a4abcce9ad68e0644564caa4.
    - Upstream ticket: https://github.com/langchain-ai/langchain/issues/9520

```
File "/var/app/ix/chains/openapi.py", line 30, in get_openapi_chain_async
    chain = get_openapi_chain(**kwargs)
File "/var/app/langchain/libs/langchain/langchain/chains/openai_functions/openapi.py", line 271, in get_openapi_chain
    raise e
File "/var/app/langchain/libs/langchain/langchain/chains/openai_functions/openapi.py", line 267, in get_openapi_chain
    spec = conversion(spec)  # type: ignore[arg-type]
File "/var/app/langchain/libs/langchain/langchain/utilities/openapi.py", line 242, in from_url
    return cls.from_text(response.text)
File "/var/app/langchain/libs/langchain/langchain/utilities/openapi.py", line 227, in from_text
    return cls.from_spec_dict(spec_dict)
File "/var/app/langchain/libs/langchain/langchain/utilities/openapi.py", line 218, in from_spec_dict
    return cls.parse_obj(spec_dict)
File "/var/app/langchain/libs/langchain/langchain/utilities/openapi.py", line 202, in parse_obj
    return super().parse_obj(obj)
```

