### PR TITLE
Chain editor node connections now support List[ChainNode]

### DIFF
--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -184,12 +184,14 @@ const ChainGraphEditor = ({ graph }) => {
       // target
       const target = reactFlowInstance.getNode(connection.target);
       const connectors = target.data.type.connectors;
-      let connector, expectedType;
+      let connector, expectedTypes;
       if (connection.targetHandle === "in") {
-        expectedType = "chain-link";
+        expectedTypes = new Set(["chain-link"]);
       } else {
         connector = connectors.find((c) => c.key === connection.targetHandle);
-        expectedType = connector?.source_type;
+        expectedTypes = Array.isArray(connector?.source_type)
+          ? new Set(connector.source_type)
+          : new Set([connector.source_type]);
       }
       const supportsMultiple = connector?.multiple || false;
 
@@ -204,8 +206,8 @@ const ChainGraphEditor = ({ graph }) => {
       // HAX: adding a special case for chain-agent connections until expectedType can be
       //      expanded to be a set of types
       if (
-        expectedType === providedType ||
-        (expectedType === "chain" && providedType === "agent")
+        expectedTypes.has(providedType) ||
+        (expectedTypes.has("chain") && providedType === "agent")
       ) {
         const instanceEdges = reactFlowInstance.getEdges();
         const targetEdges = instanceEdges.filter(

--- a/ix/chains/fixture_src/targets.py
+++ b/ix/chains/fixture_src/targets.py
@@ -93,7 +93,7 @@ DOCUMENTS_TARGET = {
 RETRIEVER_TARGET = {
     "key": "retriever",
     "type": "target",
-    "source_type": "vectorstore",
+    "source_type": ["retriever", "vectorstore"],
     "as_type": "retriever",
     "required": True,
 }

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -4071,7 +4071,10 @@
         "type": "target",
         "as_type": "retriever",
         "required": true,
-        "source_type": "vectorstore"
+        "source_type": [
+          "retriever",
+          "vectorstore"
+        ]
       }
     ],
     "fields": [


### PR DESCRIPTION
### Description
Chain editor `isValidConnection` now supports connectors with `source_type` set to a list of component types.
This enables a property to support multiple component types. 

This unblocks #177 by allowing `ConversationalRetrievalChain.retriever` to receive either a `retreiver` or `vectorstore`.   

![image](https://github.com/kreneskyp/ix/assets/68635/35067f16-c2f7-43c6-99ba-05c023c673c6)


### Changes
- updated `isValidConnection` to process `source_type` as a set. 

### How Tested
Manual testing

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
