### PR TITLE
Node config tab is now activated when nodes are selected.

### DIFF
--- a/frontend/chains/editor/EditorRightSidebar.js
+++ b/frontend/chains/editor/EditorRightSidebar.js
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useContext, useRef } from "react";
 import {
   Drawer,
   DrawerContent,
@@ -28,14 +28,32 @@ import { ChainEditorPane } from "chains/editor/ChainEditorPane";
 import { ChatPane } from "chains/editor/ChatPane";
 import { useColorMode } from "@chakra-ui/color-mode";
 import { TestChatPane } from "chains/editor/TestChatPane";
+import { useSelectedNode } from "chains/hooks/useSelectedNode";
+import { SelectedNodeContext } from "chains/editor/contexts";
 
 export const EditorRightSidebar = ({ isOpen, onOpen, onClose }) => {
   const btnRef = useRef();
+
+  // drawer size state
   const [size, setSize] = React.useState("sm");
   const toggleSize = React.useCallback(() =>
     setSize((prev) => (prev === "sm" ? "xl" : "sm"))
   );
 
+  // Tabs state
+  const [tabIndex, setTabIndex] = React.useState(1);
+  const handleTabsChange = React.useCallback((index) => setTabIndex(index));
+
+  // Select node config pane on node select
+  const { selectedNode } = useContext(SelectedNodeContext);
+  React.useEffect(() => {
+    if (selectedNode) {
+      // default to chain config pane
+      setTabIndex(0);
+    }
+  }, [selectedNode]);
+
+  // style
   const dark = {
     header: {
       color: "gray.500",
@@ -99,7 +117,8 @@ export const EditorRightSidebar = ({ isOpen, onOpen, onClose }) => {
           <Tabs
             isLazy
             isFitted
-            defaultIndex={2}
+            index={tabIndex}
+            onChange={handleTabsChange}
             m={0}
             p={0}
             pt={2}


### PR DESCRIPTION
### Description
Selecting a component node in the chain editor now auto-selects the node config tab in the sidebar.

![image](https://github.com/kreneskyp/ix/assets/68635/b2fd56be-f6e4-491a-b502-92d61771b994)


### Changes
- Selecting a component node in the chain editor now auto-selects the node config tab in the sidebar.

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
