### PR TITLE
Chat view scrolling now works again when right sidebar is open

### DIFF
--- a/frontend/chat/ChatInterface.js
+++ b/frontend/chat/ChatInterface.js
@@ -137,7 +137,7 @@ export const useChatStyle = () => {
  *
  * @param graph - chat graph from useChatGraph
  */
-export const ChatInterface = ({ graph }) => {
+export const ChatInterface = ({ graph, scrollboxProps }) => {
   const { messages, streams, subscriptionActive } = useMessageStream(
     graph.chat
   );
@@ -147,7 +147,7 @@ export const ChatInterface = ({ graph }) => {
     <MessagesTokenContext.Provider value={streams}>
       <MessagesContext.Provider value={messages}>
         <SubscriptionActiveContext.Provider value={subscriptionActive}>
-          <ScrollableBox {...scrollbox}>
+          <ScrollableBox {...scrollbox} {...scrollboxProps}>
             <Suspense>
               <ChatMessages chat={graph.chat} />
             </Suspense>

--- a/frontend/chat/ChatView.js
+++ b/frontend/chat/ChatView.js
@@ -28,6 +28,7 @@ import { SidebarTabList, SidebarTabs } from "site/SidebarTabs";
 import { ChatMembersButton } from "chat/ChatMembersButton";
 import { ChatAssistantsButton } from "chat/ChatAssistantsButton";
 import { usePaginatedAPI } from "utils/hooks/usePaginatedAPI";
+import { useLinkedScroll } from "hooks/useLinkedScroll";
 
 export const ChatLeftPaneShim = ({ graph }) => {
   const { load: loadAgents, page: agentPage } = usePaginatedAPI(
@@ -60,9 +61,14 @@ export const ChatLeftPaneShim = ({ graph }) => {
   );
 };
 
-export const ChatRightSidebar = ({ graph, disclosure }) => {
+export const ChatRightSidebar = ({ graph, disclosure, onWheel, drawerRef }) => {
   return (
-    <RightSidebar {...disclosure}>
+    <RightSidebar
+      {...disclosure}
+      onWheel={onWheel}
+      drawerRef={drawerRef}
+      pointerEvents={"auto"}
+    >
       <SidebarTabs>
         <SidebarTabList>
           <Tooltip label="Tasks" aria-label="Tasks">
@@ -97,6 +103,11 @@ export const ChatView = () => {
   const { response, call: loadGraph, isLoading } = useChatGraph(id);
   const graph = response?.data;
   const rightSidebarDisclosure = useDisclosure({ defaultIsOpen: true });
+  const {
+    updateScroll,
+    targetRef: scrollBoxRef,
+    sourceRef: drawerRef,
+  } = useLinkedScroll();
 
   useEffect(() => {
     loadGraph();
@@ -118,7 +129,10 @@ export const ChatView = () => {
               display="flex"
               flexDirection="column"
             >
-              <ChatInterface graph={graph} />
+              <ChatInterface
+                graph={graph}
+                scrollboxProps={{ ref: scrollBoxRef }}
+              />
             </Box>
             <Box position="absolute" top={0} right={0} mt={4} mr={4}>
               <IconButton
@@ -132,6 +146,8 @@ export const ChatView = () => {
             <ChatRightSidebar
               graph={graph}
               disclosure={rightSidebarDisclosure}
+              onWheel={updateScroll}
+              drawerRef={drawerRef}
             />
           </HStack>
         )}

--- a/frontend/hooks/useLinkedScroll.js
+++ b/frontend/hooks/useLinkedScroll.js
@@ -1,0 +1,46 @@
+import React from "react";
+
+/**
+ * LinkedScroll is a custom hook that synchronizes scrolling between two
+ * elements. For example, between a drawer and a scrollable box.
+ *
+ * It requires components be linked with refs, but otherwise it's self-contained.
+ */
+export const useLinkedScroll = () => {
+  const targetRef = React.useRef(null);
+  const sourceRef = React.useRef(null);
+
+  // callback to update scroll position of targetRef
+  const updateScroll = React.useCallback(
+    (e) => {
+      // Calculate isMoverOver here using mouse position and refs.
+      // Done here with refs to avoid re-rendering janky scrolling
+      const targetRect = targetRef.current.getBoundingClientRect();
+      const sourceRect = sourceRef.current
+        ? sourceRef.current.getBoundingClientRect()
+        : null;
+
+      const isOverTarget =
+        e.clientX >= targetRect.left &&
+        e.clientX <= targetRect.right &&
+        e.clientY >= targetRect.top &&
+        e.clientY <= targetRect.bottom;
+
+      const isOverDrawer =
+        sourceRect &&
+        e.clientX >= sourceRect.left &&
+        e.clientX <= sourceRect.right &&
+        e.clientY >= sourceRect.top &&
+        e.clientY <= sourceRect.bottom;
+
+      const isMouseOver = isOverTarget && !isOverDrawer;
+
+      if (isMouseOver && targetRef.current) {
+        targetRef.current.scrollTop += e.deltaY;
+      }
+    },
+    [targetRef, sourceRef]
+  );
+
+  return { updateScroll, targetRef, sourceRef };
+};

--- a/frontend/site/RightSidebar.js
+++ b/frontend/site/RightSidebar.js
@@ -13,7 +13,16 @@ import { useColorMode } from "@chakra-ui/color-mode";
 
 const DRAW_SIZES = ["xs", "sm", "xl"];
 
-export const RightSidebar = ({ isOpen, onOpen, onClose, children, sizes }) => {
+export const RightSidebar = ({
+  isOpen,
+  onOpen,
+  onClose,
+  children,
+  sizes,
+  onWheel,
+  drawerRef,
+  pointerEvents,
+}) => {
   const btnRef = useRef();
 
   // drawer size state - toggle rotates through allowed sizes
@@ -62,13 +71,15 @@ export const RightSidebar = ({ isOpen, onOpen, onClose, children, sizes }) => {
       size={size}
     >
       <DrawerOverlay
-        style={{ backgroundColor: "transparent", pointerEvents: "none" }}
+        style={{ backgroundColor: "transparent", pointerEvents }}
+        onWheel={onWheel}
       >
         <DrawerContent
           style={{ pointerEvents: "all" }}
           height="100vh"
           display="flex"
           flexDirection="column"
+          ref={drawerRef}
         >
           <DrawerHeader h={10} px={2} py={1} {...style.headerContainer}>
             <HStack display={"flex"} justifyContent={"flex-start"}>
@@ -101,4 +112,5 @@ export const RightSidebar = ({ isOpen, onOpen, onClose, children, sizes }) => {
 
 RightSidebar.defaultProps = {
   sizes: DRAW_SIZES,
+  pointerEvents: "none",
 };

--- a/frontend/site/ScrollableBox.js
+++ b/frontend/site/ScrollableBox.js
@@ -2,9 +2,9 @@ import { Box, Grid, VStack } from "@chakra-ui/react";
 import React from "react";
 import { SCROLLBAR_CSS } from "site/css";
 
-export const ScrollableBox = ({ children, ...props }) => {
+export const ScrollableBox = React.forwardRef(({ children, ...props }, ref) => {
   return (
-    <Box flexGrow="1" overflowY="auto" css={SCROLLBAR_CSS} {...props}>
+    <Box flexGrow="1" overflowY="auto" css={SCROLLBAR_CSS} {...props} ref={ref}>
       <Grid h="100%" templateRows="1fr auto" alignItems="end" gap={4}>
         <VStack spacing={4} ml={4} mr={4}>
           {children}
@@ -12,4 +12,4 @@ export const ScrollableBox = ({ children, ...props }) => {
       </Grid>
     </Box>
   );
-};
+});


### PR DESCRIPTION
### Description
Sidebar DrawerOverlay was capturing mouse events and blocked scrolling. Couldn't scroll to get to messages off the screen. Fix links scroll events from overlay to the messages `ScrollBox`

### Changes
- added `useLinkedScroll` to synchronize scroll between two components
- links scrolling between `DraweyOverlay` and chat messages `ScrollableBox`

### How Tested
- Manual tested. Final version has smooth scrolling.  It improves on the initial versions which had too many re-renders and  janky performance. 

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
