### PR TITLE
LLM: llama-cpp

### DIFF
--- a/ix/chains/fixture_src/llm.py
+++ b/ix/chains/fixture_src/llm.py
@@ -1,3 +1,7 @@
+from langchain import LlamaCpp
+
+from ix.api.chains.types import NodeTypeField
+
 OPENAI_LLM = {
     "class_path": "langchain.chat_models.openai.ChatOpenAI",
     "type": "llm",
@@ -170,3 +174,46 @@ ANTHROPIC_LLM = {
         },
     ],
 }
+
+LLAMA_CPP_LLM_CLASS_PATH = "langchain.llms.llamacpp.LlamaCpp"
+LLAMA_CPP_LLM = {
+    "class_path": LLAMA_CPP_LLM_CLASS_PATH,
+    "type": "llm",
+    "name": "Llama Cpp",
+    "description": "Llama Cpp wrapper for llama models",
+    "fields": NodeTypeField.get_fields(
+        LlamaCpp,
+        include=[
+            "model_path",
+            "lora_base",
+            "n_ctx",
+            "n_parts",
+            "seed",
+            "f16_kv",
+            "logits_all",
+            "vocab_only",
+            "use_mlock",
+            "n_threads",
+            "n_batch",
+            "n_gpu_layers",
+            "suffix",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "logprobs",
+            "echo",
+            "stop",
+            "repeat_penalty",
+            "last_n_tokens_size",
+            "use_mmap",
+            "rope_freq_scale",
+            "rope_freq_base",
+            # "model_kwargs",
+            "streaming",
+            "verbose",
+        ],
+    ),
+}
+
+
+LLMS = [ANTHROPIC_LLM, GOOGLE_PALM, LLAMA_CPP_LLM, OPENAI_LLM]

--- a/ix/chains/fixtures/node_types.json
+++ b/ix/chains/fixtures/node_types.json
@@ -1463,6 +1463,315 @@
 },
 {
   "model": "chains.nodetype",
+  "pk": "4bfd56af-222c-4428-bc5a-31c4e5a99871",
+  "fields": {
+    "name": "Llama Cpp",
+    "description": "Llama Cpp wrapper for llama models",
+    "class_path": "langchain.llms.llamacpp.LlamaCpp",
+    "type": "llm",
+    "display_type": "node",
+    "connectors": null,
+    "fields": [
+      {
+        "name": "model_path",
+        "type": "str",
+        "label": "Model_path",
+        "default": null,
+        "required": true
+      },
+      {
+        "name": "lora_base",
+        "type": "str",
+        "label": "Lora_base",
+        "default": null,
+        "required": false
+      },
+      {
+        "name": "n_ctx",
+        "type": "int",
+        "label": "N_ctx",
+        "default": 512,
+        "required": false
+      },
+      {
+        "name": "n_parts",
+        "type": "int",
+        "label": "N_parts",
+        "default": -1,
+        "required": false
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "label": "Seed",
+        "default": -1,
+        "required": false
+      },
+      {
+        "name": "f16_kv",
+        "type": "boolean",
+        "label": "F16_kv",
+        "default": true,
+        "required": false
+      },
+      {
+        "name": "logits_all",
+        "type": "boolean",
+        "label": "Logits_all",
+        "default": false,
+        "required": false
+      },
+      {
+        "name": "vocab_only",
+        "type": "boolean",
+        "label": "Vocab_only",
+        "default": false,
+        "required": false
+      },
+      {
+        "name": "use_mlock",
+        "type": "boolean",
+        "label": "Use_mlock",
+        "default": false,
+        "required": false
+      },
+      {
+        "name": "n_threads",
+        "type": "int",
+        "label": "N_threads",
+        "default": null,
+        "required": false
+      },
+      {
+        "name": "n_batch",
+        "type": "int",
+        "label": "N_batch",
+        "default": 8,
+        "required": false
+      },
+      {
+        "name": "n_gpu_layers",
+        "type": "int",
+        "label": "N_gpu_layers",
+        "default": null,
+        "required": false
+      },
+      {
+        "name": "suffix",
+        "type": "str",
+        "label": "Suffix",
+        "default": null,
+        "required": false
+      },
+      {
+        "name": "max_tokens",
+        "type": "int",
+        "label": "Max_tokens",
+        "default": 256,
+        "required": false
+      },
+      {
+        "name": "temperature",
+        "type": "float",
+        "label": "Temperature",
+        "default": 0.8,
+        "required": false
+      },
+      {
+        "name": "top_p",
+        "type": "float",
+        "label": "Top_p",
+        "default": 0.95,
+        "required": false
+      },
+      {
+        "name": "logprobs",
+        "type": "int",
+        "label": "Logprobs",
+        "default": null,
+        "required": false
+      },
+      {
+        "name": "echo",
+        "type": "boolean",
+        "label": "Echo",
+        "default": false,
+        "required": false
+      },
+      {
+        "name": "stop",
+        "type": "List",
+        "label": "Stop",
+        "default": [],
+        "required": false
+      },
+      {
+        "name": "repeat_penalty",
+        "type": "float",
+        "label": "Repeat_penalty",
+        "default": 1.1,
+        "required": false
+      },
+      {
+        "name": "last_n_tokens_size",
+        "type": "int",
+        "label": "Last_n_tokens_size",
+        "default": 64,
+        "required": false
+      },
+      {
+        "name": "use_mmap",
+        "type": "boolean",
+        "label": "Use_mmap",
+        "default": true,
+        "required": false
+      },
+      {
+        "name": "rope_freq_scale",
+        "type": "float",
+        "label": "Rope_freq_scale",
+        "default": 1.0,
+        "required": false
+      },
+      {
+        "name": "rope_freq_base",
+        "type": "float",
+        "label": "Rope_freq_base",
+        "default": 10000.0,
+        "required": false
+      },
+      {
+        "name": "streaming",
+        "type": "boolean",
+        "label": "Streaming",
+        "default": true,
+        "required": false
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "label": "Verbose",
+        "default": true,
+        "required": false
+      }
+    ],
+    "child_field": null,
+    "config_schema": {
+      "type": "object",
+      "required": [
+        "model_path"
+      ],
+      "properties": {
+        "echo": {
+          "type": "boolean",
+          "default": false
+        },
+        "seed": {
+          "type": "number",
+          "default": -1
+        },
+        "stop": {
+          "type": "object",
+          "default": []
+        },
+        "n_ctx": {
+          "type": "number",
+          "default": 512
+        },
+        "top_p": {
+          "type": "number",
+          "default": 0.95
+        },
+        "f16_kv": {
+          "type": "boolean",
+          "default": true
+        },
+        "suffix": {
+          "type": "string",
+          "default": null
+        },
+        "n_batch": {
+          "type": "number",
+          "default": 8
+        },
+        "n_parts": {
+          "type": "number",
+          "default": -1
+        },
+        "verbose": {
+          "type": "boolean",
+          "default": true
+        },
+        "logprobs": {
+          "type": "number",
+          "default": null
+        },
+        "use_mmap": {
+          "type": "boolean",
+          "default": true
+        },
+        "lora_base": {
+          "type": "string",
+          "default": null
+        },
+        "n_threads": {
+          "type": "number",
+          "default": null
+        },
+        "streaming": {
+          "type": "boolean",
+          "default": true
+        },
+        "use_mlock": {
+          "type": "boolean",
+          "default": false
+        },
+        "logits_all": {
+          "type": "boolean",
+          "default": false
+        },
+        "max_tokens": {
+          "type": "number",
+          "default": 256
+        },
+        "model_path": {
+          "type": "string",
+          "default": null
+        },
+        "vocab_only": {
+          "type": "boolean",
+          "default": false
+        },
+        "temperature": {
+          "type": "number",
+          "default": 0.8
+        },
+        "n_gpu_layers": {
+          "type": "number",
+          "default": null
+        },
+        "repeat_penalty": {
+          "type": "number",
+          "default": 1.1
+        },
+        "rope_freq_base": {
+          "type": "number",
+          "default": 10000.0
+        },
+        "rope_freq_scale": {
+          "type": "number",
+          "default": 1.0
+        },
+        "last_n_tokens_size": {
+          "type": "number",
+          "default": 64
+        }
+      }
+    }
+  }
+},
+{
+  "model": "chains.nodetype",
   "pk": "4eb6a170-d0e4-428e-be8d-09ca1ca8383d",
   "fields": {
     "name": "GraphQL Tool",

--- a/ix/chains/management/commands/import_langchain.py
+++ b/ix/chains/management/commands/import_langchain.py
@@ -21,7 +21,7 @@ from ix.chains.fixture_src.embeddings import (
     MOSAICML_INSTRUCTOR_EMBEDDINGS,
 )
 from ix.chains.fixture_src.ix import CHAT_MODERATOR_TYPE
-from ix.chains.fixture_src.llm import OPENAI_LLM, GOOGLE_PALM, ANTHROPIC_LLM
+from ix.chains.fixture_src.llm import LLMS
 from ix.chains.fixture_src.memory import (
     CONVERSATION_BUFFER_MEMORY,
     CONVERSATION_SUMMARY_BUFFER_MEMORY,
@@ -62,13 +62,7 @@ COMPONENTS.extend(AGENTS)
 COMPONENTS.extend(TOOLS)
 
 # LLMS
-COMPONENTS.extend(
-    [
-        OPENAI_LLM,
-        GOOGLE_PALM,
-        ANTHROPIC_LLM,
-    ]
-)
+COMPONENTS.extend(LLMS)
 
 # Chains
 COMPONENTS.extend(CHAINS)

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ isort==5.12.0
 jsonpath-ng==1.5.3
 jsonschema==4.0.1
 langchain==0.0.271
+llama-cpp-python==0.1.79
 openai==0.27.8
 openapi-schema-pydantic==1.2.4
 pinecone-client==2.2.1


### PR DESCRIPTION
### Description
Adds initial support for  `Llama-cpp` LLM for running local models.  This enables the model to be used but streaming and some other things don't work exactly right yet.

![image](https://github.com/kreneskyp/ix/assets/68635/95bc83c3-ba41-4d0e-8325-afaef79b506e)


##### Setup
1. download models:
     Tested with GGUF based models from huggingface

    - https://huggingface.co/TheBloke/CodeLlama-7B-GGUF
    - https://huggingface.co/TheBloke/CodeLlama-13B-Python-GGUF

2. save model to `<ix root>/llama/<model>` 
    
3. create LLM + chain

    set `model_path` to  `/var/app/ix/llama/<model>`    
    
    ![image](https://github.com/kreneskyp/ix/assets/68635/83faa560-431d-43eb-83b1-38d2633216f8)





### Changes
Adds `LLAMA_CPP_LLM`

### How Tested
- manual testing


### TODOs
- Streaming isn't working with `LLAMA_CPP_LLM`:
     - `IxHandler` isn't receiving all kwargs the model is initialized with so can't tell if streaming was enabled. This is a potential blocker. LLAMA_CPP appears to be intentionally filtering these out from `invocation params`
     - `IxHandler` needs to be updated to start streaming for LLMs (only supported for chat models right now)
     - Might be necessary to implement streaming using the officially blessed method of iterating over `chain.astream()` if workaround can't be found.
     
     
- Docker image isn't setup for GPU acceleration.  I made a short attempt at adding libraries to compile GPU support with `ENV LLAMA_CUBLAS=1` but the required libraries weren't installed in `python:3.11` docker image.  Wasn't readily apparent how to install the library.  May require switching to a different base image with better support.     