### PR TITLE
Node config does not save

### DIFF
--- a/frontend/chains/editor/ConfigEditorPane.js
+++ b/frontend/chains/editor/ConfigEditorPane.js
@@ -73,7 +73,7 @@ export const ConfigEditorPane = () => {
             <ConfigForm
               node={node}
               type={type}
-              onChange={handleConfigChange.all}
+              onChange={handleConfigChange}
             />
           }
         </CollapsibleSection>

--- a/frontend/chains/editor/EditorRightSidebar.js
+++ b/frontend/chains/editor/EditorRightSidebar.js
@@ -97,7 +97,7 @@ export const EditorRightSidebar = ({ isOpen, onOpen, onClose }) => {
           <Tabs
             isLazy
             isFitted
-            defaultIndex={2}
+            defaultIndex={0}
             m={0}
             p={0}
             pt={2}


### PR DESCRIPTION
### Description
`ConfigForm` was misconfigured with the wrong onChange handler and broke node config forms.

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
