### PR TITLE
Another fix for publish workflows

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -17,26 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # Load or build cached image
-      - name: Load image url
-        id: load_image_url
-        run: |
-          IMAGE_URL=`make image-url`
-          echo "image-url=$IMAGE_URL" >> "$GITHUB_OUTPUT"
-      - name: Restore Cache
-        uses: actions/cache@v2
-        id: restore_cache
-        with:
-          path: image.tar
-          key: ${{ steps.load_image_url.outputs.image-url }}
-      - name: load image
-        shell: bash
-        run: |
-          docker load --input image.tar
-          docker tag ${{ steps.load_image_url.outputs.image-url }} ghcr.io/kreneskyp/ix/sandbox:latest
-
-      # build javascript - Reuse the cached image from the CI workflow. A local image is needed for the
-      #                    command. It's faster to use the image that was already built.
+      # build javascript - This will build the image an extra time because it's needed locally
       - name: run
         shell: bash
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,26 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # Load or build cached image
-      - name: Load image url
-        id: load_image_url
-        run: |
-          IMAGE_URL=`make image-url`
-          echo "image-url=$IMAGE_URL" >> "$GITHUB_OUTPUT"
-      - name: Restore Cache
-        uses: actions/cache@v2
-        id: restore_cache
-        with:
-          path: image.tar
-          key: ${{ steps.load_image_url.outputs.image-url }}
-      - name: load image
-        shell: bash
-        run: |
-          docker load --input image.tar
-          docker tag ${{ steps.load_image_url.outputs.image-url }} ghcr.io/kreneskyp/ix/sandbox:latest
-
-      # build javascript - Reuse the cached image from the CI workflow. A local image is needed for the
-      #                    command. It's faster to use the image that was already built.
+      # build javascript - This will build the image an extra time because it's needed locally
       - name: run
         shell: bash
         env:


### PR DESCRIPTION
### Description
Image cache was missing, possibly due to this being a separate workflow than the test pipeline that builds the image. Fix is always build in the publish workflows. It's slower and takes extra resources but should always work.

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
