### PR TITLE
document_loader: WebBaseLoader

### DIFF
--- a/ix/chains/fixture_src/document_loaders.py
+++ b/ix/chains/fixture_src/document_loaders.py
@@ -1,3 +1,4 @@
+from langchain.document_loaders import WebBaseLoader
 from langchain.document_loaders.generic import GenericLoader
 
 from ix.api.chains.types import NodeTypeField
@@ -39,6 +40,32 @@ GENERIC_LOADER = {
     "connectors": [PARSER_TARGET],
 }
 
-DOCUMENT_LOADERS = [GENERIC_LOADER]
+
+WEB_BASE_LOADER_CLASS_PATH = "langchain.document_loaders.web_base.WebBaseLoader"
+WEB_BASE_LOADER = {
+    "class_path": WEB_BASE_LOADER_CLASS_PATH,
+    "type": "document_loader",
+    "name": "Web Loader",
+    "description": "Load documents from the web and parse them with BeautifulSoup.",
+    "connectors": [PARSER_TARGET],
+    "fields": [
+        {
+            "name": "web_path",
+            "type": "list",
+            "description": "URL(s) of the web page",
+            "style": {"width": "100%"},
+        }
+    ]
+    + NodeTypeField.get_fields(
+        WebBaseLoader.__init__,
+        include=[
+            "verify_ssl",
+            "continue_on_failure",
+        ],
+    ),
+}
+
+
+DOCUMENT_LOADERS = [GENERIC_LOADER, WEB_BASE_LOADER]
 
 __all__ = ["DOCUMENT_LOADERS", "GENERIC_LOADER_CLASS_PATH"]

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -2008,6 +2008,69 @@
 },
 {
   "model": "chains.nodetype",
+  "pk": "7477a8ad-ca83-4714-aeaf-4df8cbb900ea",
+  "fields": {
+    "name": "Web Loader",
+    "description": "Load documents from the web and parse them with BeautifulSoup.",
+    "class_path": "langchain.document_loaders.web_base.WebBaseLoader",
+    "type": "document_loader",
+    "display_type": "node",
+    "connectors": [
+      {
+        "key": "parser",
+        "type": "target",
+        "source_type": "parser"
+      }
+    ],
+    "fields": [
+      {
+        "name": "web_path",
+        "type": "list",
+        "style": {
+          "width": "100%"
+        },
+        "description": "URL(s) of the web page"
+      },
+      {
+        "name": "verify_ssl",
+        "type": "boolean",
+        "label": "Verify_ssl",
+        "default": true,
+        "required": false
+      },
+      {
+        "name": "continue_on_failure",
+        "type": "boolean",
+        "label": "Continue_on_failure",
+        "default": false,
+        "required": false
+      }
+    ],
+    "child_field": null,
+    "config_schema": {
+      "type": "object",
+      "required": [
+        "web_path"
+      ],
+      "properties": {
+        "web_path": {
+          "type": "object",
+          "default": null
+        },
+        "verify_ssl": {
+          "type": "boolean",
+          "default": true
+        },
+        "continue_on_failure": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
+  }
+},
+{
+  "model": "chains.nodetype",
   "pk": "74fd7b8b-4be7-49dc-a925-5e522c03bbf4",
   "fields": {
     "name": "OpenAI Function Agent",


### PR DESCRIPTION
### Description
This adds initial support for `WebBaseLoader` for loading documents from URLs

##### Example

Test querying LangChain docs

![image](https://github.com/kreneskyp/ix/assets/68635/7afdf529-1410-48f5-bd9c-927ab43c1d95)

![image](https://github.com/kreneskyp/ix/assets/68635/d43cf903-2b69-4683-9c04-6844bdcea824)


### Changes
- add `WebBaseLoader`

### How Tested
- manual testing

### TODOs
- Some `WebBaseLoader` are not set by the `__init__` method so they aren't currently accessible. Working on a custom loader but it isn't ready yet. There are a number of subclasses of `WebBaseLoader` that implement support for specific sources like `IMDB`.  Needs more time to develop to support that part of the component graph.