### PR TITLE
Fixing issues with connector popover click handling

### DIFF
--- a/frontend/chains/editor/ConnectorPopover.js
+++ b/frontend/chains/editor/ConnectorPopover.js
@@ -35,7 +35,8 @@ export const ConnectorPopover = ({
 }) => {
   const { isOpen, onToggle, onClose } = useDisclosure();
   const { highlight, isLight } = useEditorColorMode();
-  const { setSelectedConnector } = useContext(SelectedNodeContext);
+  const { selectedConnector, setSelectedConnector } =
+    useContext(SelectedNodeContext);
 
   const source_types = Array.isArray(connector.source_type)
     ? connector.source_type
@@ -50,11 +51,13 @@ export const ConnectorPopover = ({
       const shiftKey = event.shiftKey;
       if (shiftKey) {
         onToggle();
-      } else {
+      } else if (selectedConnector?.connector !== connector) {
         setSelectedConnector({ type, node, connector });
+      } else {
+        setSelectedConnector(null);
       }
     },
-    [onToggle]
+    [onToggle, selectedConnector]
   );
 
   const hover = isLight ? { color: "blue.400" } : { color: "blue.400" };

--- a/frontend/chains/editor/NodeTypeSearchButton.js
+++ b/frontend/chains/editor/NodeTypeSearchButton.js
@@ -45,12 +45,15 @@ export const NodeTypeSearchButton = () => {
   const highlightColor = colorMode === "light" ? "blue.500" : "blue.400";
   const color = colorMode === "light" ? "gray.800" : "white";
 
+  // HAX: Popover must be closedOnBlue=False to allow for connectors to
+  //      switch without closing the popover. It proved very difficult to
+  //      prevent onClose from detecting that a new connector was selected.
   return (
     <Popover
       isOpen={isOpen}
       onClose={onClose}
       placement={"right-start"}
-      closeOnBlur={true}
+      closeOnBlur={false}
     >
       <PopoverTrigger>
         <IconButton


### PR DESCRIPTION
### Description
Fixing two bugs in connector onclick handling:


##### Invalid State
component search popover could reach an invalid state because when `closeOnBlur=true` and clicking two node connectors in sequence. The second click would cause the popover to close-on-blue, and then the popover would not re-open.

setting `closeOnBlue=false` for now.  Attempted to implement better state management didn't work due to the interaction pattern between the connector and popover state.

##### de-selecting connectors
Connectors may now be deselected by clicking on them a second time.

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
