### PR TITLE
Nodes now snap to the grid

### DIFF
--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -361,6 +361,8 @@ const ChainGraphEditor = ({ graph, rightSidebarDisclosure }) => {
           nodeTypes={nodeTypes}
           onConnect={onConnect}
           fitView
+          snapToGrid={true}
+          snapGrid={[10, 10]}
         >
           <Controls />
           <Background


### PR DESCRIPTION
### Description
Nodes now snap to the grid in the chain editor.  Small QoL improvement

### Changes
`ChainGraphEditor` now sets grid snap props for `ReactFlow`

### How Tested
manual test

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
