### PR TITLE
Prior fix for ChatView scrolling made left sidebar unclickable.

### DIFF
--- a/frontend/chat/ChatView.js
+++ b/frontend/chat/ChatView.js
@@ -61,14 +61,9 @@ export const ChatLeftPaneShim = ({ graph }) => {
   );
 };
 
-export const ChatRightSidebar = ({ graph, disclosure, onWheel, drawerRef }) => {
+export const ChatRightSidebar = ({ graph, disclosure, drawerRef }) => {
   return (
-    <RightSidebar
-      {...disclosure}
-      onWheel={onWheel}
-      drawerRef={drawerRef}
-      pointerEvents={"auto"}
-    >
+    <RightSidebar {...disclosure} drawerRef={drawerRef}>
       <SidebarTabs>
         <SidebarTabList>
           <Tooltip label="Tasks" aria-label="Tasks">
@@ -146,7 +141,6 @@ export const ChatView = () => {
             <ChatRightSidebar
               graph={graph}
               disclosure={rightSidebarDisclosure}
-              onWheel={updateScroll}
               drawerRef={drawerRef}
             />
           </HStack>

--- a/frontend/hooks/useLinkedScroll.js
+++ b/frontend/hooks/useLinkedScroll.js
@@ -42,5 +42,15 @@ export const useLinkedScroll = () => {
     [targetRef, sourceRef]
   );
 
-  return { updateScroll, targetRef, sourceRef };
+  // add global listener for wheel events, this decouples the wheel event capture
+  // from the overlay. The overlay might need ignore all mouse events to allow buttons
+  // and other elements work. (those things do work with the pass through unlike scrolling)
+  React.useEffect(() => {
+    window.addEventListener("wheel", updateScroll);
+    return () => {
+      window.removeEventListener("wheel", updateScroll);
+    };
+  }, []);
+
+  return { targetRef, sourceRef };
 };

--- a/frontend/site/RightSidebar.js
+++ b/frontend/site/RightSidebar.js
@@ -19,9 +19,7 @@ export const RightSidebar = ({
   onClose,
   children,
   sizes,
-  onWheel,
   drawerRef,
-  pointerEvents,
 }) => {
   const btnRef = useRef();
 
@@ -71,8 +69,7 @@ export const RightSidebar = ({
       size={size}
     >
       <DrawerOverlay
-        style={{ backgroundColor: "transparent", pointerEvents }}
-        onWheel={onWheel}
+        style={{ backgroundColor: "transparent", pointerEvents: "none" }}
       >
         <DrawerContent
           style={{ pointerEvents: "all" }}
@@ -112,5 +109,4 @@ export const RightSidebar = ({
 
 RightSidebar.defaultProps = {
   sizes: DRAW_SIZES,
-  pointerEvents: "none",
 };


### PR DESCRIPTION
### Description
Prior fix for ChatView scrolling made left sidebar unclickable.  This restores that functionality while retaining fix for scrolling.

The overlay had been set to accept pointer events to capture wheel events.  This blocked other pointer events from passing through to buttons. 


### Changes
- `useLinkedScroll` now links scroll to window so it is isolated from the source components pointer event props
- `RightSideBar` overlay now once again passes through all pointer events.

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
