### PR TITLE
Updating workflow action versions 

### DIFF
--- a/.github/actions/run-docker/action.yml
+++ b/.github/actions/run-docker/action.yml
@@ -21,7 +21,7 @@ runs:
       run: |
         echo "Loading cached image: ${{ steps.load_image_url.outputs.image-url }}"
     - name: Cache docker image
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: image.tar
         key: ${{ steps.load_image_url.outputs.image-url }}

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # setup
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Load image urls
         id: load_image_url
@@ -27,7 +27,7 @@ jobs:
 
       # attempt to load both images from cache
       - name: Restore Sandbox Image Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore_cache
         with:
           path: image.tar
@@ -39,7 +39,7 @@ jobs:
           docker load --input image.tar
           docker tag ${{ steps.load_image_url.outputs.image-url }} ghcr.io/kreneskyp/ix/sandbox:latest
       - name: Restore NodeJS Image Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore_cache_nodejs
         with:
           path: image-nodejs.tar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
 
       # attempt to load both images from cache
       - name: Restore Sandbox Image Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore_cache
         with:
           path: image.tar
@@ -37,7 +37,7 @@ jobs:
           docker load --input image.tar
           docker tag ${{ steps.load_image_url.outputs.image-url }} ghcr.io/kreneskyp/ix/sandbox:latest
       - name: Restore NodeJS Image Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore_cache_nodejs
         with:
           path: image-nodejs.tar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Load image url
         id: load_image_url
@@ -20,7 +20,7 @@ jobs:
           echo "image-url=$IMAGE_URL" >> "$GITHUB_OUTPUT"
 
       - name: Restore Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore_cache
         with:
           path: image.tar
@@ -37,7 +37,7 @@ jobs:
           docker save $IMAGE_URL > image.tar
 
       - name: Cache docker image
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Load image url
         id: load_image_url
@@ -57,7 +57,7 @@ jobs:
           echo "image-url-nodejs=$IMAGE_URL" >> "$GITHUB_OUTPUT"
 
       - name: Restore Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore_cache_nodejs
         with:
           path: image-nodejs.tar
@@ -74,7 +74,7 @@ jobs:
           docker save $IMAGE_URL > image-nodejs.tar
 
       - name: Cache docker image
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -85,7 +85,7 @@ jobs:
     needs: [nodejs_build, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -103,7 +103,7 @@ jobs:
         run: |
           echo "Loading cached image: ${{ steps.load_image_url.outputs.image-url-nodejs }}"
       - name: Restore Nodejs Image Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore_cache_nodejs
         with:
           path: image-nodejs.tar
@@ -122,7 +122,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -138,7 +138,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -154,7 +154,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
### Description
Cache restore is failing in all workflows all of a sudden. Was working last night and now docker images can't be loaded after restore. Updating to latest actions in hopes that will fix it.

### Changes
- actions/checkout v2 -> v4
- actions/cache v2 -> v3

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
