### PR TITLE
Markdown improvements

### DIFF
--- a/frontend/chains/flow/ChainNode.js
+++ b/frontend/chains/flow/ChainNode.js
@@ -1,11 +1,10 @@
-import React, {useMemo} from "react";
+import React, { useMemo } from "react";
 import { Handle, useEdges } from "reactflow";
 import { Box, VStack, Heading, Flex } from "@chakra-ui/react";
 import { TypeAutoFields } from "chains/flow/TypeAutoFields";
 import { CollapsibleSection } from "chains/flow/CollapsibleSection";
-import {NodeProperties, useConnectorColor} from "chains/flow/ConfigNode";
-import {RequiredAsterisk} from "components/RequiredAsterisk";
-
+import { NodeProperties, useConnectorColor } from "chains/flow/ConfigNode";
+import { RequiredAsterisk } from "components/RequiredAsterisk";
 
 const useFlowConnectors = (node) => {
   const edges = useEdges();
@@ -15,17 +14,16 @@ const useFlowConnectors = (node) => {
       input: {
         key: "in",
         required: true,
-        connected: edges?.find((edge) => edge.target === node.id)
+        connected: edges?.find((edge) => edge.target === node.id),
       },
       output: {
         key: "out",
         required: false,
-        connected: edges?.find((edge) => edge.source === node.id)
-      }
-    }
+        connected: edges?.find((edge) => edge.source === node.id),
+      },
+    };
   }, [edges, node.id]);
 };
-
 
 export const ChainNode = ({ type, node, config, onFieldChange }) => {
   const { input, output } = useFlowConnectors(node);
@@ -42,7 +40,7 @@ export const ChainNode = ({ type, node, config, onFieldChange }) => {
             position="left"
             style={{ top: "50%", transform: "translateY(-50%)" }}
           />
-          <Heading fontSize="xs" px={2} color={intputColor} >
+          <Heading fontSize="xs" px={2} color={intputColor}>
             Inputs <RequiredAsterisk color={intputColor} />
           </Heading>
         </Box>

--- a/frontend/chains/flow/ConfigNode.js
+++ b/frontend/chains/flow/ConfigNode.js
@@ -64,7 +64,7 @@ export const useConnectorColor = (connector) => {
   } else {
     return connectorStyle.default;
   }
-}
+};
 
 export const PropertyTarget = ({ connector }) => {
   const color = useConnectorColor(connector);
@@ -79,7 +79,8 @@ export const PropertyTarget = ({ connector }) => {
         }
       />
       <Box px={2} m={0} color={color}>
-        {connector.key} {connector.required && <RequiredAsterisk color={color} />}
+        {connector.key}{" "}
+        {connector.required && <RequiredAsterisk color={color} />}
       </Box>
     </Box>
   );

--- a/frontend/components/HighlightText.js
+++ b/frontend/components/HighlightText.js
@@ -10,52 +10,83 @@ import { useChatColorMode } from "chains/editor/useColorMode";
 const HighlightText = ({ content }) => {
   const { mention, artifact } = useChatColorMode();
 
+  const regexComponentPairs = React.useMemo(
+    () => [
+      {
+        regex: /@\w+/g,
+        component: (match, idx) => (
+          <Text as="span" sx={mention} key={idx}>
+            {match}
+          </Text>
+        ),
+      },
+      {
+        regex: /\{[^\}]+\}/g,
+        component: (match, idx) => (
+          <Text as="span" sx={artifact} key={idx}>
+            {match}
+          </Text>
+        ),
+      },
+      {
+        regex: /\*\*([^*]+)\*\*/g,
+        component: (match, idx, execResult) => (
+          <strong key={idx}>{execResult[1]}</strong>
+        ),
+      }, // Markdown Bold
+      {
+        regex: /\[([^\]]+)\]\(([^)]+)\)/g,
+        component: (match, idx, execResult) => (
+          <Link href={execResult[2]} key={idx} isExternal color={"blue.400"}>
+            {execResult[1]}
+          </Link>
+        ),
+      },
+      {
+        regex: /`([^`]+)`/g,
+        component: (match, idx, execResult) => (
+          <Code key={idx}>{execResult[1]}</Code>
+        ),
+      },
+    ],
+    [mention, artifact]
+  );
+
   const formattedContent = React.useMemo(() => {
     if (content === undefined) {
       return <div>"no content field"</div>;
     }
 
-    return content.split(/(\s+)/).map((segment, idx) => {
-      if (segment.startsWith("@")) {
-        return (
-          <Text as="span" sx={mention} key={idx}>
-            {segment}
-          </Text>
-        );
-      } else if (segment.startsWith("{") && segment.endsWith("}")) {
-        return (
-          <Text as="span" sx={artifact} key={idx}>
-            {segment}
-          </Text>
-        );
-      } else {
-        const markdownLinkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
-        const matchMarkdownLink = markdownLinkRegex.exec(segment);
+    let segments = [content];
 
-        if (matchMarkdownLink) {
-          const text = matchMarkdownLink[1];
-          const url = matchMarkdownLink[2];
+    regexComponentPairs.forEach(({ regex, component }) => {
+      let newSegments = [];
+      segments.forEach((segment, idx) => {
+        if (typeof segment === "string") {
+          let lastIndex = 0;
+          let match;
+          regex.lastIndex = 0; // Reset lastIndex due to the 'g' flag
 
-          return (
-            <Link href={url} key={idx} isExternal color={"blue.400"}>
-              {text}
-            </Link>
-          );
-        } else {
-          const codeRegex = /`([^`]+)`/g;
-          const matchCode = codeRegex.exec(segment);
+          while ((match = regex.exec(segment)) !== null) {
+            const matchedText = match[0];
+            const prefix = segment.substring(lastIndex, match.index);
+            lastIndex = regex.lastIndex;
 
-          if (matchCode) {
-            const code = matchCode[1];
-
-            return <Code key={idx}>{code}</Code>;
+            if (prefix) newSegments.push(prefix);
+            newSegments.push(component(matchedText, idx, match));
           }
-        }
 
-        return segment;
-      }
+          const postfix = segment.substring(lastIndex);
+          if (postfix) newSegments.push(postfix);
+        } else {
+          newSegments.push(segment);
+        }
+      });
+      segments = newSegments;
     });
-  }, [content, mention, artifact]);
+
+    return segments;
+  }, [content, regexComponentPairs]);
 
   return <Box style={{ whiteSpace: "pre-wrap" }}>{formattedContent}</Box>;
 };

--- a/frontend/components/RequiredAsterisk.js
+++ b/frontend/components/RequiredAsterisk.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Text } from "@chakra-ui/react";
 import { useColorMode } from "@chakra-ui/color-mode";
 
-export const RequiredAsterisk = ({color}) => {
+export const RequiredAsterisk = ({ color }) => {
   const { colorMode } = useColorMode();
   const _color = color || (colorMode === "light" ? "red.500" : "red.300");
   return (


### PR DESCRIPTION
### Description
Makes a few improvements to `HighlightText` to better handle links and to handle bolded text.  This is a small quality of life improvement until #107 has some progress with full markdown support.

![image](https://github.com/kreneskyp/ix/assets/68635/e6bc5228-b737-41ac-90be-982b08745dca)

![image](https://github.com/kreneskyp/ix/assets/68635/f3793e1e-0274-4329-9ea0-6179e650d325)

![image](https://github.com/kreneskyp/ix/assets/68635/eade0f7c-169c-4361-8286-dfb3b2ea1d1c)


### Changes
- refactored `HighlightText` to use regexes over the entire content string rather than individual words. Enabled urls and other elements with spaces to be detected.
- added markdown bold pattern

### How Tested
Tested with Metaphor search agent

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
