### PR TITLE
Chain editor right sidebar

### DIFF
--- a/frontend/chains/ChainEditorView.js
+++ b/frontend/chains/ChainEditorView.js
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import {
   HStack,
   Spinner,
+  useDisclosure,
   useToast,
   VStack,
 } from "@chakra-ui/react";
@@ -63,6 +64,8 @@ export const ChainEditorView = () => {
   const [chain, setChain] = useState(graph?.chain);
   const toast = useToast();
 
+  const rightSidebarDisclosure = useDisclosure({ defaultIsOpen: true });
+
   const onAPIError = useCallback((err) => {
     toast({
       title: "Error",
@@ -79,12 +82,22 @@ export const ChainEditorView = () => {
 
   let content;
   if (isNew) {
-    content = <ChainGraphEditor key={idRef} />;
+    content = (
+      <ChainGraphEditor
+        key={idRef}
+        rightSidebarDisclosure={rightSidebarDisclosure}
+      />
+    );
   } else if (isLoading || !graph) {
     content = <Spinner />;
   } else {
     content = (
-      <ChainGraphEditor graph={graph} chain={chain} setChain={setChain} />
+      <ChainGraphEditor
+        graph={graph}
+        chain={chain}
+        setChain={setChain}
+        rightSidebarDisclosure={rightSidebarDisclosure}
+      />
     );
   }
 
@@ -104,6 +117,7 @@ export const ChainEditorView = () => {
               <VStack alignItems="start" p={5} spacing={4}>
                 {content}
               </VStack>
+              <EditorRightSidebar {...rightSidebarDisclosure} />
             </HStack>
           </LayoutContent>
         </Layout>

--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useCallback, useContext } from "react";
 import { v4 as uuid4 } from "uuid";
-import { Box, Input } from "@chakra-ui/react";
+import { Box, IconButton, Input } from "@chakra-ui/react";
 import ReactFlow, {
   addEdge,
   updateEdge,
@@ -27,6 +27,8 @@ import { useDebounce } from "utils/hooks/useDebounce";
 import { useAxios } from "utils/hooks/useAxios";
 import { NodeStateContext, SelectedNodeContext } from "chains/editor/contexts";
 import { useConnectionValidator } from "chains/hooks/useConnectionValidator";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faBars } from "@fortawesome/free-solid-svg-icons";
 
 // Nodes are either a single node or a group of nodes
 // ConfigNode renders class_path specific content
@@ -42,7 +44,12 @@ const getExpectedTypes = (connector) => {
     : new Set([connector.source_type]);
 };
 
-const ChainGraphEditor = ({ graph, chain, setChain }) => {
+const ChainGraphEditor = ({
+  graph,
+  chain,
+  setChain,
+  rightSidebarDisclosure,
+}) => {
   const reactFlowWrapper = useRef(null);
   const edgeUpdate = useRef(true);
   const [chainLoaded, setChainLoaded] = useState(graph?.chain !== undefined);
@@ -331,17 +338,26 @@ const ChainGraphEditor = ({ graph, chain, setChain }) => {
 
   return (
     <Box height="93vh">
-      <Box pb={1}>
-        <Input
-          size="sm"
-          value={chain?.name || "Unnamed"}
-          width={300}
-          borderColor="transparent"
-          _hover={{
-            border: "1px solid",
-            borderColor: "gray.500",
-          }}
-          onChange={onTitleChange}
+      <Box display="flex" alignItems="center">
+        <Box pb={1}>
+          <Input
+            size="sm"
+            value={chain?.name || "Unnamed"}
+            width={300}
+            borderColor="transparent"
+            _hover={{
+              border: "1px solid",
+              borderColor: "gray.500",
+            }}
+            onChange={onTitleChange}
+          />
+        </Box>
+
+        <IconButton
+          ml="auto"
+          icon={<FontAwesomeIcon icon={faBars} />}
+          onClick={rightSidebarDisclosure.onOpen}
+          aria-label="Open Sidebar"
         />
       </Box>
       <Box ref={reactFlowWrapper} width={"85vw"} height={"100%"}>

--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -25,7 +25,7 @@ import { RootNode } from "chains/flow/RootNode";
 import { getDefaults } from "chains/flow/TypeAutoFields";
 import { useDebounce } from "utils/hooks/useDebounce";
 import { useAxios } from "utils/hooks/useAxios";
-import { SelectedNodeContext } from "chains/editor/SelectedNodeContext";
+import { NodeStateContext, SelectedNodeContext } from "chains/editor/contexts";
 import { useConnectionValidator } from "chains/hooks/useConnectionValidator";
 
 // Nodes are either a single node or a group of nodes
@@ -54,6 +54,7 @@ const ChainGraphEditor = ({ graph, chain, setChain }) => {
   const [reactFlowInstance, setReactFlowInstance] = useState(null);
   const { colorMode } = useColorMode();
   const navigate = useNavigate();
+  const nodeState = useContext(NodeStateContext);
   const api = useContext(ChainEditorAPIContext);
   const { selectedNode, selectedConnector, setSelectedConnector } =
     useContext(SelectedNodeContext);
@@ -169,6 +170,7 @@ const ChainGraphEditor = ({ graph, chain, setChain }) => {
       if (edge) {
         data.edges = [edge];
       }
+      nodeState.setNode(data);
 
       // create ReactFlow node
       const flowNode = toReactFlowNode(data, nodeType);

--- a/frontend/chains/editor/ConfigEditorPane.js
+++ b/frontend/chains/editor/ConfigEditorPane.js
@@ -1,0 +1,156 @@
+import {
+  Badge,
+  Box,
+  FormControl,
+  FormLabel,
+  Heading,
+  HStack,
+  Input,
+  Text,
+  Textarea,
+  VStack,
+} from "@chakra-ui/react";
+import React, { useCallback, useContext, useMemo } from "react";
+import { TypeAutoFields } from "chains/flow/TypeAutoFields";
+import { useDebounce } from "utils/hooks/useDebounce";
+import { ChainEditorAPIContext } from "chains/editor/ChainEditorAPIContext";
+import { useEditorColorMode } from "chains/editor/useColorMode";
+import { NodeStateContext, SelectedNodeContext } from "chains/editor/contexts";
+import { PromptNode } from "chains/flow/PromptNode";
+import { FunctionSchemaNode } from "chains/flow/FunctionSchemaNode";
+import { CollapsibleSection } from "chains/flow/CollapsibleSection";
+import { useNodeEditorAPI } from "chains/hooks/useNodeEditorAPI";
+
+const CONFIG_FORM_COMPONENTS = {
+  "langchain.prompts.chat.ChatPromptTemplate": PromptNode,
+  "ix.chains.functions.FunctionSchema": FunctionSchemaNode,
+};
+
+const NodeGeneralForm = ({ node, onChange }) => {
+  const handleNameChange = useCallback(
+    (e) => {
+      onChange.all({
+        ...node,
+        name: e.target.value,
+      });
+    },
+    [node, onChange]
+  );
+
+  const handleDescriptionChange = useCallback(
+    (e) => {
+      onChange.all({
+        ...node,
+        description: e.target.value,
+      });
+    },
+    [node, onChange]
+  );
+
+  return (
+    <Box>
+      <VStack spacing={4} align="stretch">
+        <FormControl id="name">
+          <FormLabel>Name</FormLabel>
+          <Input
+            type="text"
+            placeholder="Enter node name"
+            value={node?.name || ""}
+            onChange={handleNameChange}
+          />
+        </FormControl>
+        <FormControl id="description">
+          <FormLabel>Description</FormLabel>
+          <Textarea
+            placeholder="Enter node description"
+            value={node?.description || ""}
+            onChange={handleDescriptionChange}
+          />
+        </FormControl>
+      </VStack>
+    </Box>
+  );
+};
+
+const DefaultForm = ({ type, node, onChange }) => {
+  if (!node) {
+    return null;
+  }
+
+  return (
+    <TypeAutoFields
+      type={type}
+      config={node.config}
+      onChange={onChange.field}
+    />
+  );
+};
+
+/**
+ * Hook for a node editor's state. Loads from selected nodes.
+ */
+export const useNodeEditorState = () => {
+  const { nodes } = useContext(NodeStateContext);
+  const { selectedNode } = useContext(SelectedNodeContext);
+  const data = selectedNode?.data || {};
+  const { type } = data;
+  const node = nodes && nodes[selectedNode?.id];
+  return { type, node };
+};
+
+const useNodeName = (type, node) => {
+  if (node?.name) {
+    return `${node.name}`;
+  } else if (type?.name) {
+    return type?.name;
+  }
+  return node?.class_path.split(".").pop();
+};
+
+export const ConfigEditorPane = () => {
+  const { selectedNode } = useContext(SelectedNodeContext);
+  const { setNode } = useContext(NodeStateContext);
+  const { type, node } = useNodeEditorState();
+  const { highlight } = useEditorColorMode();
+  const { handleConfigChange } = useNodeEditorAPI(node, setNode);
+
+  const ConfigForm = CONFIG_FORM_COMPONENTS[type?.class_path] || DefaultForm;
+  const name = useNodeName(type, node);
+
+  let content;
+  if (selectedNode && node?.config) {
+    content = (
+      <>
+        <CollapsibleSection title="General" mt={3}>
+          <NodeGeneralForm node={node} onChange={handleConfigChange} />
+        </CollapsibleSection>
+        <CollapsibleSection title="Config" initialShow={true} mt={3}>
+          {<ConfigForm node={node} type={type} onChange={handleConfigChange} />}
+        </CollapsibleSection>
+      </>
+    );
+  } else {
+    content = (
+      <Text color={"gray.500"} fontSize={"xs"}>
+        Select a component node to edit its configuration.
+      </Text>
+    );
+  }
+
+  return (
+    <Box>
+      <HStack>
+        <Badge bg={highlight[type?.type] || highlight.default} size={"xs"}>
+          {type?.type}
+        </Badge>
+        <Heading as="h3" size="md">
+          {name}
+        </Heading>
+      </HStack>
+      <Text color={"gray.500"} fontSize={"xs"}>
+        {type?.name}
+      </Text>
+      {content}
+    </Box>
+  );
+};

--- a/frontend/chains/editor/ConnectorPopover.js
+++ b/frontend/chains/editor/ConnectorPopover.js
@@ -11,7 +11,7 @@ import {
   PopoverTrigger,
   useDisclosure,
 } from "@chakra-ui/react";
-import { SelectedNodeContext } from "chains/editor/SelectedNodeContext";
+import { SelectedNodeContext } from "chains/editor/contexts";
 import { useEditorColorMode } from "chains/editor/useColorMode";
 
 const DEFAULT_DESCRIPTION =

--- a/frontend/chains/editor/EditorRightSidebar.js
+++ b/frontend/chains/editor/EditorRightSidebar.js
@@ -1,0 +1,77 @@
+import React, { useRef } from "react";
+import {
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerOverlay,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Tooltip,
+} from "@chakra-ui/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faChain,
+  faCheckCircle,
+  faComments,
+  faNetworkWired,
+  faRobot,
+} from "@fortawesome/free-solid-svg-icons";
+import { ConfigEditorPane } from "chains/editor/ConfigEditorPane";
+
+export const EditorRightSidebar = ({ isOpen, onOpen, onClose }) => {
+  const btnRef = useRef();
+
+  return (
+    <div>
+      <Drawer
+        isOpen={isOpen}
+        placement="right"
+        onClose={onClose}
+        finalFocusRef={btnRef}
+        closeOnOverlayClick={false}
+        trapFocus={false}
+        size={"sm"}
+      >
+        <DrawerOverlay
+          style={{ backgroundColor: "transparent", pointerEvents: "none" }}
+        >
+          <DrawerContent style={{ pointerEvents: "all" }}>
+            <DrawerCloseButton />
+            <DrawerBody>
+              <Tabs isLazy>
+                <TabList>
+                  <Tooltip label="Node" aria-label="Node">
+                    <Tab>
+                      <FontAwesomeIcon icon={faNetworkWired} />
+                    </Tab>
+                  </Tooltip>
+                </TabList>
+                <TabPanels>
+                  <TabPanel>
+                    <ConfigEditorPane />
+                  </TabPanel>
+                  <TabPanel>
+                    <p>Chain content here</p>
+                  </TabPanel>
+                  <TabPanel>
+                    <p>Chat content here</p>
+                  </TabPanel>
+                  <TabPanel>
+                    <p>Validation content here</p>
+                  </TabPanel>
+                  <TabPanel>
+                    <p>Assistant content here</p>
+                  </TabPanel>
+                </TabPanels>
+              </Tabs>
+            </DrawerBody>
+          </DrawerContent>
+        </DrawerOverlay>
+      </Drawer>
+    </div>
+  );
+};

--- a/frontend/chains/editor/NodeTypeSearch.js
+++ b/frontend/chains/editor/NodeTypeSearch.js
@@ -23,7 +23,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { DEFAULT_NODE_STYLE, NODE_STYLES } from "chains/editor/styles";
 import { usePaginatedAPI } from "utils/hooks/usePaginatedAPI";
-import { SelectedNodeContext } from "chains/editor/SelectedNodeContext";
+import { SelectedNodeContext } from "chains/editor/contexts";
 import { faXmark } from "@fortawesome/free-solid-svg-icons";
 
 const NodeSelectorHeader = ({ label, icon }) => {

--- a/frontend/chains/editor/PromptEditor.js
+++ b/frontend/chains/editor/PromptEditor.js
@@ -16,7 +16,6 @@ import {
   faArrowDown,
 } from "@fortawesome/free-solid-svg-icons";
 import { SCROLLBAR_CSS } from "site/css";
-import { NodeResizeControl } from "reactflow";
 
 const ROLE_OPTIONS = ["user", "assistant"];
 
@@ -100,14 +99,6 @@ const PromptEditor = ({ data, onChange }) => {
 
   return (
     <VStack spacing={1} align="stretch">
-      <NodeResizeControl
-        variant={"line"}
-        minWidth={400}
-        position={"left"}
-        h={"100%"}
-        style={{ border: "5px solid transparent" }}
-      />
-
       {messages.map((message, index) => (
         <VStack key={index} p={2} spacing={2}>
           <Flex
@@ -120,6 +111,7 @@ const PromptEditor = ({ data, onChange }) => {
               <Text fontWeight="bold">System</Text>
             ) : (
               <Select
+                size={"sm"}
                 width={125}
                 value={message.role}
                 onChange={(e) =>
@@ -166,6 +158,7 @@ const PromptEditor = ({ data, onChange }) => {
             }
             isRequired
             css={SCROLLBAR_CSS}
+            size={"sm"}
           />
         </VStack>
       ))}
@@ -175,17 +168,12 @@ const PromptEditor = ({ data, onChange }) => {
           leftIcon={<FontAwesomeIcon icon={faPlus} />}
           colorScheme="orange"
           onClick={addMessage}
-          mr={4}
+          mr={2}
+          size={"sm"}
         >
           Add Message
         </Button>
       </Flex>
-      <NodeResizeControl
-        variant={"line"}
-        minWidth={400}
-        h={"100%"}
-        style={{ border: "5px solid transparent" }}
-      />
     </VStack>
   );
 };

--- a/frontend/chains/editor/SelectedNodeContext.js
+++ b/frontend/chains/editor/SelectedNodeContext.js
@@ -1,3 +1,0 @@
-import React, { createContext } from "react";
-
-export const SelectedNodeContext = createContext(null);

--- a/frontend/chains/editor/contexts.js
+++ b/frontend/chains/editor/contexts.js
@@ -1,0 +1,5 @@
+import React, { createContext } from "react";
+
+export const NodeStateContext = createContext(null);
+export const NodeEditorContext = createContext(null);
+export const SelectedNodeContext = createContext(null);

--- a/frontend/chains/editor/styles.js
+++ b/frontend/chains/editor/styles.js
@@ -28,7 +28,6 @@ export const NODE_STYLES = {
   },
   prompt: {
     icon: faMessage,
-    width: 400,
   },
   agent: {
     icon: faRobot,

--- a/frontend/chains/flow/ChainNode.js
+++ b/frontend/chains/flow/ChainNode.js
@@ -90,9 +90,6 @@ export const ChainNode = ({ type, node, config, onFieldChange }) => {
         <OutputConnector type={type} node={node} />
       </Flex>
       <NodeProperties node={node} type={type} />
-      <CollapsibleSection title="Config">
-        <TypeAutoFields type={type} config={config} onChange={onFieldChange} />
-      </CollapsibleSection>
     </VStack>
   );
 };

--- a/frontend/chains/flow/CollapsibleSection.js
+++ b/frontend/chains/flow/CollapsibleSection.js
@@ -7,8 +7,13 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { useEditorColorMode } from "chains/editor/useColorMode";
 
-export const CollapsibleSection = ({ title, children, ...props }) => {
-  const [show, setShow] = useState(false);
+export const CollapsibleSection = ({
+  title,
+  children,
+  initialShow,
+  ...props
+}) => {
+  const [show, setShow] = useState(initialShow || false);
   const toggle = useCallback(() => setShow(!show), [show]);
   const { node } = useEditorColorMode();
 
@@ -24,7 +29,9 @@ export const CollapsibleSection = ({ title, children, ...props }) => {
         justifyContent="space-between"
         align="center"
         sx={node.header}
-        bg="blackAlpha.200"
+        color={"gray.400"}
+        borderColor={"gray.400"}
+        borderBottomWidth={1}
       >
         {title} <FontAwesomeIcon icon={show ? faChevronDown : faChevronRight} />
       </Flex>

--- a/frontend/chains/flow/ConfigNode.js
+++ b/frontend/chains/flow/ConfigNode.js
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useContext,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useContext, useMemo } from "react";
 import { Box, Flex, Heading, VStack } from "@chakra-ui/react";
 import { Handle, useEdges, useReactFlow } from "reactflow";
 import { faTrash } from "@fortawesome/free-solid-svg-icons";
@@ -19,12 +13,7 @@ import { FunctionSchemaNode } from "chains/flow/FunctionSchemaNode";
 import { DEFAULT_NODE_STYLE, NODE_STYLES } from "chains/editor/styles";
 import { RequiredAsterisk } from "components/RequiredAsterisk";
 import { ConnectorPopover } from "chains/editor/ConnectorPopover";
-import { SelectedNodeContext } from "chains/editor/SelectedNodeContext";
-
-const NODE_COMPONENTS = {
-  "langchain.prompts.chat.ChatPromptTemplate": PromptNode,
-  "ix.chains.functions.FunctionSchema": FunctionSchemaNode,
-};
+import { NodeStateContext, SelectedNodeContext } from "chains/editor/contexts";
 
 const CONNECTOR_CONFIG = {
   agent: {
@@ -146,7 +135,7 @@ export const NodeProperties = ({ node, type }) => {
   );
 };
 
-export const DefaultNodeContent = ({ type, config, node, onFieldChange }) => {
+export const DefaultNodeContent = ({ type, node }) => {
   return (
     <>
       <NodeProperties node={node} type={type} />
@@ -175,53 +164,35 @@ const DeleteIcon = ({ node }) => {
   );
 };
 
-export const ConfigNode = ({ data, selected, ...args }) => {
-  const { type, node } = data;
+export const ConfigNode = ({ id, data, selected }) => {
+  const { type } = data;
   const styles = NODE_STYLES[type.type] || DEFAULT_NODE_STYLE;
   const { border, color, highlight, highlightColor, bg, selectionShadow } =
     useEditorColorMode();
-  const [config, setConfig] = useState(node.config);
+  const position = CONNECTOR_CONFIG[type.type]?.source_position || "right";
+  const { nodes } = useContext(NodeStateContext);
+  const node = nodes[data.node.id];
 
-  const api = useContext(ChainEditorAPIContext);
+  const nodeStyle = {
+    color,
+    border: "1px solid",
+    borderColor: border,
+    backgroundColor: bg,
+    boxShadow: selected ? selectionShadow : "md",
+  };
 
-  // ref for handlers to access latest config without re-rendering
-  const configRef = useRef();
-  configRef.current = config;
-
-  const { callback: debouncedUpdateNode } = useDebounce(api.updateNode, 1000);
-  const handleConfigChange = useMemo(() => {
-    function all(newConfig, delay = 0) {
-      const data = {
-        class_path: node.class_path,
-        description: node.description,
-        position: node.position,
-        config: newConfig,
-      };
-      debouncedUpdateNode(node.id, data);
-      setConfig(newConfig);
-    }
-
-    const field = (key, value, delay = 1000) => {
-      const newConfig = { ...configRef.current, [key]: value };
-      all(newConfig, delay);
-    };
-
-    return { all, field };
-  }, [node.id, api, configRef]);
+  if (!node) {
+    return null;
+  }
 
   // node type specific content
   let NodeComponent = null;
-  if (NODE_COMPONENTS[node.class_path]) {
-    NodeComponent = NODE_COMPONENTS[node.class_path];
-  } else if (styles?.component) {
+  if (styles?.component) {
     NodeComponent = styles.component;
   }
   const node_component_props = {
     type,
     node,
-    config,
-    onChange: handleConfigChange.all,
-    onFieldChange: handleConfigChange.field,
   };
   const content = NodeComponent ? (
     <NodeComponent {...node_component_props} />

--- a/frontend/chains/flow/ConfigNode.js
+++ b/frontend/chains/flow/ConfigNode.js
@@ -4,12 +4,7 @@ import { Handle, useEdges, useReactFlow } from "reactflow";
 import { faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useEditorColorMode } from "chains/editor/useColorMode";
-import { PromptNode } from "chains/flow/PromptNode";
 import { ChainEditorAPIContext } from "chains/editor/ChainEditorAPIContext";
-import { TypeAutoFields } from "chains/flow/TypeAutoFields";
-import { CollapsibleSection } from "chains/flow/CollapsibleSection";
-import { useDebounce } from "utils/hooks/useDebounce";
-import { FunctionSchemaNode } from "chains/flow/FunctionSchemaNode";
 import { DEFAULT_NODE_STYLE, NODE_STYLES } from "chains/editor/styles";
 import { RequiredAsterisk } from "components/RequiredAsterisk";
 import { ConnectorPopover } from "chains/editor/ConnectorPopover";
@@ -139,9 +134,6 @@ export const DefaultNodeContent = ({ type, node }) => {
   return (
     <>
       <NodeProperties node={node} type={type} />
-      <CollapsibleSection title="Config">
-        <TypeAutoFields type={type} config={config} onChange={onFieldChange} />
-      </CollapsibleSection>
     </>
   );
 };
@@ -199,15 +191,6 @@ export const ConfigNode = ({ id, data, selected }) => {
   ) : (
     <DefaultNodeContent {...node_component_props} />
   );
-  const position = CONNECTOR_CONFIG[type.type]?.source_position || "right";
-
-  const nodeStyle = {
-    color,
-    border: "1px solid",
-    borderColor: border,
-    backgroundColor: bg,
-    boxShadow: selected ? selectionShadow : "md",
-  };
 
   return (
     <Box p={5} className="config-node">
@@ -215,7 +198,7 @@ export const ConfigNode = ({ id, data, selected }) => {
         borderWidth="0px"
         borderRadius={8}
         padding="0"
-        minWidth={styles?.width || 250}
+        minWidth={250}
         {...nodeStyle}
       >
         <Handle

--- a/frontend/chains/flow/FunctionSchemaNode.js
+++ b/frontend/chains/flow/FunctionSchemaNode.js
@@ -4,61 +4,36 @@ import { Editable, Slate, withReact } from "slate-react";
 import { withHistory } from "slate-history";
 import { createEditor } from "slate";
 import { INITIAL_EDITOR_CONTENT } from "utils/slate";
-import { NodeResizeControl, NodeResizer } from "reactflow";
 import { useEditorColorMode } from "chains/editor/useColorMode";
 import { SCROLLBAR_CSS } from "site/css";
 
-export const FunctionSchemaNode = ({ config, onFieldChange }) => {
+export const FunctionSchemaNode = ({ node, onChange }) => {
   const editor = useMemo(() => withReact(withHistory(createEditor())), []);
 
   const { code } = useEditorColorMode();
 
   const handleChange = useCallback(
     (e) => {
-      onFieldChange(e.target.name, e.target.value);
+      onChange.field(e.target.name, e.target.value);
     },
-    [onFieldChange]
+    [onChange]
   );
 
   return (
     <>
-      <Box p={2} minWidth={200}>
-        <NodeResizeControl
-          variant={"line"}
-          minWidth={250}
-          position={"left"}
-          h={"100%"}
-          w={"10px"}
-          style={{ border: "5px solid transparent" }}
-        />
-        <FormLabel justify="start">Name</FormLabel>
-        <Input name="name" value={config.name} onChange={handleChange} />
-        <FormLabel justify="start">Description</FormLabel>
-        <Textarea
-          name="description"
-          value={config.description}
-          onChange={handleChange}
-          css={SCROLLBAR_CSS}
-        ></Textarea>
-        <FormLabel justify="start">Parameters</FormLabel>
-        <Textarea
-          name="parameters"
-          value={config.parameters}
-          onChange={handleChange}
-          color={code.color}
-          bg={code.bg}
-          fontFamily="monospace"
-          font="monospace"
-          fontSize="sm"
-          css={SCROLLBAR_CSS}
-        />
-        <NodeResizeControl
-          variant={"line"}
-          minWidth={250}
-          h={"100%"}
-          style={{ border: "5px solid transparent" }}
-        />
-      </Box>
+      <FormLabel justify="start">Parameters</FormLabel>
+      <Textarea
+        name="parameters"
+        value={node.config.parameters}
+        onChange={handleChange}
+        color={code.color}
+        bg={code.bg}
+        fontFamily="monospace"
+        font="monospace"
+        fontSize="sm"
+        css={SCROLLBAR_CSS}
+        placeholder={"Enter JSON Schema for function parameters."}
+      />
     </>
   );
 };

--- a/frontend/chains/flow/PromptNode.js
+++ b/frontend/chains/flow/PromptNode.js
@@ -1,11 +1,8 @@
 import React from "react";
 import PromptEditor from "chains/editor/PromptEditor";
-import { Box } from "@chakra-ui/react";
 
-export const PromptNode = ({ config, onChange }) => {
+export const PromptNode = ({ node, onChange }) => {
   return (
-    <Box p={2}>
-      <PromptEditor data={config} onChange={onChange} />
-    </Box>
+    <PromptEditor key={node.id} data={node.config} onChange={onChange.config} />
   );
 };

--- a/frontend/chains/flow/TypeAutoFields.js
+++ b/frontend/chains/flow/TypeAutoFields.js
@@ -48,7 +48,7 @@ const AutoFieldInput = ({ field, value, onChange }) => {
         onChange={handleChange}
         px={1}
         py={2}
-        sx={field.style || { width: 100 }}
+        sx={field.style || { width: 130 }}
       />
     </Flex>
   );

--- a/frontend/chains/hooks/useNodeEditorAPI.js
+++ b/frontend/chains/hooks/useNodeEditorAPI.js
@@ -1,0 +1,39 @@
+import { useContext, useMemo } from "react";
+import { SelectedNodeContext } from "chains/editor/contexts";
+import { ChainEditorAPIContext } from "chains/editor/ChainEditorAPIContext";
+import { useDebounce } from "utils/hooks/useDebounce";
+
+/**
+ * Hook for a node editor's API. Returns debounced updateNode functions
+ * for the full object and for individual fields.
+ */
+export const useNodeEditorAPI = (node, setNode) => {
+  const { selectedNode } = useContext(SelectedNodeContext);
+  const api = useContext(ChainEditorAPIContext);
+  const { callback: debouncedUpdateNode } = useDebounce(api.updateNode, 500);
+  const handleConfigChange = useMemo(() => {
+    function all(newNode, delay = 0) {
+      const data = {
+        name: newNode.name,
+        description: newNode.description,
+        config: newNode.config,
+        class_path: node.class_path,
+        position: node.position,
+      };
+      debouncedUpdateNode(node.id, data);
+      setNode(newNode);
+    }
+
+    const config = (newConfig, delay = 500) => {
+      all({ ...node, config: newConfig }, delay);
+    };
+
+    const field = (key, value, delay = 500) => {
+      config({ ...node.config, [key]: value }, delay);
+    };
+
+    return { all, field, config };
+  }, [selectedNode, api, node, setNode]);
+
+  return { handleConfigChange };
+};

--- a/frontend/chains/hooks/useNodeState.js
+++ b/frontend/chains/hooks/useNodeState.js
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+/**
+ * Central state for nodes in the editor. All components that need to
+ * read or write node state should use this hook.
+ */
+export const useNodeState = (chain, initialNodes) => {
+  const [nodes, setNodes] = useState(initialNodes || {});
+
+  // convert node list into a map, reload if the chain changes
+  // first render chain may be null.
+  useEffect(() => {
+    const nodeMap = {};
+    initialNodes?.forEach((node) => {
+      nodeMap[node.id] = node;
+    });
+    setNodes(nodeMap);
+  }, [chain?.id]);
+
+  // callback for updating a single node
+  const setNode = useCallback(
+    (node) => {
+      setNodes((prev) => ({ ...prev, [node.id]: node }));
+    },
+    [setNodes]
+  );
+
+  return useMemo(
+    () => ({
+      nodes,
+      setNodes,
+      setNode,
+    }),
+    [nodes, setNodes, setNode]
+  );
+};

--- a/frontend/chains/hooks/useSelectedNode.js
+++ b/frontend/chains/hooks/useSelectedNode.js
@@ -1,23 +1,47 @@
-import React, { useCallback, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { useOnSelectionChange } from "reactflow";
+
+/**
+ * Hook for a node editor's state. Loads from selected nodes.
+ * Also handles syncing back to the ReactFlow node.
+ */
+export const useNodeEditorState = (selectedNode, nodes, setNode) => {
+  const data = selectedNode?.data || {};
+  const { type } = data;
+  const node = nodes && nodes[selectedNode?.id];
+
+  const onUpdateNode = useCallback(
+    (data) => {
+      setNode(data);
+    },
+    [selectedNode, setNode]
+  );
+
+  return useMemo(
+    () => ({
+      type,
+      node,
+      setNode: onUpdateNode,
+    }),
+    [type, node, onUpdateNode]
+  );
+};
 
 export const useSelectedNode = () => {
   const [data, setData] = useState({
     selectedNode: null,
     selectedConnector: null,
-    config: null,
   });
 
   const setSelectedNode = useCallback(
     (node) => {
       setData((prev) => ({ ...prev, selectedNode: node }));
-    },
-    [setData]
-  );
-
-  const setConfig = useCallback(
-    (config) => {
-      setData((prev) => ({ ...prev, config }));
     },
     [setData]
   );

--- a/frontend/chains/hooks/useSelectedNode.js
+++ b/frontend/chains/hooks/useSelectedNode.js
@@ -53,21 +53,21 @@ export const useSelectedNode = () => {
     [setData]
   );
 
-  const onSelectionChange = useOnSelectionChange({
+  useOnSelectionChange({
     onChange: ({ nodes }) => {
       setData((prev) => ({
         ...prev,
         selectedNode: nodes[0] || null,
-        selectedConfig: nodes[0]?.data?.node?.config || null,
       }));
     },
   });
 
-  return {
-    ...data,
-    setSelectedNode,
-    setSelectedConnector,
-    setConfig,
-    onSelectionChange,
-  };
+  return useMemo(
+    () => ({
+      ...data,
+      setSelectedNode,
+      setSelectedConnector,
+    }),
+    [data, setSelectedNode, setSelectedConnector]
+  );
 };


### PR DESCRIPTION
### Description
This PR introduces a new side bar to the chain editor. Component config and other options will move over here. This space provides more real estate for rich editors, complex configuration, test chat, validation, and other features.

![image](https://github.com/kreneskyp/ix/assets/68635/01c0f482-758b-432d-bd8c-fbdb8149e0d5)
![image](https://github.com/kreneskyp/ix/assets/68635/64c00929-89e1-42ec-9761-01132ab876f3)

The sidebar can be hidden.

![image](https://github.com/kreneskyp/ix/assets/68635/61d83f68-2ada-4653-a1c1-38c1127c5ce4)


This PR also required aligning state within the editor. Nodes are now available consistently throughout the editor.

### Changes
- Adds `NodeStateContext` for managing shared node state in `ChainGraphView`
- Adds right sidebar to `ChainGraphEditor`
- Moves component config forms to `ConfigEditorPane` in the sidebar.

### How Tested
manual testing

### TODOs
- Follow-up: add more features to the sidebar.
- Follow-up: add controls to resize the sidebar.
