### PR TITLE
Dropping arm/v8 from build. 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v8
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/kreneskyp/ix/sandbox:latest


### PR DESCRIPTION
### Description
Release build included `linux/arm/v8` which fails to build.  M1/M2 based macs should be natively supported by `linux/arm64` but I wanted to cover all bases. Dropping v8 for now until build can be fixed.

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
