### PR TITLE
Minor validation fix for agent update

### DIFF
--- a/ix/api/chains/types.py
+++ b/ix/api/chains/types.py
@@ -40,11 +40,7 @@ class CreateChain(BaseModel):
 
 
 class UpdateChain(CreateChain):
-    @root_validator
-    def validate_chain(cls, values):
-        if values.get("is_agent") and not values.get("alias"):
-            raise ValueError("alias is required when is_agent is True")
-        return values
+    pass
 
 
 class ChainQueryPage(QueryPage[Chain]):


### PR DESCRIPTION
### Description
Removing the alias for an existing chain was resulting in confusing errors. The validation isn't strictly needed. The alias could be empty string but most of the downstream issues are cosmetic. 

Disabling validation until error can be presented in a more useful way

### Changes
-  UpdateChain no longer throws an error if `alias` is emptystring.

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
