### PR TITLE
Sidebar chains

### DIFF
--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -342,7 +342,8 @@ const ChainGraphEditor = ({ graph, rightSidebarDisclosure }) => {
         <Box pb={1}>
           <Input
             size="sm"
-            value={chain?.name || "Unnamed"}
+            placeholder={"Unnamed Chain"}
+            value={chain?.name || ""}
             width={300}
             borderColor="transparent"
             _hover={{

--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -25,7 +25,11 @@ import { RootNode } from "chains/flow/RootNode";
 import { getDefaults } from "chains/flow/TypeAutoFields";
 import { useDebounce } from "utils/hooks/useDebounce";
 import { useAxios } from "utils/hooks/useAxios";
-import { NodeStateContext, SelectedNodeContext } from "chains/editor/contexts";
+import {
+  ChainState,
+  NodeStateContext,
+  SelectedNodeContext,
+} from "chains/editor/contexts";
 import { useConnectionValidator } from "chains/hooks/useConnectionValidator";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBars } from "@fortawesome/free-solid-svg-icons";
@@ -44,16 +48,12 @@ const getExpectedTypes = (connector) => {
     : new Set([connector.source_type]);
 };
 
-const ChainGraphEditor = ({
-  graph,
-  chain,
-  setChain,
-  rightSidebarDisclosure,
-}) => {
+const ChainGraphEditor = ({ graph, rightSidebarDisclosure }) => {
   const reactFlowWrapper = useRef(null);
   const edgeUpdate = useRef(true);
   const [chainLoaded, setChainLoaded] = useState(graph?.chain !== undefined);
   const { call: loadChain } = useAxios();
+  const { chain, setChain } = useContext(ChainState);
 
   const reactFlowGraph = useGraphForReactFlow(graph);
   const [nodes, setNodes, onNodesChange] = useNodesState(reactFlowGraph.nodes);

--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -298,11 +298,11 @@ const ChainGraphEditor = ({ graph, rightSidebarDisclosure }) => {
 
   const { callback: debouncedChainUpdate } = useDebounce((...args) => {
     api.updateChain(...args);
-  }, 1000);
+  }, 500);
 
   const { callback: debouncedChainCreate } = useDebounce((...args) => {
     api.createChain(...args);
-  }, 1000);
+  }, 800);
 
   const onTitleChange = useCallback(
     (event) => {

--- a/frontend/chains/editor/ChainEditorPane.js
+++ b/frontend/chains/editor/ChainEditorPane.js
@@ -1,0 +1,110 @@
+import React, { useCallback, useContext } from "react";
+import { Box, Button, HStack, useDisclosure, Text } from "@chakra-ui/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faChain, faRobot } from "@fortawesome/free-solid-svg-icons";
+import { useEditorColorMode } from "chains/editor/useColorMode";
+import { ChainState } from "chains/editor/contexts";
+import { ChainEditorAPIContext } from "chains/editor/ChainEditorAPIContext";
+import { useDebounce } from "utils/hooks/useDebounce";
+import { CollapsibleSection } from "chains/flow/CollapsibleSection";
+import { NameField } from "chains/editor/fields/NameField";
+import { DescriptionField } from "chains/editor/fields/DescriptionField";
+
+const ChainExplanation = () => {
+  return (
+    <Box>
+      Chains may be used by other agents and chains as tools with a{" "}
+      <Text as={"span"} color={"blue.300"}>
+        ChainReference
+      </Text>{" "}
+      component.
+    </Box>
+  );
+};
+
+const AgentExplanation = () => {
+  const { agent } = useContext(AgentState);
+  return (
+    <Box>
+      Agents may be summoned to chat sessions and will respond to messages. This
+      agents responds to the alias{" "}
+      <Text as={"span"} color={"blue.300"}>
+        @{agent}
+      </Text>
+    </Box>
+  );
+};
+
+const SaveModeChooser = () => {
+  const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: true });
+  const { isLight, highlight } = useEditorColorMode();
+  const color = isLight
+    ? { onColor: "#38A169", offColor: "gray.600" }
+    : { onColor: "#38A169", offColor: "gray.600" };
+  return (
+    <Box>
+      <HStack justifyItems={"fle"}>
+        <Box>
+          <Button
+            size="sm"
+            onClick={onToggle}
+            bg={isOpen ? highlight.agent : color.offColor}
+          >
+            <FontAwesomeIcon icon={faRobot} />
+            <Text as={"span"} ml={1}>
+              Agent
+            </Text>
+          </Button>
+        </Box>
+        <Box>
+          <Button
+            size="sm"
+            onClick={onToggle}
+            bg={isOpen ? color.offColor : highlight.chain}
+          >
+            <FontAwesomeIcon icon={faChain} />{" "}
+            <Text as={"span"} ml={1}>
+              Chain
+            </Text>
+          </Button>
+        </Box>
+      </HStack>
+      <Box
+        border={"1px solid"}
+        borderColor={"gray.600"}
+        fontSize={"xs"}
+        color={"gray.300"}
+        bg={"blackAlpha.300"}
+        p={2}
+        m={5}
+      >
+        {isOpen ? <AgentExplanation /> : <ChainExplanation />}
+      </Box>
+    </Box>
+  );
+};
+
+export const ChainEditorPane = () => {
+  const { chain, setChain } = useContext(ChainState);
+  const { updateChain } = useContext(ChainEditorAPIContext);
+
+  const { callback: debouncedChainUpdate } = useDebounce((...args) => {
+    updateChain(...args);
+  }, 500);
+
+  // save to API and state
+  const onChange = useCallback(
+    (data) => {
+      debouncedChainUpdate(data);
+      setChain(data);
+    },
+    [setChain, updateChain]
+  );
+
+  return (
+    <CollapsibleSection title="General" mt={3} initialShow={true}>
+      <NameField object={chain} onChange={onChange} />
+      <DescriptionField object={chain} onChange={onChange} />
+    </CollapsibleSection>
+  );
+};

--- a/frontend/chains/editor/ConfigEditorPane.js
+++ b/frontend/chains/editor/ConfigEditorPane.js
@@ -1,75 +1,18 @@
-import {
-  Badge,
-  Box,
-  FormControl,
-  FormLabel,
-  Heading,
-  HStack,
-  Input,
-  Text,
-  Textarea,
-  VStack,
-} from "@chakra-ui/react";
-import React, { useCallback, useContext, useMemo } from "react";
+import { Badge, Box, Heading, HStack, Text } from "@chakra-ui/react";
+import React, { useContext } from "react";
 import { TypeAutoFields } from "chains/flow/TypeAutoFields";
-import { useDebounce } from "utils/hooks/useDebounce";
-import { ChainEditorAPIContext } from "chains/editor/ChainEditorAPIContext";
 import { useEditorColorMode } from "chains/editor/useColorMode";
 import { NodeStateContext, SelectedNodeContext } from "chains/editor/contexts";
 import { PromptNode } from "chains/flow/PromptNode";
 import { FunctionSchemaNode } from "chains/flow/FunctionSchemaNode";
 import { CollapsibleSection } from "chains/flow/CollapsibleSection";
 import { useNodeEditorAPI } from "chains/hooks/useNodeEditorAPI";
+import { NameField } from "chains/editor/fields/NameField";
+import { DescriptionField } from "chains/editor/fields/DescriptionField";
 
 const CONFIG_FORM_COMPONENTS = {
   "langchain.prompts.chat.ChatPromptTemplate": PromptNode,
   "ix.chains.functions.FunctionSchema": FunctionSchemaNode,
-};
-
-const NodeGeneralForm = ({ node, onChange }) => {
-  const handleNameChange = useCallback(
-    (e) => {
-      onChange.all({
-        ...node,
-        name: e.target.value,
-      });
-    },
-    [node, onChange]
-  );
-
-  const handleDescriptionChange = useCallback(
-    (e) => {
-      onChange.all({
-        ...node,
-        description: e.target.value,
-      });
-    },
-    [node, onChange]
-  );
-
-  return (
-    <Box>
-      <VStack spacing={4} align="stretch">
-        <FormControl id="name">
-          <FormLabel>Name</FormLabel>
-          <Input
-            type="text"
-            placeholder="Enter node name"
-            value={node?.name || ""}
-            onChange={handleNameChange}
-          />
-        </FormControl>
-        <FormControl id="description">
-          <FormLabel>Description</FormLabel>
-          <Textarea
-            placeholder="Enter node description"
-            value={node?.description || ""}
-            onChange={handleDescriptionChange}
-          />
-        </FormControl>
-      </VStack>
-    </Box>
-  );
 };
 
 const DefaultForm = ({ type, node, onChange }) => {
@@ -122,10 +65,17 @@ export const ConfigEditorPane = () => {
     content = (
       <>
         <CollapsibleSection title="General" mt={3}>
-          <NodeGeneralForm node={node} onChange={handleConfigChange} />
+          <NameField object={node} onChange={handleConfigChange.all} />
+          <DescriptionField object={node} onChange={handleConfigChange.all} />
         </CollapsibleSection>
         <CollapsibleSection title="Config" initialShow={true} mt={3}>
-          {<ConfigForm node={node} type={type} onChange={handleConfigChange} />}
+          {
+            <ConfigForm
+              node={node}
+              type={type}
+              onChange={handleConfigChange.all}
+            />
+          }
         </CollapsibleSection>
       </>
     );

--- a/frontend/chains/editor/EditorRightSidebar.js
+++ b/frontend/chains/editor/EditorRightSidebar.js
@@ -21,6 +21,7 @@ import {
   faRobot,
 } from "@fortawesome/free-solid-svg-icons";
 import { ConfigEditorPane } from "chains/editor/ConfigEditorPane";
+import { ChainEditorPane } from "chains/editor/ChainEditorPane";
 
 export const EditorRightSidebar = ({ isOpen, onOpen, onClose }) => {
   const btnRef = useRef();
@@ -49,13 +50,18 @@ export const EditorRightSidebar = ({ isOpen, onOpen, onClose }) => {
                       <FontAwesomeIcon icon={faNetworkWired} />
                     </Tab>
                   </Tooltip>
+                  <Tooltip label="Chain" aria-label="Chain">
+                    <Tab>
+                      <FontAwesomeIcon icon={faChain} />
+                    </Tab>
+                  </Tooltip>
                 </TabList>
                 <TabPanels>
                   <TabPanel>
                     <ConfigEditorPane />
                   </TabPanel>
                   <TabPanel>
-                    <p>Chain content here</p>
+                    <ChainEditorPane />
                   </TabPanel>
                   <TabPanel>
                     <p>Chat content here</p>

--- a/frontend/chains/editor/contexts.js
+++ b/frontend/chains/editor/contexts.js
@@ -1,5 +1,6 @@
 import React, { createContext } from "react";
 
+export const ChainState = createContext(null);
 export const NodeStateContext = createContext(null);
 export const NodeEditorContext = createContext(null);
 export const SelectedNodeContext = createContext(null);

--- a/frontend/chains/editor/fields/DescriptionField.js
+++ b/frontend/chains/editor/fields/DescriptionField.js
@@ -1,0 +1,25 @@
+import React, { useCallback } from "react";
+import { FormControl, FormLabel, Textarea } from "@chakra-ui/react";
+
+export const DescriptionField = ({ object, onChange }) => {
+  const handleDescriptionChange = useCallback(
+    (e) => {
+      onChange({
+        ...object,
+        description: e.target.value,
+      });
+    },
+    [object, onChange]
+  );
+
+  return (
+    <FormControl id="description">
+      <FormLabel>Description</FormLabel>
+      <Textarea
+        placeholder="Enter description"
+        value={object?.description || ""}
+        onChange={handleDescriptionChange}
+      />
+    </FormControl>
+  );
+};

--- a/frontend/chains/editor/fields/NameField.js
+++ b/frontend/chains/editor/fields/NameField.js
@@ -1,0 +1,26 @@
+import React, { useCallback } from "react";
+import { FormControl, FormLabel, Input } from "@chakra-ui/react";
+
+export const NameField = ({ object, onChange }) => {
+  const handleNameChange = useCallback(
+    (e) => {
+      onChange({
+        ...object,
+        name: e.target.value,
+      });
+    },
+    [object, onChange]
+  );
+
+  return (
+    <FormControl id="name">
+      <FormLabel>Name</FormLabel>
+      <Input
+        type="text"
+        placeholder="Enter name"
+        value={object?.name || ""}
+        onChange={handleNameChange}
+      />
+    </FormControl>
+  );
+};

--- a/frontend/chains/hooks/useChainState.js
+++ b/frontend/chains/hooks/useChainState.js
@@ -1,0 +1,19 @@
+import { useEffect, useMemo, useState } from "react";
+
+export const useChainState = (graph) => {
+  const [chain, setChain] = useState(graph?.chain);
+
+  // update chain if graph changes
+  useEffect(() => {
+    console.log("graph changed, chain=", graph?.chain);
+    setChain(graph?.chain);
+  }, [graph?.chain]);
+
+  return useMemo(
+    () => ({
+      chain,
+      setChain,
+    }),
+    [chain, setChain]
+  );
+};


### PR DESCRIPTION
### Description
This PR implement the chain tab for the chain editor sidebar. It also fixes bugs with chain title reverting when the user types.

![image](https://github.com/kreneskyp/ix/assets/68635/9a1a37ec-736a-487d-91ed-93a069c76d5a)

### Changes
- add hook and context for managing shared `ChainState`.
- added `NameField` and `DescriptionField` components (good example of reusable fields) 
- added `ChainEditorPane` to `EditorRightSidebar`

### How Tested


### TODOs
- Follow-up: Agent creation workflow simplification.  PR includes mock-up components for `Agent` /  `Chain` mode toggle. Future PR will enable these components. 
