### PR TITLE
App startup improvement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,11 +122,26 @@ compile_relay: compose
 # Run
 # =========================================================
 
+
+.PHONY: cluster
+cluster: compose
+	docker-compose up -d web nginx worker
+
+
+.PHONY: up
+up: cluster
+
+
+.PHONY: down
+down: compose
+	docker-compose down
+
+
 # run backend and frontend. This starts uvicorn for asgi+websockers
 # and nginx to serve static files
 .PHONY: server
-server: compose
-	docker-compose up web nginx
+server: cluster
+	@docker-compose logs -f --tail=10 web nginx
 
 
 # run django debug server, backup in case nginx ever breaks
@@ -137,7 +152,16 @@ runserver: compose
 # run worker
 .PHONY: worker
 worker: compose
-	${DOCKER_COMPOSE_RUN} celery.sh
+	@docker-compose logs -f --tail=10 worker
+
+# reset worker (for code refresh)
+.PHONY: worker-reset
+worker-reset: compose
+	@echo stopping workers...
+	@docker-compose up -d --scale worker=0
+	@echo restarting worker...
+	@docker-compose up -d --scale worker=1
+
 
 # =========================================================
 # Shells

--- a/README.md
+++ b/README.md
@@ -135,23 +135,41 @@ OPENAI_API_KEY=YOUR_KEY_HERE
 ```
 
 ### Build and run the dev image.
-Set NO_IMAGE_BUILD=1 to rebuild the image
+Set NO_IMAGE_BUILD=1 to skip rebuilding the image
 ```
 make dev_setup
 ```
 
-### Run the dev server & worker
-Set NO_IMAGE_BUILD=1 to rebuild the image
+### Run the docker cluster
+Set NO_IMAGE_BUILD=1 to skip rebuilding the image
 
+```bash
+make cluster
+```
+
+### View logs
+
+Web server logs
 ```bash
 make server
 ```
 
-Start a worker
+Agent worker logs
 ```bash
 make worker
 ```
 
+### Halt the docker cluster
+
+```bash
+make down
+```
+
+### recycle workers
+Recycle workers to deploy new code changes.
+```bash
+make worker-reset
+```
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       POSTGRES_USER: ix
       POSTGRES_DB: ix
       POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
 
   web:
     image: ghcr.io/kreneskyp/ix/sandbox:latest
@@ -57,3 +59,6 @@ services:
   redis:
     image: redis/redis-stack-server:latest
 
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
### Description
Make targets that start the app were refactored to work better:
- Single target `cluster` or `up` starts all services
- Can now scale workers via `docker-compose`


https://github.com/kreneskyp/ix/assets/68635/d69b606b-b51b-4ba3-8e99-1924b91e4562


### Changes
- refactor startup targets.
- postgres service now uses volume to persist data when container is stopped.

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
