### PR TITLE
/node_types/ now allows filtering on component type

### DIFF
--- a/frontend/utils/hooks/usePaginatedAPI.js
+++ b/frontend/utils/hooks/usePaginatedAPI.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import axios from "axios";
+import qs from "qs";
 
 export function usePaginatedAPI(
   endpoint,
@@ -15,6 +16,9 @@ export function usePaginatedAPI(
       try {
         const response = await axios.get(endpoint, {
           params,
+          paramsSerializer: (params) => {
+            return qs.stringify(params, { arrayFormat: "repeat" });
+          },
         });
         setPage(response.data);
       } catch (error) {

--- a/ix/api/chains/endpoints.py
+++ b/ix/api/chains/endpoints.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from asgiref.sync import sync_to_async
 from django.db.models import Q
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
 from ix.chains.models import Chain, ChainNode, NodeType, ChainEdge
@@ -91,7 +91,10 @@ async def delete_chain(chain_id: UUID):
 
 @router.get("/node_types/", response_model=NodeTypePage, tags=["Components"])
 async def get_node_types(
-    search: Optional[str] = None, limit: int = 50, offset: int = 0
+    search: Optional[str] = None,
+    types: Optional[List[str]] = Query(None, alias="types"),
+    limit: int = 50,
+    offset: int = 0,
 ):
     if search:
         query = NodeType.objects.filter(
@@ -102,6 +105,9 @@ async def get_node_types(
         )
     else:
         query = NodeType.objects.all()
+
+    if types:
+        query = query.filter(type__in=types)
 
     # punting on async implementation of pagination until later
     return await sync_to_async(NodeTypePage.paginate)(

--- a/ix/api/tests/test_chains.py
+++ b/ix/api/tests/test_chains.py
@@ -55,7 +55,7 @@ class TestNodeType:
 
     async def test_search_node_types_types(self, anode_types):
         async with AsyncClient(app=app, base_url="http://test") as ac:
-            response = await ac.get(f"/node_types/?types=memory&types=llm")
+            response = await ac.get("/node_types/?types=memory&types=llm")
 
         assert response.status_code == 200, response.content
         page = response.json()

--- a/ix/chains/fixture_src/llm.py
+++ b/ix/chains/fixture_src/llm.py
@@ -2,8 +2,9 @@ from langchain import LlamaCpp
 
 from ix.api.chains.types import NodeTypeField
 
+OPENAI_LLM_CLASS_PATH = "langchain.chat_models.openai.ChatOpenAI"
 OPENAI_LLM = {
-    "class_path": "langchain.chat_models.openai.ChatOpenAI",
+    "class_path": OPENAI_LLM_CLASS_PATH,
     "type": "llm",
     "name": "OpenAI LLM",
     "description": "OpenAI LLM",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.4.0",
     "dagre": "^0.8.5",
     "package.json": "^2.0.1",
+    "qs": "^6.11.2",
     "react-syntax-highlighter": "^15.5.0",
     "reactflow": "^11.8.3",
     "slate": "^0.94.1",


### PR DESCRIPTION
### Description
`/node_types/` can now filter on component `types`.  Prep work for contextual searches triggered by selecting connectors.

### Changes
`/node_types/` can now filter on component `types`

### How Tested
- new unittests

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
