### PR TITLE
Auto connecting nodes

### DIFF
--- a/frontend/chains/ChainEditorView.js
+++ b/frontend/chains/ChainEditorView.js
@@ -1,18 +1,57 @@
-import React from "react";
+import React, { useCallback, useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
-import { Spinner, VStack } from "@chakra-ui/react";
+import { HStack, Spinner, useToast, VStack } from "@chakra-ui/react";
+import { ReactFlowProvider, useReactFlow } from "reactflow";
 
 import { Layout, LayoutContent, LayoutLeftPane } from "site/Layout";
 import ChainGraphEditor from "chains/ChainGraphEditor";
 import { ChainGraphEditorSideBar } from "chains/editor/ChainGraphEditorSideBar";
 import { useDetailAPI } from "utils/hooks/useDetailAPI";
 import { useObjectEditorView } from "utils/hooks/useObjectEditorView";
+import { useChainEditorAPI } from "chains/hooks/useChainEditorAPI";
+import { ChainEditorAPIContext } from "chains/editor/ChainEditorAPIContext";
+import { useSelectedNode } from "chains/hooks/useSelectedNode";
+import { SelectedNodeContext } from "chains/editor/SelectedNodeContext";
+
+const ChainEditorProvider = ({ chain, onError, children }) => {
+  const reactFlowInstance = useReactFlow();
+  const api = useChainEditorAPI({
+    chain,
+    reactFlowInstance,
+    onError,
+  });
+  const selectedNode = useSelectedNode();
+
+  return (
+    <SelectedNodeContext.Provider value={selectedNode}>
+      <ChainEditorAPIContext.Provider value={api}>
+        {children}
+      </ChainEditorAPIContext.Provider>
+    </SelectedNodeContext.Provider>
+  );
+};
 
 export const ChainEditorView = () => {
   const { id } = useParams();
   const { response, call, isLoading } = useDetailAPI(`/api/chains/${id}/graph`);
   const { isNew, idRef } = useObjectEditorView(id, call);
   const graph = response?.data;
+  const [chain, setChain] = useState(graph?.chain);
+  const toast = useToast();
+
+  const onAPIError = useCallback((err) => {
+    toast({
+      title: "Error",
+      description: `Failed to save chain. ${err.message}`,
+      status: "error",
+      duration: 10000,
+      isClosable: true,
+    });
+  }, []);
+
+  useEffect(() => {
+    setChain(graph?.chain);
+  }, [graph?.chain]);
 
   let content;
   if (isNew) {
@@ -20,19 +59,27 @@ export const ChainEditorView = () => {
   } else if (isLoading || !graph) {
     content = <Spinner />;
   } else {
-    content = <ChainGraphEditor graph={graph} />;
+    content = (
+      <ChainGraphEditor graph={graph} chain={chain} setChain={setChain} />
+    );
   }
 
   return (
-    <Layout>
-      <LayoutLeftPane>
-        <ChainGraphEditorSideBar />
-      </LayoutLeftPane>
-      <LayoutContent>
-        <VStack alignItems="start" p={5} spacing={4}>
-          {content}
-        </VStack>
-      </LayoutContent>
-    </Layout>
+    <ReactFlowProvider>
+      <ChainEditorProvider chain={chain} onError={onAPIError}>
+        <Layout>
+          <LayoutLeftPane>
+            <ChainGraphEditorSideBar />
+          </LayoutLeftPane>
+          <LayoutContent>
+            <HStack>
+              <VStack alignItems="start" p={5} spacing={4}>
+                {content}
+              </VStack>
+            </HStack>
+          </LayoutContent>
+        </Layout>
+      </ChainEditorProvider>
+    </ReactFlowProvider>
   );
 };

--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -196,6 +196,11 @@ const ChainGraphEditor = ({ graph, chain, setChain }) => {
   );
 
   const onNodeDragStop = useCallback((event, node) => {
+    // ignore position updates for root
+    if (node.id === "root") {
+      return;
+    }
+
     // update node with new position
     api.updateNodePosition(node.id, node.position);
   }, []);

--- a/frontend/chains/editor/ConnectorPopover.js
+++ b/frontend/chains/editor/ConnectorPopover.js
@@ -1,0 +1,66 @@
+import React, { useState, useEffect, useContext } from "react";
+import {
+  Badge,
+  Box,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverCloseButton,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTrigger,
+} from "@chakra-ui/react";
+import { SelectedNodeContext } from "chains/editor/SelectedNodeContext";
+import { useEditorColorMode } from "chains/editor/useColorMode";
+
+const DEFAULT_DESCRIPTION =
+  "Attach components to this connector by dragging them from the search results in the left panel.";
+
+export const ConnectorPopover = ({ node, connector, label, placement }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { highlight } = useEditorColorMode();
+  const { setSelectedConnector } = useContext(SelectedNodeContext);
+
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedConnector({ node, connector });
+    }
+  }, [isOpen, setSelectedConnector, connector]);
+
+  const openPopover = () => setIsOpen(true);
+  const closePopover = () => setIsOpen(false);
+
+  const source_types = Array.isArray(connector.source_type)
+    ? connector.source_type
+    : [connector?.source_type];
+
+  const description = connector.description || DEFAULT_DESCRIPTION;
+
+  return (
+    <Popover
+      isOpen={isOpen}
+      onClose={closePopover}
+      placement={placement || "left"}
+    >
+      <PopoverTrigger>
+        <Box as="button" onClick={openPopover}>
+          {label || connector.key}
+        </Box>
+      </PopoverTrigger>
+      <PopoverContent zIndex={99999} color={"white"}>
+        <PopoverArrow />
+        <PopoverHeader>
+          {source_types?.map((type) => {
+            return (
+              <Badge px={2} mr={1} bg={highlight[type]} key={type}>
+                {type}
+              </Badge>
+            );
+          })}
+        </PopoverHeader>
+        <PopoverCloseButton onClick={closePopover} />
+        <PopoverBody>{description}</PopoverBody>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/frontend/chains/editor/ConnectorPopover.js
+++ b/frontend/chains/editor/ConnectorPopover.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, { useEffect, useContext } from "react";
 import {
   Badge,
   Box,
@@ -9,6 +9,7 @@ import {
   PopoverContent,
   PopoverHeader,
   PopoverTrigger,
+  useDisclosure,
 } from "@chakra-ui/react";
 import { SelectedNodeContext } from "chains/editor/SelectedNodeContext";
 import { useEditorColorMode } from "chains/editor/useColorMode";
@@ -22,8 +23,9 @@ export const ConnectorPopover = ({
   connector,
   label,
   placement,
+  children,
 }) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const { isOpen, onToggle, onClose } = useDisclosure();
   const { highlight } = useEditorColorMode();
   const { setSelectedConnector } = useContext(SelectedNodeContext);
 
@@ -33,9 +35,6 @@ export const ConnectorPopover = ({
     }
   }, [isOpen, setSelectedConnector, connector]);
 
-  const openPopover = () => setIsOpen(true);
-  const closePopover = () => setIsOpen(false);
-
   const source_types = Array.isArray(connector.source_type)
     ? connector.source_type
     : [connector?.source_type];
@@ -43,14 +42,10 @@ export const ConnectorPopover = ({
   const description = connector.description || DEFAULT_DESCRIPTION;
 
   return (
-    <Popover
-      isOpen={isOpen}
-      onClose={closePopover}
-      placement={placement || "left"}
-    >
+    <Popover isOpen={isOpen} onClose={onClose} placement={placement}>
       <PopoverTrigger>
-        <Box as="button" onClick={openPopover}>
-          {label || connector.key}
+        <Box as="button" onClick={onToggle}>
+          {children || label || connector.key}
         </Box>
       </PopoverTrigger>
       <PopoverContent zIndex={99999} color={"white"}>
@@ -64,9 +59,13 @@ export const ConnectorPopover = ({
             );
           })}
         </PopoverHeader>
-        <PopoverCloseButton onClick={closePopover} />
+        <PopoverCloseButton />
         <PopoverBody>{description}</PopoverBody>
       </PopoverContent>
     </Popover>
   );
+};
+
+ConnectorPopover.defaultProps = {
+  placement: "left",
 };

--- a/frontend/chains/editor/ConnectorPopover.js
+++ b/frontend/chains/editor/ConnectorPopover.js
@@ -16,14 +16,20 @@ import { useEditorColorMode } from "chains/editor/useColorMode";
 const DEFAULT_DESCRIPTION =
   "Attach components to this connector by dragging them from the search results in the left panel.";
 
-export const ConnectorPopover = ({ node, connector, label, placement }) => {
+export const ConnectorPopover = ({
+  type,
+  node,
+  connector,
+  label,
+  placement,
+}) => {
   const [isOpen, setIsOpen] = useState(false);
   const { highlight } = useEditorColorMode();
   const { setSelectedConnector } = useContext(SelectedNodeContext);
 
   useEffect(() => {
     if (isOpen) {
-      setSelectedConnector({ node, connector });
+      setSelectedConnector({ type, node, connector });
     }
   }, [isOpen, setSelectedConnector, connector]);
 

--- a/frontend/chains/editor/NodeTypeSearch.js
+++ b/frontend/chains/editor/NodeTypeSearch.js
@@ -151,7 +151,7 @@ export const NodeTypeSearch = () => {
   const [query, setQuery] = useState({ search: "", types: [] });
 
   // component query
-  const { load, page } = usePaginatedAPI(`/api/node_types/`, { load: false });
+  const { load, page } = usePaginatedAPI(`/api/node_types/`, { load: false, limit: 50 });
 
   // trigger query when query state changes
   useEffect(() => {

--- a/frontend/chains/editor/NodeTypeSearch.js
+++ b/frontend/chains/editor/NodeTypeSearch.js
@@ -151,7 +151,10 @@ export const NodeTypeSearch = () => {
   const [query, setQuery] = useState({ search: "", types: [] });
 
   // component query
-  const { load, page } = usePaginatedAPI(`/api/node_types/`, { load: false, limit: 50 });
+  const { load, page } = usePaginatedAPI(`/api/node_types/`, {
+    load: false,
+    limit: 50,
+  });
 
   // trigger query when query state changes
   useEffect(() => {

--- a/frontend/chains/editor/NodeTypeSearch.js
+++ b/frontend/chains/editor/NodeTypeSearch.js
@@ -172,10 +172,10 @@ export const NodeTypeSearch = () => {
       const types = Array.isArray(connector.source_type)
         ? connector.source_type
         : [connector?.source_type];
-      setQuery({ search: "", types: types });
+      setQuery((prev) => ({ ...prev, types }));
     } else {
       // clear query
-      setQuery({ search: "", types: [] });
+      setQuery((prev) => ({ ...prev, types: [] }));
     }
   }, [selectedConnector]);
 

--- a/frontend/chains/editor/NodeTypeSearch.js
+++ b/frontend/chains/editor/NodeTypeSearch.js
@@ -1,11 +1,24 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useContext, useEffect, useMemo } from "react";
 import { NodeSelector } from "chains/editor/NodeSelector";
 import { useDebounce } from "utils/hooks/useDebounce";
-import { Box, Heading, HStack, Input, Text, VStack } from "@chakra-ui/react";
-import { useSideBarColorMode } from "chains/editor/useColorMode";
+import {
+  Badge,
+  Box,
+  Heading,
+  HStack,
+  Input,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import {
+  useEditorColorMode,
+  useSideBarColorMode,
+} from "chains/editor/useColorMode";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { DEFAULT_NODE_STYLE, NODE_STYLES } from "chains/editor/styles";
 import { usePaginatedAPI } from "utils/hooks/usePaginatedAPI";
+import { SelectedNodeContext } from "chains/editor/SelectedNodeContext";
+import { faXmark } from "@fortawesome/free-solid-svg-icons";
 
 const NodeSelectorHeader = ({ label, icon }) => {
   const { color } = useSideBarColorMode();

--- a/frontend/chains/editor/SelectedNodeContext.js
+++ b/frontend/chains/editor/SelectedNodeContext.js
@@ -1,0 +1,3 @@
+import React, { createContext } from "react";
+
+export const SelectedNodeContext = createContext(null);

--- a/frontend/chains/editor/useColorMode.js
+++ b/frontend/chains/editor/useColorMode.js
@@ -4,10 +4,11 @@ export const useEditorColorMode = () => {
   const { colorMode } = useColorMode();
   const isLight = colorMode === "light";
 
-  const retrieval = isLight ? "gray.700" : "gray.900";
+  const retrieval = isLight ? "gray.700" : "gray.800";
 
   return {
     isLight,
+    selectionShadow: isLight ? "0 0 10px 2px black" : "0 0 7px 1px cyan",
     highlightColor: isLight ? "gray.100" : "gray.100",
     color: isLight ? "gray.800" : "gray.100",
     bg: isLight ? "white" : "gray.700",
@@ -43,6 +44,7 @@ export const useEditorColorMode = () => {
       connected: isLight ? "gray.800" : "gray.100",
       required: isLight ? "red.800" : "red.300",
       default: isLight ? "gray.400" : "gray.500",
+      selected: isLight ? "blue.400" : "blue.400",
     },
     highlight: {
       root: isLight ? "gray.300" : "gray.900",

--- a/frontend/chains/flow/ChainNode.js
+++ b/frontend/chains/flow/ChainNode.js
@@ -33,7 +33,7 @@ const useFlowConnectors = (node) => {
   }, [edges, node.id]);
 };
 
-export const InputConnector = ({ node }) => {
+export const InputConnector = ({ type, node }) => {
   const { input } = useFlowConnectors(node);
   const intputColor = useConnectorColor(node, input);
   return (
@@ -46,6 +46,7 @@ export const InputConnector = ({ node }) => {
       />
       <Heading fontSize="xs" px={2} color={intputColor}>
         <ConnectorPopover
+          type={type}
           node={node}
           connector={input}
           label={"Input"}
@@ -57,7 +58,7 @@ export const InputConnector = ({ node }) => {
   );
 };
 
-export const OutputConnector = ({ node }) => {
+export const OutputConnector = ({ type, node }) => {
   const { output } = useFlowConnectors(node);
   const outputColor = useConnectorColor(node, output);
   return (
@@ -70,6 +71,7 @@ export const OutputConnector = ({ node }) => {
       />
       <Heading fontSize="xs" px={2} color={outputColor}>
         <ConnectorPopover
+          type={type}
           node={node}
           connector={output}
           label={"Output"}
@@ -84,8 +86,8 @@ export const ChainNode = ({ type, node, config, onFieldChange }) => {
   return (
     <VStack spacing={0} alignItems="stretch" fontSize="xs">
       <Flex mt={1} mb={3} justify={"space-between"}>
-        <InputConnector node={node} />
-        <OutputConnector node={node} />
+        <InputConnector type={type} node={node} />
+        <OutputConnector type={type} node={node} />
       </Flex>
       <NodeProperties node={node} type={type} />
       <CollapsibleSection title="Config">

--- a/frontend/chains/flow/ChainNode.js
+++ b/frontend/chains/flow/ChainNode.js
@@ -5,6 +5,7 @@ import { TypeAutoFields } from "chains/flow/TypeAutoFields";
 import { CollapsibleSection } from "chains/flow/CollapsibleSection";
 import { NodeProperties, useConnectorColor } from "chains/flow/ConfigNode";
 import { RequiredAsterisk } from "components/RequiredAsterisk";
+import { ConnectorPopover } from "chains/editor/ConnectorPopover";
 
 const useFlowConnectors = (node) => {
   const edges = useEdges();
@@ -13,11 +14,18 @@ const useFlowConnectors = (node) => {
     return {
       input: {
         key: "in",
+        type: "target",
         required: true,
         connected: edges?.find((edge) => edge.target === node.id),
+        source_type: ["root", "agent", "chain"],
       },
       output: {
         key: "out",
+        type: "source",
+        // TODO: need to handle agent/chain output types
+        //       reusing source_types property for now since
+        //       the rest of the code is treated the same.
+        source_type: ["agent", "chain"],
         required: false,
         connected: edges?.find((edge) => edge.source === node.id),
       },
@@ -25,37 +33,59 @@ const useFlowConnectors = (node) => {
   }, [edges, node.id]);
 };
 
-export const ChainNode = ({ type, node, config, onFieldChange }) => {
-  const { input, output } = useFlowConnectors(node);
-  const intputColor = useConnectorColor(input);
-  const outputColor = useConnectorColor(output);
+export const InputConnector = ({ node }) => {
+  const { input } = useFlowConnectors(node);
+  const intputColor = useConnectorColor(node, input);
+  return (
+    <Box position="relative">
+      <Handle
+        id="in"
+        type="target"
+        position="left"
+        style={{ top: "50%", transform: "translateY(-50%)" }}
+      />
+      <Heading fontSize="xs" px={2} color={intputColor}>
+        <ConnectorPopover
+          node={node}
+          connector={input}
+          label={"Input"}
+          placement={"left"}
+        />{" "}
+        <RequiredAsterisk color={intputColor} />
+      </Heading>
+    </Box>
+  );
+};
 
+export const OutputConnector = ({ node }) => {
+  const { output } = useFlowConnectors(node);
+  const outputColor = useConnectorColor(node, output);
+  return (
+    <Box position="relative">
+      <Handle
+        id="out"
+        type="source"
+        position="right"
+        style={{ top: "50%", transform: "translateY(-50%)" }}
+      />
+      <Heading fontSize="xs" px={2} color={outputColor}>
+        <ConnectorPopover
+          node={node}
+          connector={output}
+          label={"Output"}
+          placement={"right"}
+        />
+      </Heading>
+    </Box>
+  );
+};
+
+export const ChainNode = ({ type, node, config, onFieldChange }) => {
   return (
     <VStack spacing={0} alignItems="stretch" fontSize="xs">
       <Flex mt={1} mb={3} justify={"space-between"}>
-        <Box position="relative">
-          <Handle
-            id="in"
-            type="target"
-            position="left"
-            style={{ top: "50%", transform: "translateY(-50%)" }}
-          />
-          <Heading fontSize="xs" px={2} color={intputColor}>
-            Inputs <RequiredAsterisk color={intputColor} />
-          </Heading>
-        </Box>
-
-        <Box position="relative">
-          <Handle
-            id="out"
-            type="source"
-            position="right"
-            style={{ top: "50%", transform: "translateY(-50%)" }}
-          />
-          <Heading fontSize="xs" px={2} color={outputColor}>
-            Output
-          </Heading>
-        </Box>
+        <InputConnector node={node} />
+        <OutputConnector node={node} />
       </Flex>
       <NodeProperties node={node} type={type} />
       <CollapsibleSection title="Config">

--- a/frontend/chains/flow/ConfigNode.js
+++ b/frontend/chains/flow/ConfigNode.js
@@ -18,6 +18,8 @@ import { useDebounce } from "utils/hooks/useDebounce";
 import { FunctionSchemaNode } from "chains/flow/FunctionSchemaNode";
 import { DEFAULT_NODE_STYLE, NODE_STYLES } from "chains/editor/styles";
 import { RequiredAsterisk } from "components/RequiredAsterisk";
+import { ConnectorPopover } from "chains/editor/ConnectorPopover";
+import { SelectedNodeContext } from "chains/editor/SelectedNodeContext";
 
 const NODE_COMPONENTS = {
   "langchain.prompts.chat.ChatPromptTemplate": PromptNode,
@@ -59,9 +61,15 @@ const usePropertyTargets = (node, type) => {
   }, [type, edges, node.id]);
 };
 
-export const useConnectorColor = (connector) => {
+export const useConnectorColor = (node, connector) => {
+  const { selectedConnector } = useContext(SelectedNodeContext);
   const { connector: connectorStyle } = useEditorColorMode();
-  if (connector.connected) {
+  if (
+    connector.key === selectedConnector?.connector.key &&
+    node.id === selectedConnector?.node.id
+  ) {
+    return connectorStyle.selected;
+  } else if (connector.connected) {
     return connectorStyle.connected;
   } else if (connector.required) {
     return connectorStyle.required;
@@ -70,20 +78,23 @@ export const useConnectorColor = (connector) => {
   }
 };
 
-export const PropertyTarget = ({ connector }) => {
-  const color = useConnectorColor(connector);
-  const source_type = Array.isArray(connector.source_type) ? connector.source_type[0] : connector.source_type;
+export const PropertyTarget = ({ node, connector }) => {
+  const color = useConnectorColor(node, connector);
+  const source_type = Array.isArray(connector.source_type)
+    ? connector.source_type[0]
+    : connector.source_type;
+
+  const position = CONNECTOR_CONFIG[source_type]?.target_position || "left";
+
   return (
     <Box position="relative" width="100%">
-      <Handle
-        id={connector.key}
-        type="target"
-        position={
-          CONNECTOR_CONFIG[source_type]?.target_position || "left"
-        }
-      />
+      <Handle id={connector.key} type="target" position={position} />
       <Box px={2} m={0} color={color}>
-        {connector.key}{" "}
+        <ConnectorPopover
+          node={node}
+          connector={connector}
+          placement={position}
+        />{" "}
         {connector.required && <RequiredAsterisk color={color} />}
       </Box>
     </Box>
@@ -97,9 +108,10 @@ export const NodeProperties = ({ node, type }) => {
   const left = [];
   const right = [];
   propertyTargets?.forEach((connector) => {
-    const source_type = Array.isArray(connector.source_type) ? connector.source_type[0] : connector.source_type;
-    const position =
-      CONNECTOR_CONFIG[source_type]?.target_position || "left";
+    const source_type = Array.isArray(connector.source_type)
+      ? connector.source_type[0]
+      : connector.source_type;
+    const position = CONNECTOR_CONFIG[source_type]?.target_position || "left";
     if (position === "right") {
       right.push(connector);
     } else {
@@ -111,12 +123,12 @@ export const NodeProperties = ({ node, type }) => {
     <Flex justify={"space-between"}>
       <VStack spacing={0} cursor="default">
         {left?.map((connector, index) => (
-          <PropertyTarget key={index} connector={connector} />
+          <PropertyTarget key={index} node={node} connector={connector} />
         ))}
       </VStack>
       <VStack spacing={0} cursor="default">
         {right?.map((connector, index) => (
-          <PropertyTarget key={index} connector={connector} />
+          <PropertyTarget key={index} node={node} connector={connector} />
         ))}
       </VStack>
     </Flex>
@@ -152,10 +164,11 @@ const DeleteIcon = ({ node }) => {
   );
 };
 
-export const ConfigNode = ({ data }) => {
+export const ConfigNode = ({ data, selected, ...args }) => {
   const { type, node } = data;
   const styles = NODE_STYLES[type.type] || DEFAULT_NODE_STYLE;
-  const { border, color, highlight, highlightColor, bg } = useEditorColorMode();
+  const { border, color, highlight, highlightColor, bg, selectionShadow } =
+    useEditorColorMode();
   const [config, setConfig] = useState(node.config);
 
   const api = useContext(ChainEditorAPIContext);
@@ -206,18 +219,22 @@ export const ConfigNode = ({ data }) => {
   );
   const position = CONNECTOR_CONFIG[type.type]?.source_position || "right";
 
+  const nodeStyle = {
+    color,
+    border: "1px solid",
+    borderColor: border,
+    backgroundColor: bg,
+    boxShadow: selected ? selectionShadow : "md",
+  };
+
   return (
     <Box p={5} className="config-node">
       <Box
         borderWidth="0px"
         borderRadius={8}
         padding="0"
-        border="1px solid"
-        borderColor={border}
-        backgroundColor={bg}
         minWidth={styles?.width || 250}
-        color={color}
-        boxShadow="md"
+        {...nodeStyle}
       >
         <Handle
           id={type.type}

--- a/frontend/chains/flow/ConfigNode.js
+++ b/frontend/chains/flow/ConfigNode.js
@@ -78,7 +78,7 @@ export const useConnectorColor = (node, connector) => {
   }
 };
 
-export const PropertyTarget = ({ node, connector }) => {
+export const PropertyTarget = ({ type, node, connector }) => {
   const color = useConnectorColor(node, connector);
   const source_type = Array.isArray(connector.source_type)
     ? connector.source_type[0]
@@ -91,6 +91,7 @@ export const PropertyTarget = ({ node, connector }) => {
       <Handle id={connector.key} type="target" position={position} />
       <Box px={2} m={0} color={color}>
         <ConnectorPopover
+          type={type}
           node={node}
           connector={connector}
           placement={position}
@@ -123,12 +124,22 @@ export const NodeProperties = ({ node, type }) => {
     <Flex justify={"space-between"}>
       <VStack spacing={0} cursor="default">
         {left?.map((connector, index) => (
-          <PropertyTarget key={index} node={node} connector={connector} />
+          <PropertyTarget
+            key={index}
+            type={type}
+            node={node}
+            connector={connector}
+          />
         ))}
       </VStack>
       <VStack spacing={0} cursor="default">
         {right?.map((connector, index) => (
-          <PropertyTarget key={index} node={node} connector={connector} />
+          <PropertyTarget
+            key={index}
+            type={type}
+            node={node}
+            connector={connector}
+          />
         ))}
       </VStack>
     </Flex>

--- a/frontend/chains/flow/RootNode.js
+++ b/frontend/chains/flow/RootNode.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, Heading } from "@chakra-ui/react";
+import { Box } from "@chakra-ui/react";
 import { Handle } from "reactflow";
 import { faKeyboard } from "@fortawesome/free-solid-svg-icons";
 
@@ -15,7 +15,7 @@ const ROOT_CONNECTOR = {
   key: "out",
   type: "source",
   source_type: ["agent", "chain"],
-  description: "Connect to an agent or chain input that starts the chain.",
+  description: "Connect to an agent or chain input to start the chain.",
 };
 
 const ROOT_TYPE = {
@@ -37,33 +37,30 @@ export const RootNode = () => {
       borderColor="blue.800"
       backgroundColor={bg}
       minWidth={150}
-      alignItems={"right"}
     >
       <Handle
-        id="out"
-        type="source"
-        position="right"
+        id={ROOT_CONNECTOR.key}
+        type={ROOT_CONNECTOR.type}
+        position={"right"}
         style={{ top: "15px", transform: "translateX(-2px)" }}
       />
-      <Heading
-        as="h4"
-        size="xs"
+      <Box
+        size="sm"
         color={node.root.color}
         borderRadius={7}
         bg={node.root.bg}
         px={1}
-        py={2}
-        className="drag-handle"
+        py={1}
       >
-        <FontAwesomeIcon icon={faKeyboard} />{" "}
         <ConnectorPopover
           type={ROOT_TYPE}
           node={ROOT_NODE}
           connector={ROOT_CONNECTOR}
-          label={"Chat Input"}
-          placement={"right"}
-        />
-      </Heading>
+          placement={"left"}
+        >
+          <FontAwesomeIcon icon={faKeyboard} /> Chat Input
+        </ConnectorPopover>
+      </Box>
     </Box>
   );
 };

--- a/frontend/chains/flow/RootNode.js
+++ b/frontend/chains/flow/RootNode.js
@@ -5,6 +5,25 @@ import { faKeyboard } from "@fortawesome/free-solid-svg-icons";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useEditorColorMode } from "chains/editor/useColorMode";
+import { ConnectorPopover } from "chains/editor/ConnectorPopover";
+
+const ROOT_NODE = {
+  id: "root",
+};
+
+const ROOT_CONNECTOR = {
+  key: "out",
+  type: "source",
+  source_type: ["agent", "chain"],
+  description: "Connect to an agent or chain input that starts the chain.",
+};
+
+const ROOT_TYPE = {
+  id: "root",
+  class_path: "root",
+  fields: [],
+  connectors: [ROOT_CONNECTOR],
+};
 
 export const RootNode = () => {
   const { node, bg } = useEditorColorMode();
@@ -18,6 +37,7 @@ export const RootNode = () => {
       borderColor="blue.800"
       backgroundColor={bg}
       minWidth={150}
+      alignItems={"right"}
     >
       <Handle
         id="out"
@@ -35,7 +55,14 @@ export const RootNode = () => {
         py={2}
         className="drag-handle"
       >
-        <FontAwesomeIcon icon={faKeyboard} /> Chat Input
+        <FontAwesomeIcon icon={faKeyboard} />{" "}
+        <ConnectorPopover
+          type={ROOT_TYPE}
+          node={ROOT_NODE}
+          connector={ROOT_CONNECTOR}
+          label={"Chat Input"}
+          placement={"right"}
+        />
       </Heading>
     </Box>
   );

--- a/frontend/chains/flow/TypeAutoFields.js
+++ b/frontend/chains/flow/TypeAutoFields.js
@@ -69,7 +69,7 @@ const AutoFieldSecret = ({ field, value, onChange }) => {
       </FormLabel>
       <Input
         size="sm"
-        value={value}
+        value={value || ""}
         onChange={handleChange}
         px={1}
         py={2}

--- a/frontend/chains/flow/TypeAutoFields.js
+++ b/frontend/chains/flow/TypeAutoFields.js
@@ -44,7 +44,7 @@ const AutoFieldInput = ({ field, value, onChange }) => {
       </FormLabel>
       <Input
         size="sm"
-        value={value}
+        value={value || ""}
         onChange={handleChange}
         px={1}
         py={2}

--- a/frontend/chains/hooks/useConnectionValidator.js
+++ b/frontend/chains/hooks/useConnectionValidator.js
@@ -1,0 +1,79 @@
+import { useMemo } from "react";
+import { useReactFlow } from "reactflow";
+
+export const useConnectionValidator = (edgeUpdate) => {
+  const reactFlowInstance = useReactFlow();
+
+  const isValidConnection = useMemo(() => {
+    return ({
+      source,
+      target,
+      sourceHandle,
+      targetHandle,
+      sourceType,
+      targetType,
+    }) => {
+      // target
+      // hax: targetNode isn't available when creating a new node
+      //      require targetType when not available
+      const targetNode = reactFlowInstance.getNode(target);
+      const targetNodeType = targetType || targetNode.data.type;
+      const connectors = targetNodeType.connectors;
+      let connector, expectedTypes;
+      if (targetHandle === "in") {
+        expectedTypes = new Set(["chain-link"]);
+      } else {
+        connector = connectors.find((c) => c.key === targetHandle);
+        expectedTypes = Array.isArray(connector?.source_type)
+          ? new Set(connector.source_type)
+          : new Set([connector.source_type]);
+      }
+      const supportsMultiple = connector?.multiple || false;
+
+      // source
+      // hax: sourceNode isn't available when creating a new node
+      //      require sourceType when not available
+      const sourceNode = reactFlowInstance.getNode(source);
+      const sourceNodeType = sourceType || sourceNode.data.type;
+      const providedType =
+        sourceHandle === "out" ? "chain-link" : sourceNodeType.type;
+
+      // Check connection types
+      if (
+        expectedTypes.has(providedType) ||
+        (expectedTypes.has("chain") && providedType === "agent")
+      ) {
+        const instanceEdges = reactFlowInstance.getEdges();
+        const targetEdges = instanceEdges.filter(
+          (e) => e.target === target && e.targetHandle === targetHandle
+        );
+        const sourceEdges = instanceEdges.filter(
+          (e) => e.source === source && e.sourceHandle === sourceHandle
+        );
+
+        const sourceConnected = sourceEdges.length > 0;
+        const targetConnected = targetEdges.length > 0;
+
+        if (edgeUpdate.edge) {
+          const currentSource = edgeUpdate.edge.source;
+          const currentTarget = edgeUpdate.edge.target;
+          const isSameSource = source === currentSource;
+          const isSameTarget = target === currentTarget;
+
+          return (
+            (isSameSource || !sourceConnected) &&
+            (isSameTarget || !targetConnected || supportsMultiple)
+          );
+        } else {
+          return !sourceConnected && (!targetConnected || supportsMultiple);
+        }
+      }
+
+      return false;
+    };
+  }, [reactFlowInstance, edgeUpdate]);
+
+  return {
+    isValidConnection,
+  };
+};

--- a/frontend/chains/hooks/useConnectionValidator.js
+++ b/frontend/chains/hooks/useConnectionValidator.js
@@ -34,9 +34,10 @@ export const useConnectionValidator = (edgeUpdate) => {
       // hax: sourceNode isn't available when creating a new node
       //      require sourceType when not available
       const sourceNode = reactFlowInstance.getNode(source);
-      const sourceNodeType = sourceType || sourceNode.data.type;
       const providedType =
-        sourceHandle === "out" ? "chain-link" : sourceNodeType.type;
+        sourceHandle === "out"
+          ? "chain-link"
+          : (sourceType || sourceNode.data.type).type;
 
       // Check connection types
       if (

--- a/frontend/chains/hooks/useGraphForReactFlow.js
+++ b/frontend/chains/hooks/useGraphForReactFlow.js
@@ -17,7 +17,6 @@ export const toReactFlowNode = (node, nodeType) => {
   return {
     id: node.id,
     type: nodeType.display_type,
-    dragHandle: ".drag-handle",
     position: node.position,
     data: {
       type: nodeType,

--- a/frontend/chains/hooks/useSelectedNode.js
+++ b/frontend/chains/hooks/useSelectedNode.js
@@ -1,0 +1,49 @@
+import React, { useCallback, useState } from "react";
+import { useOnSelectionChange } from "reactflow";
+
+export const useSelectedNode = () => {
+  const [data, setData] = useState({
+    selectedNode: null,
+    selectedConnector: null,
+    config: null,
+  });
+
+  const setSelectedNode = useCallback(
+    (node) => {
+      setData((prev) => ({ ...prev, selectedNode: node }));
+    },
+    [setData]
+  );
+
+  const setConfig = useCallback(
+    (config) => {
+      setData((prev) => ({ ...prev, config }));
+    },
+    [setData]
+  );
+
+  const setSelectedConnector = useCallback(
+    (connector) => {
+      setData((prev) => ({ ...prev, selectedConnector: connector }));
+    },
+    [setData]
+  );
+
+  const onSelectionChange = useOnSelectionChange({
+    onChange: ({ nodes }) => {
+      setData((prev) => ({
+        ...prev,
+        selectedNode: nodes[0] || null,
+        selectedConfig: nodes[0]?.data?.node?.config || null,
+      }));
+    },
+  });
+
+  return {
+    ...data,
+    setSelectedNode,
+    setSelectedConnector,
+    setConfig,
+    onSelectionChange,
+  };
+};

--- a/ix/api/chains/endpoints.py
+++ b/ix/api/chains/endpoints.py
@@ -91,7 +91,7 @@ async def delete_chain(chain_id: UUID):
 
 @router.get("/node_types/", response_model=NodeTypePage, tags=["Components"])
 async def get_node_types(
-    search: Optional[str] = None, limit: int = 50, offset: int = 0
+    search: Optional[str] = None, type: List[str] = None, limit: int = 50, offset: int = 0
 ):
     if search:
         query = NodeType.objects.filter(
@@ -102,6 +102,9 @@ async def get_node_types(
         )
     else:
         query = NodeType.objects.all()
+
+    if type:
+        query = query.filter(type__in=type)
 
     # punting on async implementation of pagination until later
     return await sync_to_async(NodeTypePage.paginate)(


### PR DESCRIPTION
### Description
This PR introduces nodes that auto-connect. Nodes and connectors may now be selected. Nodes creating while a selection is active will auto-connect when possible:

- Selected Node: the first open valid connection will be created
- Selected Connector: Connection created to open and valid connectors.  

![metaphor-agent-auto-edges_V1](https://github.com/kreneskyp/ix/assets/68635/2c5b74bd-6495-4196-93f6-9faf099e32be)


### Changes

#### ChainGraphView state
- Providers used by `ChainGraphEditor` pushed up to surround `ChainGraphView` to make them accessible across the whole editor including sidebars
- Added selection state & styling for nodes and connectors

#### Auto edges
- Nodes and connectors may now be selected by clicking them
- `/node/` now allows a list of `Edge` to be created with the `Node`
- `ChainGraphEditor` includes edges to selected node/connector when creating a new node

#### Component search
- `NodeTypeSearch` refactored to support multiple search fields
- `NodeTypeSearch` can now search component types
- `NodeTypeSearch` query now updates in response to selected connectors

### How Tested
- manual testing

### TODOs
- [ ] Add descriptions to all connectors (followup)
- [x] Disallow invalid connections
      Need to refactor `isValidConnection` code for reuse in this context 
    - [x] mismatched types
    - [x] no vacancy
- [x] Root node: search filter + auto-connect

