### PR TITLE
Agent: ConversationalRetrievalAgent

### DIFF
--- a/ix/chains/fixture_src/agents.py
+++ b/ix/chains/fixture_src/agents.py
@@ -1,3 +1,4 @@
+from ix.api.chains.types import NodeTypeField
 from ix.chains.fixture_src.common import VERBOSE
 from ix.chains.fixture_src.targets import (
     PROMPT_TARGET,
@@ -5,6 +6,22 @@ from ix.chains.fixture_src.targets import (
     LLM_TARGET,
     MEMORY_TARGET,
 )
+from langchain.agents.agent_toolkits.conversational_retrieval.openai_functions import (
+    create_conversational_retrieval_agent,
+)
+
+MAX_ITERATIONS = {
+    "name": "max_iterations",
+    "type": "integer",
+    "default": 15,
+    "nullable": True,
+}
+
+MAX_EXECUTION_TIME = {
+    "name": "max_execution_time",
+    "type": "float",
+    "nullable": True,
+}
 
 EXECUTOR_BASE_FIELDS = [
     {
@@ -12,17 +29,8 @@ EXECUTOR_BASE_FIELDS = [
         "type": "boolean",
         "default": False,
     },
-    {
-        "name": "max_iterations",
-        "type": "integer",
-        "default": 15,
-        "nullable": True,
-    },
-    {
-        "name": "max_execution_time",
-        "type": "float",
-        "nullable": True,
-    },
+    MAX_ITERATIONS,
+    MAX_EXECUTION_TIME,
     VERBOSE,
 ]
 
@@ -109,6 +117,20 @@ STRUCTURED_CHAT_ZERO_SHOT_REACT_DESCRIPTION_AGENT = {
 }
 
 
+CONVERSATIONAL_RETRIEVAL_AGENT = {
+    "class_path": "langchain.agents.agent_toolkits.conversational_retrieval.openai_functions.create_conversational_retrieval_agent",
+    "type": "agent",
+    "name": "Conversational Retrieval agent",
+    "description": "Agent that generates descriptions in a structured chat context using a zero-shot approach and reaction information.",
+    "connectors": [LLM_TARGET, TOOLS_TARGET],
+    "fields": [MAX_ITERATIONS, MAX_EXECUTION_TIME, VERBOSE]
+    + NodeTypeField.get_fields(
+        create_conversational_retrieval_agent,
+        include=["remember_intermediate_steps" "memory_key" "max_token_limit"],
+    ),
+}
+
+
 AGENTS = [
     OPENAI_FUNCTIONS_AGENT,
     OPENAI_MULTIFUNCTION_AGENT,
@@ -119,4 +141,5 @@ AGENTS = [
     CHAT_ZERO_SHOT_REACT_DESCRIPTION_AGENT,
     CHAT_CONVERSATIONAL_REACT_DESCRIPTION_AGENT,
     STRUCTURED_CHAT_ZERO_SHOT_REACT_DESCRIPTION_AGENT,
+    CONVERSATIONAL_RETRIEVAL_AGENT,
 ]

--- a/ix/chains/fixture_src/tools.py
+++ b/ix/chains/fixture_src/tools.py
@@ -1,4 +1,4 @@
-from ix.chains.fixture_src.targets import CHAIN_TARGET
+from ix.chains.fixture_src.targets import CHAIN_TARGET, RETRIEVER_TARGET
 from langchain import (
     GoogleSearchAPIWrapper,
     GoogleSerperAPIWrapper,
@@ -174,6 +174,15 @@ PUB_MED = {
     ),
 }
 
+RETRIEVER_TOOL = {
+    "class_path": "langchain.agents.agent_toolkits.create_retriever_tool",
+    "type": "tool",
+    "name": "Retriever Tool",
+    "description": "Create a tool to do retrieval of documents.",
+    "connectors": [RETRIEVER_TARGET],
+    "fields": [NAME, DESCRIPTION],
+}
+
 WIKIPEDIA = {
     "name": "Wikipedia",
     "description": "Wikipedia search engine",
@@ -220,6 +229,7 @@ TOOLS = [
     GRAPHQL_TOOL,
     LAMBDA_API,
     PUB_MED,
+    RETRIEVER_TOOL,
     WIKIPEDIA,
     WOLFRAM,
 ]

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -2277,6 +2277,71 @@
 },
 {
   "model": "chains.nodetype",
+  "pk": "851f01f8-374e-44e8-882e-db68a34d24b2",
+  "fields": {
+    "name": "Conversational Retrieval agent",
+    "description": "Agent that generates descriptions in a structured chat context using a zero-shot approach and reaction information.",
+    "class_path": "langchain.agents.agent_toolkits.conversational_retrieval.openai_functions.create_conversational_retrieval_agent",
+    "type": "agent",
+    "display_type": "node",
+    "connectors": [
+      {
+        "key": "llm",
+        "type": "target",
+        "source_type": "llm"
+      },
+      {
+        "key": "tools",
+        "type": "target",
+        "multiple": true,
+        "source_type": "tool"
+      }
+    ],
+    "fields": [
+      {
+        "name": "max_iterations",
+        "type": "integer",
+        "default": 15,
+        "nullable": true
+      },
+      {
+        "name": "max_execution_time",
+        "type": "float",
+        "nullable": true
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "default": false
+      }
+    ],
+    "child_field": null,
+    "config_schema": {
+      "type": "object",
+      "required": [
+        "max_iterations",
+        "max_execution_time",
+        "verbose"
+      ],
+      "properties": {
+        "verbose": {
+          "type": "boolean",
+          "default": false
+        },
+        "max_iterations": {
+          "type": "number",
+          "default": 15
+        },
+        "max_execution_time": {
+          "type": "number",
+          "default": null
+        }
+      }
+    }
+  }
+},
+{
+  "model": "chains.nodetype",
   "pk": "8a49959a-b5bc-414e-a25f-51b8d3ad6249",
   "fields": {
     "name": "Conversation Buffer Window",
@@ -3854,6 +3919,62 @@
         "max_token_limit": {
           "type": "number",
           "default": 2000
+        }
+      }
+    }
+  }
+},
+{
+  "model": "chains.nodetype",
+  "pk": "da4b8229-8856-498e-a123-07107bb304f6",
+  "fields": {
+    "name": "Retriever Tool",
+    "description": "Create a tool to do retrieval of documents.",
+    "class_path": "langchain.agents.agent_toolkits.create_retriever_tool",
+    "type": "tool",
+    "display_type": "node",
+    "connectors": [
+      {
+        "key": "retriever",
+        "type": "target",
+        "as_type": "retriever",
+        "source_type": "vectorstore"
+      }
+    ],
+    "fields": [
+      {
+        "name": "name",
+        "type": "str",
+        "style": {
+          "width": "100%"
+        },
+        "default": ""
+      },
+      {
+        "name": "description",
+        "type": "str",
+        "style": {
+          "width": "100%"
+        },
+        "default": "",
+        "input_type": "textarea"
+      }
+    ],
+    "child_field": null,
+    "config_schema": {
+      "type": "object",
+      "required": [
+        "name",
+        "description"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "default": ""
+        },
+        "description": {
+          "type": "string",
+          "default": ""
         }
       }
     }


### PR DESCRIPTION
### Description
Adds support for `ConversationalRetrievalAgent`, an `OpenAIFunction` agent configured for completing tasks using information retrieved with `RetrieverTool`.

This follows langchain documentation:
https://python.langchain.com/docs/use_cases/question_answering/how_to/conversational_retrieval_agents

![image](https://github.com/kreneskyp/ix/assets/68635/12119c4d-b153-4b19-a565-000464a04ca0)

![image](https://github.com/kreneskyp/ix/assets/68635/dfa1b17b-1841-434f-a9f0-f06995dd80f1)


### Changes
- Adds `ConversationalRetrievalAgent`
- Adds `RetrieverTool`


### How Tested
- [ ] manual test of agent
### TODOs
- [x] dependent on #175 
- [ ] The memory component auto-configured by `create_conversational_retrieval_agent` is unable to save the input because there are more than one input. IX sets multiple inputs for key compatibility (different chains/agents expect a different key). Need to investigate possible workarounds. One possibility is configurable input_key per chain on the `ChatInput` node.
 
    ![image](https://github.com/kreneskyp/ix/assets/68635/98b76589-8786-4bae-add5-eca15e7ae6e1)


