### PR TITLE
Skinny left sidemenu

### DIFF
--- a/frontend/agents/AgentsListView.js
+++ b/frontend/agents/AgentsListView.js
@@ -1,9 +1,8 @@
 import React from "react";
-import { Layout, LayoutContent, LayoutLeftPane } from "site/Layout";
+import { Layout, LayoutContent } from "site/Layout";
 import { AgentCardList } from "agents/AgentCardList";
 import { Heading, Spinner, VStack } from "@chakra-ui/react";
 import { ScrollableBox } from "site/ScrollableBox";
-import { NewAgentButton } from "agents/NewAgentButton";
 import { usePaginatedAPI } from "utils/hooks/usePaginatedAPI";
 import { useLocation } from "react-router-dom";
 
@@ -16,9 +15,6 @@ export const AgentsListView = () => {
 
   return (
     <Layout>
-      <LayoutLeftPane>
-        <NewAgentButton />
-      </LayoutLeftPane>
       <LayoutContent>
         <VStack alignItems="start" p={5} spacing={4}>
           <Heading>Agents</Heading>

--- a/frontend/agents/NewAgentButton.js
+++ b/frontend/agents/NewAgentButton.js
@@ -1,23 +1,24 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { Button, Icon } from "@chakra-ui/react";
+import { Button, Icon, IconButton } from "@chakra-ui/react";
 import { useColorMode } from "@chakra-ui/color-mode";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPlus } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faUserPlus } from "@fortawesome/free-solid-svg-icons";
 
 export const NewAgentButton = () => {
   const { colorMode } = useColorMode();
 
   return (
     <Link to="/chains/new">
-      <Button
+      <IconButton
         width="100%"
         border="1px solid"
         borderColor={colorMode === "light" ? "gray.300" : "whiteAlpha.50"}
-        leftIcon={<Icon as={FontAwesomeIcon} icon={faPlus} />}
+        icon={<FontAwesomeIcon icon={faUserPlus} />}
+        title={"New Agent"}
       >
         New Agent
-      </Button>
+      </IconButton>
     </Link>
   );
 };

--- a/frontend/chains/ChainEditorView.js
+++ b/frontend/chains/ChainEditorView.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect, useMemo } from "react";
+import React, { useCallback, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import {
   HStack,
@@ -11,7 +11,6 @@ import { ReactFlowProvider, useReactFlow } from "reactflow";
 
 import { Layout, LayoutContent, LayoutLeftPane } from "site/Layout";
 import ChainGraphEditor from "chains/ChainGraphEditor";
-import { ChainGraphEditorSideBar } from "chains/editor/ChainGraphEditorSideBar";
 import { useDetailAPI } from "utils/hooks/useDetailAPI";
 import { useObjectEditorView } from "utils/hooks/useObjectEditorView";
 import { useChainEditorAPI } from "chains/hooks/useChainEditorAPI";
@@ -29,7 +28,7 @@ import {
 import { EditorRightSidebar } from "chains/editor/EditorRightSidebar";
 import { useNodeState } from "chains/hooks/useNodeState";
 import { useChainState } from "chains/hooks/useChainState";
-import { NewAgentButton } from "agents/NewAgentButton";
+import { NodeTypeSearchButton } from "chains/editor/NodeTypeSearchButton";
 
 const ChainEditorProvider = ({ graph, onError, children }) => {
   const chainState = useChainState(graph);
@@ -128,12 +127,18 @@ export const ChainEditorView = () => {
       <ChainEditorProvider graph={graph} onError={onAPIError}>
         <Layout>
           <LayoutLeftPane>
-            <NewAgentButton />
-            <ChainGraphEditorSideBar />
+            <NodeTypeSearchButton />
           </LayoutLeftPane>
           <LayoutContent>
             <HStack>
-              <VStack alignItems="start" p={5} spacing={4}>
+              <VStack
+                alignItems="start"
+                pl={0}
+                pr={2}
+                pt={5}
+                pb={2}
+                spacing={4}
+              >
                 {content}
               </VStack>
               <EditorRightSidebar {...rightSidebarDisclosure} />

--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -343,7 +343,7 @@ const ChainGraphEditor = ({ graph, rightSidebarDisclosure }) => {
           title={"Open Sidebar"}
         />
       </Box>
-      <Box ref={reactFlowWrapper} width={"85vw"} height={"100%"}>
+      <Box ref={reactFlowWrapper} width={"calc(100vw - 100px)"} height={"100%"}>
         <ReactFlow
           nodes={nodes}
           edges={edges}

--- a/frontend/chains/editor/ChainGraphEditorSideBar.js
+++ b/frontend/chains/editor/ChainGraphEditorSideBar.js
@@ -1,6 +1,0 @@
-import React from "react";
-import { NodeTypeSearch } from "chains/editor/NodeTypeSearch";
-
-export const ChainGraphEditorSideBar = () => {
-  return <NodeTypeSearch />;
-};

--- a/frontend/chains/editor/ConnectorPopover.js
+++ b/frontend/chains/editor/ConnectorPopover.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext } from "react";
+import React, { useContext, useCallback } from "react";
 import {
   Badge,
   Box,
@@ -29,22 +29,35 @@ export const ConnectorPopover = ({
   const { highlight } = useEditorColorMode();
   const { setSelectedConnector } = useContext(SelectedNodeContext);
 
-  useEffect(() => {
-    if (isOpen) {
-      setSelectedConnector({ type, node, connector });
-    }
-  }, [isOpen, setSelectedConnector, connector]);
-
   const source_types = Array.isArray(connector.source_type)
     ? connector.source_type
     : [connector?.source_type];
 
   const description = connector.description || DEFAULT_DESCRIPTION;
 
+  const onClick = useCallback(
+    (event) => {
+      // click: search for components
+      // shift-click: toggle help
+      const shiftKey = event.shiftKey;
+      if (shiftKey) {
+        onToggle();
+      } else {
+        setSelectedConnector({ type, node, connector });
+      }
+    },
+    [onToggle]
+  );
+
   return (
-    <Popover isOpen={isOpen} onClose={onClose} placement={placement}>
+    <Popover
+      isOpen={isOpen}
+      onClose={onClose}
+      placement={placement}
+      closeOnBlur={true}
+    >
       <PopoverTrigger>
-        <Box as="button" onClick={onToggle}>
+        <Box as="button" onClick={onClick} title={"shift-click for help"}>
           {children || label || connector.key}
         </Box>
       </PopoverTrigger>

--- a/frontend/chains/editor/EditorRightSidebar.js
+++ b/frontend/chains/editor/EditorRightSidebar.js
@@ -1,49 +1,27 @@
-import React, { useContext, useRef } from "react";
-import {
-  Box,
-  Drawer,
-  DrawerContent,
-  DrawerHeader,
-  DrawerOverlay,
-  HStack,
-  IconButton,
-  Tab,
-  TabList,
-  TabPanel,
-  TabPanels,
-  Tabs,
-  Tooltip,
-} from "@chakra-ui/react";
+import React, { useContext } from "react";
+import { Tab, TabPanel, Tooltip } from "@chakra-ui/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
-  faChain,
-  faCheckCircle,
   faComments,
   faNetworkWired,
-  faRightLeft,
   faRobot,
-  faX,
 } from "@fortawesome/free-solid-svg-icons";
 import { ConfigEditorPane } from "chains/editor/ConfigEditorPane";
 import { ChainEditorPane } from "chains/editor/ChainEditorPane";
-import { ChatPane } from "chains/editor/ChatPane";
-import { useColorMode } from "@chakra-ui/color-mode";
 import { TestChatPane } from "chains/editor/TestChatPane";
-import { useSelectedNode } from "chains/hooks/useSelectedNode";
 import { SelectedNodeContext } from "chains/editor/contexts";
+import { RightSidebar } from "site/RightSidebar";
+import {
+  SidebarTabList,
+  SidebarTabPanels,
+  SidebarTabs,
+} from "site/SidebarTabs";
 
-export const EditorRightSidebar = ({ isOpen, onOpen, onClose }) => {
-  const btnRef = useRef();
+const SIZES = ["sm", "xl", "xs"];
 
-  // drawer size state
-  const [size, setSize] = React.useState("sm");
-  const toggleSize = React.useCallback(() =>
-    setSize((prev) => (prev === "sm" ? "xl" : "sm"))
-  );
-
+export const EditorRightSidebar = ({ isOpen, onClose }) => {
   // Tabs state
   const [tabIndex, setTabIndex] = React.useState(1);
-  const handleTabsChange = React.useCallback((index) => setTabIndex(index));
 
   // Select node config pane on node select
   const { selectedNode } = useContext(SelectedNodeContext);
@@ -54,138 +32,51 @@ export const EditorRightSidebar = ({ isOpen, onOpen, onClose }) => {
     }
   }, [selectedNode]);
 
-  // style
-  const dark = {
-    header: {
-      color: "gray.500",
-    },
-    headerContainer: {
-      borderBottom: "1px solid",
-      borderColor: "blackAlpha.100",
-      bg: "blackAlpha.400",
-    },
-    icon: {
-      color: "gray.500",
-    },
-  };
-  const light = {
-    header: {
-      color: "gray.500",
-    },
-    headerContainer: {
-      borderBottom: "1px solid",
-      borderColor: "blackAlpha.200",
-      bg: "blackAlpha.50",
-    },
-    icon: {
-      color: "gray.400",
-    },
-  };
-  const style = useColorMode().colorMode === "dark" ? dark : light;
-
   return (
-    <Drawer
-      isOpen={isOpen}
-      placement="right"
-      onClose={onClose}
-      finalFocusRef={btnRef}
-      closeOnOverlayClick={false}
-      trapFocus={false}
-      size={size}
-    >
-      <DrawerOverlay
-        style={{ backgroundColor: "transparent", pointerEvents: "none" }}
-      >
-        <DrawerContent
-          style={{ pointerEvents: "all" }}
-          height="100vh"
-          display="flex"
-          flexDirection="column"
-        >
-          <DrawerHeader h={10} px={2} py={1} {...style.headerContainer}>
-            <HStack display={"flex"} justifyContent={"flex-start"}>
-              <IconButton
-                aria-label="Expand"
-                bg={"transparent"}
-                icon={<FontAwesomeIcon icon={faRightLeft} />}
-                size={"xs"}
-                title={"Expanded"}
-                onClick={toggleSize}
-                {...style.header}
-              />
-              <IconButton
-                aria-label={"Close"}
-                bg={"transparent"}
-                icon={<FontAwesomeIcon icon={faX} />}
-                size={"xs"}
-                title={"Close"}
-                onClick={onClose}
-                {...style.header}
-              />
-            </HStack>
-          </DrawerHeader>
-          <Tabs
-            isLazy
-            isFitted
-            index={tabIndex}
-            onChange={handleTabsChange}
-            m={0}
+    <RightSidebar isOpen={isOpen} onClose={onClose} sizes={SIZES}>
+      <SidebarTabs index={tabIndex} onChange={setTabIndex}>
+        <SidebarTabList>
+          <Tooltip label="Node" aria-label="Node">
+            <Tab>
+              <FontAwesomeIcon icon={faNetworkWired} />
+            </Tab>
+          </Tooltip>
+          <Tooltip label="Agent" aria-label="Agent">
+            <Tab>
+              <FontAwesomeIcon icon={faRobot} />
+            </Tab>
+          </Tooltip>
+          <Tooltip label="Chat" aria-label="Chat">
+            <Tab>
+              <FontAwesomeIcon icon={faComments} />
+            </Tab>
+          </Tooltip>
+        </SidebarTabList>
+        <SidebarTabPanels>
+          <TabPanel p={0}>
+            <ConfigEditorPane />
+          </TabPanel>
+          <TabPanel p={3}>
+            <ChainEditorPane />
+          </TabPanel>
+          <TabPanel
             p={0}
-            pt={2}
+            m={0}
+            display="flex"
             flex="1"
             flexDirection="column"
-            display="flex"
+            justifyContent="flex-end"
           >
-            <TabList {...style.icon}>
-              <Tooltip label="Node" aria-label="Node">
-                <Tab>
-                  <FontAwesomeIcon icon={faNetworkWired} />
-                </Tab>
-              </Tooltip>
-              <Tooltip label="Agent" aria-label="Agent">
-                <Tab>
-                  <FontAwesomeIcon icon={faRobot} />
-                </Tab>
-              </Tooltip>
-              <Tooltip label="Chat" aria-label="Chat">
-                <Tab>
-                  <FontAwesomeIcon icon={faComments} />
-                </Tab>
-              </Tooltip>
-            </TabList>
-            <TabPanels
-              p={0}
-              m={0}
-              display="flex"
-              flex="1"
-              flexDirection="column"
-            >
-              <TabPanel p={0}>
-                <ConfigEditorPane />
-              </TabPanel>
-              <TabPanel p={3}>
-                <ChainEditorPane />
-              </TabPanel>
-              <TabPanel
-                p={0}
-                m={0}
-                display="flex"
-                flex="1"
-                flexDirection="column"
-                justifyContent="flex-end"
-              >
-                <TestChatPane />
-              </TabPanel>
-              <TabPanel>
-                <p>Validation content here</p>
-              </TabPanel>
-              <TabPanel>
-                <p>Assistant content here</p>
-              </TabPanel>
-            </TabPanels>
-          </Tabs>
-        </DrawerContent>
-      </DrawerOverlay>
-    </Drawer>
+            <TestChatPane />
+          </TabPanel>
+          <TabPanel>
+            <p>Validation content here</p>
+          </TabPanel>
+          <TabPanel>
+            <p>Assistant content here</p>
+          </TabPanel>
+        </SidebarTabPanels>
+      </SidebarTabs>
+    </RightSidebar>
   );
 };

--- a/frontend/chains/editor/NodeTypeSearch.js
+++ b/frontend/chains/editor/NodeTypeSearch.js
@@ -209,7 +209,7 @@ export const NodeTypeSearch = () => {
 
   return (
     <Box
-      mt={0}
+      mt={2}
       pt={0}
       width="100%"
       minWidth={170}

--- a/frontend/chains/editor/NodeTypeSearch.js
+++ b/frontend/chains/editor/NodeTypeSearch.js
@@ -147,6 +147,7 @@ const NodeTypeSearchBadge = ({ type, onRemove }) => {
  */
 export const NodeTypeSearch = () => {
   const { border } = useSideBarColorMode();
+  const { input: inputStyle, scrollbar } = useEditorColorMode();
   const { selectedConnector } = useContext(SelectedNodeContext);
   const [query, setQuery] = useState({ search: "", types: [] });
 
@@ -208,33 +209,32 @@ export const NodeTypeSearch = () => {
 
   return (
     <Box
-      mt={5}
-      pt={5}
+      mt={0}
+      pt={0}
       width="100%"
-      maxHeight={"60vh"}
       minWidth={170}
       overflowY={"hidden"}
+      maxHeight={"calc(100vh - 170px)"}
     >
-      <Heading as="h3" size="xs" mb={2}>
-        Components
-      </Heading>
-      <Box mb={2}>
+      <Box px={3} pb={1}>
         {query.types?.map((type) => (
           <NodeTypeSearchBadge key={type} type={type} onRemove={onRemoveType} />
         ))}
       </Box>
-
-      <Input
-        onChange={onSearchChange}
-        placeholder="search components"
-        mb={2}
-        borderColor={border}
-        value={query.search}
-      />
+      <Box px={2}>
+        <Input
+          onChange={onSearchChange}
+          placeholder="search components"
+          mb={2}
+          borderColor={border}
+          value={query.search}
+          {...inputStyle}
+        />
+      </Box>
       <VStack
-        overflowY="scroll"
-        css={SCROLLBAR_CSS}
-        maxHeight={"60vh"}
+        overflowY="auto"
+        css={scrollbar}
+        maxHeight={"calc(100vh - 170px)"}
         spacing={2}
         width="100%"
       >

--- a/frontend/chains/editor/NodeTypeSearchButton.js
+++ b/frontend/chains/editor/NodeTypeSearchButton.js
@@ -1,0 +1,69 @@
+import React, { useContext, useEffect } from "react";
+import { NodeTypeSearch } from "chains/editor/NodeTypeSearch";
+import {
+  IconButton,
+  Popover,
+  PopoverArrow,
+  PopoverCloseButton,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTrigger,
+  useDisclosure,
+} from "@chakra-ui/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faSquarePlus } from "@fortawesome/free-solid-svg-icons";
+import { useColorMode } from "@chakra-ui/color-mode";
+import { SelectedNodeContext } from "chains/editor/contexts";
+
+export const NodeTypeSearchButton = () => {
+  const { isOpen, onToggle, onClose, onOpen } = useDisclosure();
+
+  // auto-open when connector is [de]selected
+  // HAX: couldn't get this to work when closeOnBlur={true}
+  //      this behavior is mostly ok though so can revisit later
+  //      to make popover pinning a toggle.
+  const { selectedConnector } = useContext(SelectedNodeContext);
+  useEffect(() => {
+    if (selectedConnector && !isOpen) {
+      onOpen();
+    } else if (!selectedConnector) {
+      onClose();
+    }
+  }, [selectedConnector]);
+
+  const { colorMode } = useColorMode();
+  const style =
+    colorMode === "light"
+      ? {
+          border: "1px solid",
+          borderColor: "gray.300",
+        }
+      : {
+          border: "1px solid",
+          borderColor: "whiteAlpha.50",
+        };
+
+  return (
+    <Popover
+      isOpen={isOpen}
+      onClose={onClose}
+      placement={"right-start"}
+      closeOnBlur={true}
+    >
+      <PopoverTrigger>
+        <IconButton
+          icon={<FontAwesomeIcon size={"lg"} icon={faSquarePlus} />}
+          {...style}
+          onClick={onToggle}
+          title={"Add components"}
+        />
+      </PopoverTrigger>
+      <PopoverContent zIndex={99998} pb={2}>
+        <PopoverHeader>Components</PopoverHeader>
+        <PopoverArrow />
+        <PopoverCloseButton />
+        <NodeTypeSearch />
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/frontend/chains/editor/NodeTypeSearchButton.js
+++ b/frontend/chains/editor/NodeTypeSearchButton.js
@@ -42,6 +42,8 @@ export const NodeTypeSearchButton = () => {
           border: "1px solid",
           borderColor: "whiteAlpha.50",
         };
+  const highlightColor = colorMode === "light" ? "blue.500" : "blue.400";
+  const color = colorMode === "light" ? "gray.800" : "white";
 
   return (
     <Popover
@@ -58,8 +60,18 @@ export const NodeTypeSearchButton = () => {
           title={"Add components"}
         />
       </PopoverTrigger>
-      <PopoverContent zIndex={99998} pb={2}>
-        <PopoverHeader>Components</PopoverHeader>
+      <PopoverContent
+        zIndex={99998}
+        pb={2}
+        boxShadow="0px 0px 10px 0px rgba(0,0,0,0.15)"
+      >
+        <PopoverHeader
+          borderBottom="2px solid"
+          borderColor={highlightColor}
+          color={color}
+        >
+          Components
+        </PopoverHeader>
         <PopoverArrow />
         <PopoverCloseButton />
         <NodeTypeSearch />

--- a/frontend/chains/editor/PromptEditor.js
+++ b/frontend/chains/editor/PromptEditor.js
@@ -51,7 +51,7 @@ function parseVariables(str) {
 
 const PromptEditor = ({ data, onChange }) => {
   const [messages, setMessages] = useState(data.messages || DEFAULT_MESSAGES);
-  const { code, scrollbar } = useEditorColorMode();
+  const { input, scrollbar } = useEditorColorMode();
 
   const handleOnChange = useCallback(
     (updatedMessages) => {
@@ -115,7 +115,9 @@ const PromptEditor = ({ data, onChange }) => {
               <Text fontWeight="bold">System</Text>
             ) : (
               <Select
+                {...input}
                 size={"sm"}
+                borderRadius={5}
                 width={125}
                 value={message.role}
                 onChange={(e) =>
@@ -154,6 +156,8 @@ const PromptEditor = ({ data, onChange }) => {
             </HStack>
           </Flex>
           <AutoResizingTextarea
+            {...input}
+            borderRadius={5}
             width="100%"
             value={message.template}
             placeholder="Enter template"
@@ -163,8 +167,6 @@ const PromptEditor = ({ data, onChange }) => {
             isRequired
             css={scrollbar}
             size={"sm"}
-            bg={code.bg}
-            color={code.color}
           />
         </VStack>
       ))}

--- a/frontend/chains/flow/TypeAutoFields.js
+++ b/frontend/chains/flow/TypeAutoFields.js
@@ -149,7 +149,7 @@ const AutoFieldSelect = ({ field, value, onChange }) => {
       </FormLabel>
       <Select
         onChange={handleChange}
-        width={field.width || 125}
+        width={field.width || 200}
         value={value}
         {...colorMode.input}
       >

--- a/frontend/chat/AssistantAvatar.js
+++ b/frontend/chat/AssistantAvatar.js
@@ -2,13 +2,20 @@ import React from "react";
 import PropTypes from "prop-types";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import Avatar from "./Avatar";
-import { faMap, faRobot } from "@fortawesome/free-solid-svg-icons";
+import {
+  faBrain,
+  faMap,
+  faRobot,
+  faUserNinja,
+  faUserSecret,
+  faUserTie,
+} from "@fortawesome/free-solid-svg-icons";
 
-library.add(faRobot, faMap);
+library.add(faRobot, faMap, faUserTie, faUserNinja, faUserSecret, faBrain);
 
 const AssistantAvatar = ({ agent, size, color }) => {
   // Check if agent.icon is a valid icon and render it, else render the default 'robot' icon
-  const iconName = agent?.icon || "robot";
+  const iconName = agent?.icon || "brain";
 
   const state = {
     icon: iconName,

--- a/frontend/chat/ChatInterface.js
+++ b/frontend/chat/ChatInterface.js
@@ -82,7 +82,7 @@ export const DEFAULT_CHAT_LIGHT_STYLE = {
     ...SCROLLBOX,
   },
   messages: {
-    width: "100%",
+    width: 800,
   },
   message: {
     container: {

--- a/frontend/chat/ChatMembersButton.js
+++ b/frontend/chat/ChatMembersButton.js
@@ -1,0 +1,56 @@
+import React from "react";
+import {
+  IconButton,
+  Popover,
+  PopoverArrow,
+  PopoverCloseButton,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTrigger,
+  useDisclosure,
+} from "@chakra-ui/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faSquarePlus, faUsers } from "@fortawesome/free-solid-svg-icons";
+import { useColorMode } from "@chakra-ui/color-mode";
+import { NodeTypeSearch } from "chains/editor/NodeTypeSearch";
+import SideBarAgentList from "chat/sidebar/SideBarAgentList";
+
+export const ChatMembersButton = ({ graph, loadGraph }) => {
+  const { isOpen, onToggle, onClose } = useDisclosure();
+
+  const { colorMode } = useColorMode();
+  const style =
+    colorMode === "light"
+      ? {
+          border: "1px solid",
+          borderColor: "gray.300",
+        }
+      : {
+          border: "1px solid",
+          borderColor: "whiteAlpha.50",
+        };
+
+  return (
+    <Popover
+      isOpen={isOpen}
+      onClose={onClose}
+      placement={"right-start"}
+      closeOnBlur={false}
+    >
+      <PopoverTrigger>
+        <IconButton
+          icon={<FontAwesomeIcon size={"lg"} icon={faUsers} />}
+          {...style}
+          onClick={onToggle}
+          title={"Chat members"}
+        />
+      </PopoverTrigger>
+      <PopoverContent zIndex={99998} pb={2}>
+        <PopoverHeader>Assistants</PopoverHeader>
+        <PopoverArrow />
+        <PopoverCloseButton />
+        <SideBarAgentList graph={graph} loadGraph={loadGraph} />
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/frontend/chat/ChatMembersButton.js
+++ b/frontend/chat/ChatMembersButton.js
@@ -10,9 +10,8 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faSquarePlus, faUsers } from "@fortawesome/free-solid-svg-icons";
+import { faUsers } from "@fortawesome/free-solid-svg-icons";
 import { useColorMode } from "@chakra-ui/color-mode";
-import { NodeTypeSearch } from "chains/editor/NodeTypeSearch";
 import SideBarAgentList from "chat/sidebar/SideBarAgentList";
 
 export const ChatMembersButton = ({ graph, loadGraph }) => {
@@ -29,6 +28,8 @@ export const ChatMembersButton = ({ graph, loadGraph }) => {
           border: "1px solid",
           borderColor: "whiteAlpha.50",
         };
+  const highlightColor = colorMode === "light" ? "blue.500" : "blue.400";
+  const color = colorMode === "light" ? "gray.800" : "white";
 
   return (
     <Popover
@@ -45,8 +46,18 @@ export const ChatMembersButton = ({ graph, loadGraph }) => {
           title={"Chat members"}
         />
       </PopoverTrigger>
-      <PopoverContent zIndex={99998} pb={2}>
-        <PopoverHeader>Assistants</PopoverHeader>
+      <PopoverContent
+        zIndex={99998}
+        pb={2}
+        boxShadow="0px 0px 10px 0px rgba(0,0,0,0.15)"
+      >
+        <PopoverHeader
+          borderBottom="2px solid"
+          borderColor={highlightColor}
+          color={color}
+        >
+          Assistants
+        </PopoverHeader>
         <PopoverArrow />
         <PopoverCloseButton />
         <SideBarAgentList graph={graph} loadGraph={loadGraph} />

--- a/frontend/chat/ChatView.js
+++ b/frontend/chat/ChatView.js
@@ -1,27 +1,66 @@
-import React, { Suspense, useEffect } from "react";
+import React, { useEffect } from "react";
 import { useParams } from "react-router-dom";
-import { Spinner, VStack, Box } from "@chakra-ui/react";
+import {
+  Spinner,
+  Box,
+  HStack,
+  useDisclosure,
+  Tab,
+  Tooltip,
+  TabPanel,
+  TabPanels,
+} from "@chakra-ui/react";
 
 import { Layout, LayoutContent, LayoutLeftPane } from "site/Layout";
+import { RightSidebar } from "site/RightSidebar";
 import SideBarPlanList from "chat/SideBarPlanList";
 import SideBarArtifactList from "chat/sidebar/SideBarArtifactList";
-import SideBarAgentList from "chat/sidebar/SideBarAgentList";
 import { ChatInterface } from "chat/ChatInterface";
 import { useChatGraph } from "chat/hooks/useChatGraph";
-import { NewAgentButton } from "agents/NewAgentButton";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faBox, faClipboardCheck } from "@fortawesome/free-solid-svg-icons";
+import { SidebarTabList, SidebarTabs } from "site/SidebarTabs";
+import { ChatMembersButton } from "chat/ChatMembersButton";
 
 export const ChatLeftPaneShim = ({ graph, loadGraph }) => {
   return (
     <>
-      <NewAgentButton />
-      <Suspense>
-        <VStack spacing={4} align="stretch">
-          <SideBarAgentList graph={graph} loadGraph={loadGraph} />
-          <SideBarPlanList plans={graph.plans} />
-          <SideBarArtifactList chat={graph.chat} artifacts={graph.artifacts} />
-        </VStack>
-      </Suspense>
+      <ChatMembersButton graph={graph} loadGraph={loadGraph} />
     </>
+  );
+};
+
+export const ChatRightSidebar = ({ graph }) => {
+  const rightSidebarDisclosure = useDisclosure({ defaultIsOpen: true });
+
+  return (
+    <RightSidebar {...rightSidebarDisclosure}>
+      <SidebarTabs>
+        <SidebarTabList>
+          <Tooltip label="Tasks" aria-label="Tasks">
+            <Tab>
+              <FontAwesomeIcon icon={faClipboardCheck} />
+            </Tab>
+          </Tooltip>
+          <Tooltip label="Artifacts" aria-label="Artifacts">
+            <Tab>
+              <FontAwesomeIcon icon={faBox} />
+            </Tab>
+          </Tooltip>
+        </SidebarTabList>
+        <TabPanels p={0} m={0} display="flex" flex="1" flexDirection="column">
+          <TabPanel>
+            <SideBarPlanList plans={graph.plans} />
+          </TabPanel>
+          <TabPanel>
+            <SideBarArtifactList
+              chat={graph.chat}
+              artifacts={graph.artifacts}
+            />
+          </TabPanel>
+        </TabPanels>
+      </SidebarTabs>
+    </RightSidebar>
   );
 };
 
@@ -47,9 +86,17 @@ export const ChatView = () => {
         {isLoading || !graph ? (
           <Spinner />
         ) : (
-          <Box height="100%" display="flex" flexDirection="column">
-            <ChatInterface graph={graph} />
-          </Box>
+          <HStack justifyContent={"start"}>
+            <Box
+              width="100%"
+              height="100vh"
+              display="flex"
+              flexDirection="column"
+            >
+              <ChatInterface graph={graph} />
+            </Box>
+            <ChatRightSidebar graph={graph} />
+          </HStack>
         )}
       </LayoutContent>
     </Layout>

--- a/frontend/chat/NewChatButton.js
+++ b/frontend/chat/NewChatButton.js
@@ -1,9 +1,10 @@
-import { Button, Icon } from "@chakra-ui/react";
+import { Button, Icon, IconButton } from "@chakra-ui/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import React from "react";
 import useCreateChat from "chat/hooks/useCreateChat";
 import { useColorMode } from "@chakra-ui/color-mode";
+import PlusMessageIcon from "components/PlusMessageIcon";
 
 export const NewChatButton = () => {
   const { createChat } = useCreateChat();
@@ -24,14 +25,12 @@ export const NewChatButton = () => {
   };
 
   return (
-    <Button
+    <IconButton
       border="1px solid"
       borderColor={colorMode === "light" ? "gray.300" : "whiteAlpha.50"}
-      width="100%"
-      leftIcon={<Icon as={FontAwesomeIcon} icon={faPlus} />}
+      icon={<PlusMessageIcon />}
+      title={"New Chat"}
       onClick={handleCreate}
-    >
-      New Chat
-    </Button>
+    />
   );
 };

--- a/frontend/chat/SideBarPlanList.js
+++ b/frontend/chat/SideBarPlanList.js
@@ -1,5 +1,12 @@
 import React from "react";
-import { HStack, VStack, Text, Heading, Box, Spinner } from "@chakra-ui/react";
+import {
+  HStack,
+  VStack,
+  Text,
+  Box,
+  Spinner,
+  FormLabel,
+} from "@chakra-ui/react";
 import { useColorMode } from "@chakra-ui/color-mode";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClock } from "@fortawesome/free-regular-svg-icons";
@@ -21,10 +28,10 @@ const StatusIcon = ({ isComplete, isRunning }) => {
 const SideBarPlanList = ({ plans }) => {
   const { colorMode } = useColorMode();
   return (
-    <VStack spacing={1}>
-      <Heading as="h3" size="md" width="100%" align="left" mt={5}>
+    <VStack spacing={1} px={2}>
+      <FormLabel as="h3" size="md" width="100%" align="left">
         Tasks
-      </Heading>
+      </FormLabel>
       {!plans || plans?.length === 0 ? (
         <Text
           p={2}

--- a/frontend/chat/sidebar/SideBarAgentList.js
+++ b/frontend/chat/sidebar/SideBarAgentList.js
@@ -1,11 +1,20 @@
 import React, { useCallback, useEffect } from "react";
-import { HStack, VStack, Text, Box, useColorModeValue } from "@chakra-ui/react";
+import {
+  HStack,
+  VStack,
+  Text,
+  Box,
+  useColorModeValue,
+  IconButton,
+} from "@chakra-ui/react";
 import AssistantAvatar from "chat/AssistantAvatar";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
+  faAddressBook,
   faSquareMinus,
 } from "@fortawesome/free-solid-svg-icons";
 import RemoveAgentModalTrigger from "chat/agents/RemoveAgentModalTrigger";
+import AddAgentModalTrigger from "chat/agents/AddAgentModalTrigger";
 import { useColorMode } from "@chakra-ui/color-mode";
 import { usePaginatedAPI } from "utils/hooks/usePaginatedAPI";
 
@@ -69,6 +78,24 @@ const SideBarAgentList = ({ graph }) => {
       bg={colorMode === "light" ? "transparent" : "transparent"}
       color={colorMode === "light" ? "gray.800" : "gray.300"}
     >
+      <HStack
+        width="100%"
+        mb={2}
+        color={colorMode === "light" ? "gray.800" : "whiteAlpha.500"}
+      >
+        <Box width="100%" align="right">
+          <AddAgentModalTrigger
+            graph={graph}
+            chatAgents={agents}
+            onSuccess={onUpdateAgents}
+          >
+            <IconButton
+              icon={<FontAwesomeIcon icon={faAddressBook} />}
+              title={"add/remove assistants"}
+            />
+          </AddAgentModalTrigger>
+        </Box>
+      </HStack>
       <VStack spacing={3}>
         <AgentListItem agent={lead} chat={graph.chat} />
         {agents?.map((agent, i) => (

--- a/frontend/chat/sidebar/SideBarAgentList.js
+++ b/frontend/chat/sidebar/SideBarAgentList.js
@@ -2,14 +2,17 @@ import React, { useCallback, useEffect } from "react";
 import { HStack, VStack, Text, Box, useColorModeValue } from "@chakra-ui/react";
 import AssistantAvatar from "chat/AssistantAvatar";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faSquareMinus, faUserPlus } from "@fortawesome/free-solid-svg-icons";
+import {
+  faAddressBook,
+  faSquareMinus,
+} from "@fortawesome/free-solid-svg-icons";
 import RemoveAgentModalTrigger from "chat/agents/RemoveAgentModalTrigger";
 import AddAgentModalTrigger from "chat/agents/AddAgentModalTrigger";
 import { useColorMode } from "@chakra-ui/color-mode";
 import { usePaginatedAPI } from "utils/hooks/usePaginatedAPI";
 
 const AgentListItem = ({ chat, agent, onUpdateAgents }) => {
-  const avatarColor = useColorModeValue("gray.700", "gray.400");
+  const avatarColor = useColorModeValue("gray.500", "gray.400");
 
   return (
     <Box bg="transparent" width="100%">
@@ -62,10 +65,10 @@ const SideBarAgentList = ({ graph }) => {
       px={3}
       pb={3}
       pt={1}
-      border="1px solid"
+      border="0px solid"
       borderRadius={5}
-      borderColor={colorMode === "light" ? "gray.400" : "gray.700"}
-      bg={colorMode === "light" ? "gray.300" : "gray.800"}
+      borderColor={colorMode === "light" ? "gray.300" : "gray.600"}
+      bg={colorMode === "light" ? "transparent" : "transparent"}
       color={colorMode === "light" ? "gray.800" : "gray.300"}
     >
       <HStack
@@ -73,16 +76,13 @@ const SideBarAgentList = ({ graph }) => {
         mb={2}
         color={colorMode === "light" ? "gray.800" : "whiteAlpha.500"}
       >
-        <Text fontSize="xs" fontWeight="bold" mb={2}>
-          Agents
-        </Text>
         <Box width="100%" align="right">
           <AddAgentModalTrigger
             graph={graph}
             chatAgents={agents}
             onSuccess={onUpdateAgents}
           >
-            <FontAwesomeIcon icon={faUserPlus} />
+            <FontAwesomeIcon icon={faAddressBook} />
           </AddAgentModalTrigger>
         </Box>
       </HStack>

--- a/frontend/chat/sidebar/SideBarAgentList.js
+++ b/frontend/chat/sidebar/SideBarAgentList.js
@@ -69,21 +69,6 @@ const SideBarAgentList = ({ graph }) => {
       bg={colorMode === "light" ? "transparent" : "transparent"}
       color={colorMode === "light" ? "gray.800" : "gray.300"}
     >
-      <HStack
-        width="100%"
-        mb={2}
-        color={colorMode === "light" ? "gray.800" : "whiteAlpha.500"}
-      >
-        <Box width="100%" align="right">
-          <AddAgentModalTrigger
-            graph={graph}
-            chatAgents={agents}
-            onSuccess={onUpdateAgents}
-          >
-            <FontAwesomeIcon icon={faAddressBook} />
-          </AddAgentModalTrigger>
-        </Box>
-      </HStack>
       <VStack spacing={3}>
         <AgentListItem agent={lead} chat={graph.chat} />
         {agents?.map((agent, i) => (

--- a/frontend/chat/sidebar/SideBarAgentList.js
+++ b/frontend/chat/sidebar/SideBarAgentList.js
@@ -3,16 +3,14 @@ import { HStack, VStack, Text, Box, useColorModeValue } from "@chakra-ui/react";
 import AssistantAvatar from "chat/AssistantAvatar";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
-  faAddressBook,
   faSquareMinus,
 } from "@fortawesome/free-solid-svg-icons";
 import RemoveAgentModalTrigger from "chat/agents/RemoveAgentModalTrigger";
-import AddAgentModalTrigger from "chat/agents/AddAgentModalTrigger";
 import { useColorMode } from "@chakra-ui/color-mode";
 import { usePaginatedAPI } from "utils/hooks/usePaginatedAPI";
 
 const AgentListItem = ({ chat, agent, onUpdateAgents }) => {
-  const avatarColor = useColorModeValue("gray.500", "gray.400");
+  const avatarColor = useColorModeValue("blue.400", "blue.300");
 
   return (
     <Box bg="transparent" width="100%">

--- a/frontend/chat/sidebar/SideBarArtifactList.js
+++ b/frontend/chat/sidebar/SideBarArtifactList.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { HStack, VStack, Heading, Box, Text } from "@chakra-ui/react";
+import { HStack, VStack, Box, Text, FormLabel } from "@chakra-ui/react";
 import { useColorMode } from "@chakra-ui/color-mode";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -45,24 +45,11 @@ const SideBarArtifactList = ({ chat, artifacts: initialArtifacts }) => {
   );
 
   return (
-    <Box
-      mt={5}
-      pt={5}
-      width="100%"
-      maxHeight={"60vh"}
-      minWidth={170}
-      overflowY={"hidden"}
-    >
-      <Heading as="h3" size="md" width="100%" align="left" mt={5}>
+    <Box width="100%" minWidth={170} overflowY={"hidden"}>
+      <FormLabel as="h3" size="md" align="left">
         Artifacts
-      </Heading>
-      <VStack
-        overflowY="scroll"
-        css={SCROLLBAR_CSS}
-        maxHeight={"30vh"}
-        spacing={2}
-        width="100%"
-      >
+      </FormLabel>
+      <VStack overflowY="scroll" css={SCROLLBAR_CSS} spacing={2} width="100%">
         {!artifacts || artifacts?.length === 0 ? (
           <Text
             p={2}

--- a/frontend/components/ColorModeButton.js
+++ b/frontend/components/ColorModeButton.js
@@ -1,14 +1,36 @@
 import React from "react";
 import { useColorMode } from "@chakra-ui/color-mode";
-import { Button } from "@chakra-ui/react";
+import { Button, IconButton } from "@chakra-ui/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faMoon } from "@fortawesome/free-solid-svg-icons";
+import { faSun } from "@fortawesome/free-regular-svg-icons";
 
 export const ColorModeButton = () => {
   const { colorMode, toggleColorMode } = useColorMode();
+  const style =
+    colorMode === "light"
+      ? {
+          text: "Dark Mode",
+          border: "1px solid",
+          borderColor: "gray.300",
+        }
+      : {
+          title: "Light Mode",
+          border: "1px solid",
+          borderColor: "whiteAlpha.50",
+        };
+
+  const icon = colorMode === "light" ? faMoon : faSun;
+  const title = colorMode === "light" ? "Dark Mode" : "Light Mode";
   return (
     <header>
-      <Button onClick={toggleColorMode}>
+      <IconButton
+        {...style}
+        icon={<FontAwesomeIcon icon={icon} />}
+        onClick={toggleColorMode}
+      >
         Toggle {colorMode === "light" ? "Dark" : "Light"}
-      </Button>
+      </IconButton>
     </header>
   );
 };

--- a/frontend/components/PlusMessageIcon.js
+++ b/frontend/components/PlusMessageIcon.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faMessage, faPlus } from "@fortawesome/free-solid-svg-icons";
+import { useColorMode } from "@chakra-ui/color-mode";
+
+const PlusMessageIcon = () => {
+  const { colorMode } = useColorMode();
+  const iconColor = colorMode === "light" ? "black" : "black";
+  return (
+    <span className="fa-stack">
+      <FontAwesomeIcon icon={faMessage} className="fa-stack-1x" />
+      <FontAwesomeIcon
+        icon={faPlus}
+        size={"xs"}
+        className="fa-stack-1x"
+        fontWeight={"bold"}
+        color={iconColor}
+        style={{ position: "absolute", top: -1.5 }}
+      />
+    </span>
+  );
+};
+export default PlusMessageIcon;

--- a/frontend/site/Layout.js
+++ b/frontend/site/Layout.js
@@ -1,10 +1,11 @@
 import React, { Suspense } from "react";
 import { Divider, Flex, Spacer, VStack } from "@chakra-ui/react";
 import { useColorMode } from "@chakra-ui/color-mode";
-import Navigation from "site/Navigation";
 import { ColorModeButton } from "components/ColorModeButton";
 import { CenteredSpinner } from "site/CenteredSpinner";
 import { NewChatButton } from "chat/NewChatButton";
+import { NewAgentButton } from "agents/NewAgentButton";
+import Navigation from "site/Navigation";
 
 export const LayoutLeftPane = ({ children }) => {
   return children;
@@ -27,25 +28,25 @@ export const Layout = ({ children }) => {
   return (
     <Flex h="100vh" overflowX="hidden">
       <VStack
-        bg={colorMode === "light" ? "gray.200" : "gray.900"}
-        width={300}
-        p={2}
+        bg={colorMode === "light" ? "gray.200" : "blackAlpha.200"}
+        p={1}
         minH="100vh"
         align="left"
-        borderRightColor={colorMode === "light" ? "gray.400" : "transparent"}
+        borderRightColor={colorMode === "light" ? "gray.300" : "transparent"}
         borderRightWidth={1}
       >
         {/* left sidebar */}
         <NewChatButton />
+        <NewAgentButton />
+        <Divider
+          borderColor={colorMode === "light" ? "gray.400" : "whiteAlpha.400"}
+        />
         {leftPane}
         <Spacer />
         <Divider
           borderColor={colorMode === "light" ? "gray.400" : "whiteAlpha.400"}
         />
         <Navigation />
-        <Divider
-          borderColor={colorMode === "light" ? "gray.400" : "whiteAlpha.400"}
-        />
         <ColorModeButton />
       </VStack>
       <Flex

--- a/frontend/site/Navigation.js
+++ b/frontend/site/Navigation.js
@@ -1,11 +1,11 @@
 import React from "react";
-import { Box, HStack, Stack } from "@chakra-ui/react";
+import { Box, Divider, HStack, IconButton, Stack } from "@chakra-ui/react";
 import {
   faCog,
   faSignOutAlt,
-  faRobot,
   faServer,
   faMessage,
+  faAddressBook,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Link } from "react-router-dom";
@@ -13,44 +13,68 @@ import { useColorMode } from "@chakra-ui/color-mode";
 
 function Navigation() {
   const { colorMode } = useColorMode();
+  const style =
+    colorMode === "light"
+      ? {
+          border: "1px solid",
+          borderColor: "gray.300",
+        }
+      : {
+          border: "1px solid",
+          borderColor: "whiteAlpha.50",
+        };
 
   return (
-    <Box
-      as="nav"
-      fontSize="sm"
-      color={colorMode === "light" ? "gray.900" : "gray.200"}
-    >
+    <Box as="nav" color={colorMode === "light" ? "gray.900" : "gray.200"}>
       <Stack spacing={3}>
         <HStack align="center">
-          <FontAwesomeIcon icon={faMessage} />
           <Link ml={3} to="/chats">
-            Chats
+            <IconButton
+              icon={<FontAwesomeIcon icon={faMessage} />}
+              title={"Chat history"}
+              {...style}
+            />
           </Link>
         </HStack>
         <HStack align="center">
-          <FontAwesomeIcon icon={faRobot} />
           <Link ml={3} to="/agents">
-            Agents
+            <IconButton
+              icon={<FontAwesomeIcon icon={faAddressBook} />}
+              title={"Agents"}
+              {...style}
+            />
           </Link>
         </HStack>
         {false && (
           <HStack align="center">
-            <FontAwesomeIcon icon={faServer} />
             <Link ml={3} to="#">
-              Resources
+              <IconButton
+                icon={<FontAwesomeIcon icon={faServer} />}
+                title={"Resources"}
+                {...style}
+              />
             </Link>
           </HStack>
         )}
+        <Divider
+          borderColor={colorMode === "light" ? "gray.400" : "whiteAlpha.400"}
+        />
         <HStack align="center">
-          <FontAwesomeIcon icon={faCog} />
           <Link ml={3} to="#">
-            Settings
+            <IconButton
+              icon={<FontAwesomeIcon icon={faCog} />}
+              title={"Settings"}
+              {...style}
+            />
           </Link>
         </HStack>
         <HStack align="center" spacing={3}>
-          <FontAwesomeIcon icon={faSignOutAlt} />
           <Link ml={3} to="#">
-            Logout
+            <IconButton
+              icon={<FontAwesomeIcon icon={faSignOutAlt} />}
+              title={"Sign out"}
+              {...style}
+            />
           </Link>
         </HStack>
       </Stack>

--- a/frontend/site/RightSidebar.js
+++ b/frontend/site/RightSidebar.js
@@ -1,0 +1,104 @@
+import React, { useRef } from "react";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+  HStack,
+  IconButton,
+} from "@chakra-ui/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faRightLeft, faX } from "@fortawesome/free-solid-svg-icons";
+import { useColorMode } from "@chakra-ui/color-mode";
+
+const DRAW_SIZES = ["xs", "sm", "xl"];
+
+export const RightSidebar = ({ isOpen, onOpen, onClose, children, sizes }) => {
+  const btnRef = useRef();
+
+  // drawer size state - toggle rotates through allowed sizes
+  const [size, setSize] = React.useState(sizes[0]);
+  const toggleSize = React.useCallback(() => {
+    setSize((prev) => sizes[(sizes.indexOf(prev) + 1) % sizes.length]);
+  }, [sizes]);
+
+  // style
+  const dark = {
+    header: {
+      color: "gray.500",
+    },
+    headerContainer: {
+      borderBottom: "1px solid",
+      borderColor: "blackAlpha.100",
+      bg: "blackAlpha.400",
+    },
+    icon: {
+      color: "gray.500",
+    },
+  };
+  const light = {
+    header: {
+      color: "gray.500",
+    },
+    headerContainer: {
+      borderBottom: "1px solid",
+      borderColor: "blackAlpha.200",
+      bg: "blackAlpha.50",
+    },
+    icon: {
+      color: "gray.400",
+    },
+  };
+  const style = useColorMode().colorMode === "dark" ? dark : light;
+
+  return (
+    <Drawer
+      isOpen={isOpen}
+      placement="right"
+      onClose={onClose}
+      finalFocusRef={btnRef}
+      closeOnOverlayClick={false}
+      trapFocus={false}
+      size={size}
+    >
+      <DrawerOverlay
+        style={{ backgroundColor: "transparent", pointerEvents: "none" }}
+      >
+        <DrawerContent
+          style={{ pointerEvents: "all" }}
+          height="100vh"
+          display="flex"
+          flexDirection="column"
+        >
+          <DrawerHeader h={10} px={2} py={1} {...style.headerContainer}>
+            <HStack display={"flex"} justifyContent={"flex-start"}>
+              <IconButton
+                aria-label="Expand"
+                bg={"transparent"}
+                icon={<FontAwesomeIcon icon={faRightLeft} />}
+                size={"xs"}
+                title={"Toggle width"}
+                onClick={toggleSize}
+                {...style.header}
+              />
+              <IconButton
+                aria-label={"Close"}
+                bg={"transparent"}
+                icon={<FontAwesomeIcon icon={faX} />}
+                size={"xs"}
+                title={"Close"}
+                onClick={onClose}
+                {...style.header}
+              />
+            </HStack>
+          </DrawerHeader>
+          {children}
+        </DrawerContent>
+      </DrawerOverlay>
+    </Drawer>
+  );
+};
+
+RightSidebar.defaultProps = {
+  sizes: DRAW_SIZES,
+};

--- a/frontend/site/SidebarTabs.js
+++ b/frontend/site/SidebarTabs.js
@@ -1,0 +1,69 @@
+import { TabList, TabPanels, Tabs } from "@chakra-ui/react";
+import React from "react";
+import { useColorMode } from "@chakra-ui/color-mode";
+
+const DARK = {
+  header: {
+    color: "gray.500",
+  },
+  headerContainer: {
+    borderBottom: "1px solid",
+    borderColor: "blackAlpha.100",
+    bg: "blackAlpha.400",
+  },
+  icon: {
+    color: "gray.500",
+  },
+};
+const LIGHT = {
+  header: {
+    color: "gray.500",
+  },
+  headerContainer: {
+    borderBottom: "1px solid",
+    borderColor: "blackAlpha.200",
+    bg: "blackAlpha.50",
+  },
+  icon: {
+    color: "gray.400",
+  },
+};
+
+export const useSidebarColorMode = () => {
+  return useColorMode().colorMode === "dark" ? DARK : LIGHT;
+};
+
+export const SidebarTabList = ({ children, ...props }) => {
+  const style = useSidebarColorMode();
+  return (
+    <TabList {...style.icon} {...props}>
+      {children}
+    </TabList>
+  );
+};
+
+export const SidebarTabPanels = ({ children, ...props }) => {
+  return (
+    <TabPanels p={0} m={0} display="flex" flex="1" flexDirection="column">
+      {children}
+    </TabPanels>
+  );
+};
+
+export const SidebarTabs = ({ children, ...props }) => {
+  return (
+    <Tabs
+      isLazy
+      isFitted
+      m={0}
+      p={0}
+      pt={2}
+      flex="1"
+      flexDirection="column"
+      display="flex"
+      {...props}
+    >
+      {children}
+    </Tabs>
+  );
+};


### PR DESCRIPTION
### Description
This PR converts to a skinny sidemenu. This intends to provide more space for the editor and allow for more popup features.

![image](https://github.com/kreneskyp/ix/assets/68635/93f0904d-afdf-4053-a3f2-7bf9335cbe2f)
![image](https://github.com/kreneskyp/ix/assets/68635/8222481f-559d-43a9-bdc1-e78706196f57)
![image](https://github.com/kreneskyp/ix/assets/68635/159e81cb-c972-4dd7-916a-ab2555932e07)


### Changes
- Factor RightSideBar and SidebarTabs out of EditorRightSidebar
- Connector popover click functionality split into click and shiftclick
- Converted chain editor to skinny menu
- Component search now in popup available from menu button
- converted chat to skinny menu

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
