### PR TITLE
Agents endpoint should exclude test agents

### DIFF
--- a/ix/api/agents/endpoints.py
+++ b/ix/api/agents/endpoints.py
@@ -46,7 +46,7 @@ async def get_agents(
     limit: int = 10,
     offset: int = 0,
 ):
-    query = Agent.objects.all()
+    query = Agent.objects.filter(is_test=False)
     if chat_id:
         query = query.filter(chats__id=chat_id)
     if search:


### PR DESCRIPTION
### Description
The agent book was showing `@test` agents.  These are created for test chats but aren't meant to be used elsewhere.

![image](https://github.com/kreneskyp/ix/assets/68635/43051d65-1bcb-4cd3-b517-f0427bd39fc4)


### Changes
- `/agents/` now excludes test agents

### How Tested
manual test

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
