### PR TITLE
Adding scrolling to ConfigNode

### DIFF
--- a/frontend/chains/editor/ConfigEditorPane.js
+++ b/frontend/chains/editor/ConfigEditorPane.js
@@ -54,7 +54,7 @@ export const ConfigEditorPane = () => {
   const { selectedNode } = useContext(SelectedNodeContext);
   const { setNode } = useContext(NodeStateContext);
   const { type, node } = useNodeEditorState();
-  const { highlight } = useEditorColorMode();
+  const { highlight, scrollbar } = useEditorColorMode();
   const { handleConfigChange } = useNodeEditorAPI(node, setNode);
 
   const ConfigForm = CONFIG_FORM_COMPONENTS[type?.class_path] || DefaultForm;
@@ -63,15 +63,23 @@ export const ConfigEditorPane = () => {
   let content;
   if (selectedNode && node?.config) {
     content = (
-      <>
-        <CollapsibleSection title="General" mt={3}>
-          <NameField object={node} onChange={handleConfigChange.all} />
-          <DescriptionField object={node} onChange={handleConfigChange.all} />
-        </CollapsibleSection>
-        <CollapsibleSection title="Config" initialShow={true} mt={3}>
-          {<ConfigForm node={node} type={type} onChange={handleConfigChange} />}
-        </CollapsibleSection>
-      </>
+      <Box height={"calc(100vh - 150px)"} display={"flex"}>
+        <Box width="100%" overflow={"auto"} css={scrollbar} px={3}>
+          <CollapsibleSection title="General">
+            <NameField object={node} onChange={handleConfigChange.all} />
+            <DescriptionField object={node} onChange={handleConfigChange.all} />
+          </CollapsibleSection>
+          <CollapsibleSection title="Config" initialShow={true} mt={3}>
+            {
+              <ConfigForm
+                node={node}
+                type={type}
+                onChange={handleConfigChange}
+              />
+            }
+          </CollapsibleSection>
+        </Box>
+      </Box>
     );
   } else {
     content = (
@@ -85,17 +93,19 @@ export const ConfigEditorPane = () => {
 
   return (
     <Box>
-      <HStack>
-        <Badge bg={highlight[type?.type] || highlight.default} size={"xs"}>
-          {type?.type}
-        </Badge>
-        <Heading as="h3" size="md">
-          {name}
-        </Heading>
-      </HStack>
-      <Text color={"gray.500"} fontSize={"xs"}>
-        {type?.name}
-      </Text>
+      <Box p={3}>
+        <HStack>
+          <Badge bg={highlight[type?.type] || highlight.default} size={"xs"}>
+            {type?.type}
+          </Badge>
+          <Heading as="h3" size="md">
+            {name}
+          </Heading>
+        </HStack>
+        <Text color={"gray.500"} fontSize={"xs"}>
+          {type?.name}
+        </Text>
+      </Box>
       {content}
     </Box>
   );

--- a/frontend/chains/editor/EditorRightSidebar.js
+++ b/frontend/chains/editor/EditorRightSidebar.js
@@ -1,5 +1,6 @@
 import React, { useContext, useRef } from "react";
 import {
+  Box,
   Drawer,
   DrawerContent,
   DrawerHeader,
@@ -150,10 +151,10 @@ export const EditorRightSidebar = ({ isOpen, onOpen, onClose }) => {
               flex="1"
               flexDirection="column"
             >
-              <TabPanel>
+              <TabPanel p={0}>
                 <ConfigEditorPane />
               </TabPanel>
-              <TabPanel>
+              <TabPanel p={3}>
                 <ChainEditorPane />
               </TabPanel>
               <TabPanel

--- a/frontend/chains/editor/PromptEditor.js
+++ b/frontend/chains/editor/PromptEditor.js
@@ -104,7 +104,7 @@ const PromptEditor = ({ data, onChange }) => {
   return (
     <VStack spacing={1} align="stretch">
       {messages.map((message, index) => (
-        <VStack key={index} p={2} spacing={2}>
+        <VStack key={index} py={2} spacing={2}>
           <Flex
             alignItems="center"
             justifyContent="space-between"


### PR DESCRIPTION
### Description
Editor node config pane now scrolls

https://github.com/kreneskyp/ix/assets/68635/30790fa0-64f3-41b0-a6a9-861324f4969e


### Changes
- pushed editor sidebar padding and margin inward to allow panes to utilize the full sidebar
- scrollbar added to node config pane.

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
