### PR TITLE
Agent: @readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ migrate: compose
 migrations: compose
 	${DOCKER_COMPOSE_RUN} ./manage.py makemigrations
 
-LOAD_FIXTURE = docker-compose exec web ./manage.py loaddata
+LOAD_FIXTURE = docker-compose exec -T web ./manage.py loaddata
 
 # load initial data needed for dev environment
 .PHONY: dev_fixtures

--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,11 @@ scale: compose
 bash: compose
 	${DOCKER_COMPOSE_RUN} /bin/bash
 
+.PHONY: nodejs-bash
+nodejs-bash: compose
+	${DOCKER_COMPOSE_RUN_NODEJS} /bin/bash
+
+
 .PHONY: shell
 shell: compose
 	${DOCKER_COMPOSE_RUN} ./manage.py shell_plus

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ compile_relay: nodejs
 
 .PHONY: cluster
 cluster: compose
+	@echo starting IX dev cluster
 	docker-compose up -d web nginx worker
 
 

--- a/Makefile
+++ b/Makefile
@@ -230,16 +230,30 @@ migrate: compose
 migrations: compose
 	${DOCKER_COMPOSE_RUN} ./manage.py makemigrations
 
+LOAD_FIXTURE = docker-compose exec web ./manage.py loaddata
+
 # load initial data needed for dev environment
 .PHONY: dev_fixtures
-dev_fixtures: compose
-	${DOCKER_COMPOSE_RUN} ./manage.py loaddata fake_user
+dev_fixtures: cluster components agents
+	$(LOAD_FIXTURE) fake_user
 
-	# load component NodeTypes
-	${DOCKER_COMPOSE_RUN} ./manage.py loaddata node_types
+.PHONY: components
+components: cluster
+	@echo "\nrestoring components from fixtures"
+	$(LOAD_FIXTURE) node_types
 
+.PHONY: agents
+agents: cluster components
  	# initial agents + chains
-	${DOCKER_COMPOSE_RUN} ./manage.py loaddata agent/ix agent/code agent/pirate agent/wikipedia agent/klarna agent/smithy
+	@echo ""
+	@echo restoring agents from fixtures
+	$(LOAD_FIXTURE) agent/ix
+	$(LOAD_FIXTURE) agent/readme
+	$(LOAD_FIXTURE) agent/code
+	$(LOAD_FIXTURE) agent/pirate
+	$(LOAD_FIXTURE) agent/wikipedia
+	$(LOAD_FIXTURE) agent/klarna
+	$(LOAD_FIXTURE) agent/smithy
 
 
 # Generate fixture for NodeTypes defined in python fixtures.

--- a/ix/api/chats/endpoints.py
+++ b/ix/api/chats/endpoints.py
@@ -7,9 +7,9 @@ from typing import Optional, Dict, Any
 from uuid import UUID
 
 from django.db.models import Q
+from django.conf import settings
 
 from ix.api.chains.endpoints import DeletedItem
-from ix.chains.management.commands.create_coder_v2 import CODER_V2_AGENT
 from ix.chains.management.commands.create_ix_v2 import IX_AGENT_V2
 from ix.chat.models import Chat, Task
 from ix.agents.models import Agent
@@ -70,8 +70,14 @@ async def create_chat(chat: ChatNew):
         name=chat.name,
     )
 
-    code = await Agent.objects.aget(id=CODER_V2_AGENT)
-    await chat_obj.agents.aadd(code)
+    # Add default agents to chat
+    for agent_id in settings.DEFAULT_AGENTS:
+        try:
+            agent = await Agent.objects.aget(pk=agent_id)
+        except Agent.DoesNotExist:
+            logger.exception(f"Default agent {agent_id} not found")
+            raise
+        await chat_obj.agents.aadd(agent)
 
     return ChatPydantic.from_orm(chat_obj)
 

--- a/ix/chains/fixtures/agent/readme.json
+++ b/ix/chains/fixtures/agent/readme.json
@@ -1,0 +1,359 @@
+[
+  {
+    "model": "agents.agent",
+    "pk": "cc054ff5-67cd-4489-b0f1-b8b62af2d825",
+    "fields": {
+      "name": "IX Readme",
+      "alias": "readme",
+      "purpose": "A bot that can answer questions using the IX README file as context. \n\nThis bot is a demonstration of a retrieval augmented generation (RAG):\n- Chroma vectorstore to search text embeddings\n- WebLoader to access a file hosted on the web\n- Recursive splitter to prepare document for embedding\n- Multi Query Retriever to enhance search results\n\nThis bot contains both ingestion and query in the same chain. The document is fetched, embedded, and then queried.\n",
+      "created_at": "2023-09-10T21:57:51.951Z",
+      "model": "",
+      "config": {},
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820",
+      "is_test": false
+    }
+  },
+  {
+    "model": "chains.chain",
+    "pk": "791ac570-6da8-4ce1-990c-2d4de7ea6820",
+    "fields": {
+      "name": "IX Readme",
+      "description": "A bot that can answer questions using the IX README file as context. \n\nThis bot is a demonstration of a retrieval augmented generation (RAG):\n- Chroma vectorstore to search text embeddings\n- WebLoader to access a file hosted on the web\n- Recursive splitter to prepare document for embedding\n- Multi Query Retriever to enhance search results\n\nThis bot contains both ingestion and query in the same chain. The document is fetched, embedded, and then queried.\n",
+      "created_at": "2023-09-10T21:57:51.937Z",
+      "is_agent": true
+    }
+  },
+  {
+    "model": "chains.chainnode",
+    "pk": "0ac2d539-4cbd-4c7c-8196-83d51d610c1c",
+    "fields": {
+      "class_path": "langchain.chat_models.openai.ChatOpenAI",
+      "node_type": "bbb7544c-6891-4204-985a-d13d65e02523",
+      "config": {
+        "verbose": false,
+        "streaming": true,
+        "max_tokens": 256,
+        "model_name": "gpt-4-0613",
+        "max_retries": 6,
+        "temperature": 0,
+        "request_timeout": 60
+      },
+      "name": null,
+      "description": null,
+      "root": false,
+      "position": {
+        "x": -250.0,
+        "y": 660.0
+      },
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820"
+    }
+  },
+  {
+    "model": "chains.chainnode",
+    "pk": "15f2a320-5a4b-4314-9000-8b777dedcd27",
+    "fields": {
+      "class_path": "langchain.memory.buffer_window.ConversationBufferWindowMemory",
+      "node_type": "8a49959a-b5bc-414e-a25f-51b8d3ad6249",
+      "config": {
+        "k": "0",
+        "ai_prefix": "AI",
+        "input_key": "input",
+        "memory_key": "chat_history",
+        "output_key": "answer",
+        "human_prefix": "Human"
+      },
+      "name": null,
+      "description": null,
+      "root": false,
+      "position": {
+        "x": 70.0,
+        "y": 440.0
+      },
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820"
+    }
+  },
+  {
+    "model": "chains.chainnode",
+    "pk": "24caad61-ade3-40a2-b3cb-4d8b23c17a0e",
+    "fields": {
+      "class_path": "langchain.text_splitter.RecursiveCharacterTextSplitter.from_language",
+      "node_type": "f4789b2b-7eae-4ea9-a92f-c3bff954cac8",
+      "config": {
+        "language": "markdown",
+        "chunk_size": 4000,
+        "chunk_overlap": 200
+      },
+      "name": null,
+      "description": null,
+      "root": false,
+      "position": {
+        "x": -610.0,
+        "y": 640.0
+      },
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820"
+    }
+  },
+  {
+    "model": "chains.chainnode",
+    "pk": "24cba13b-6938-499d-bdbd-4ae4dd36727a",
+    "fields": {
+      "class_path": "ix.chains.components.vectorstores.AsyncChromaVectorstore",
+      "node_type": "9e8d970a-55ba-4afd-add9-bd33a52fc30c",
+      "config": {
+        "search_type": "similarity",
+        "allowed_search_types": [
+          "similarity",
+          "similarity_score_threshold",
+          "mmr"
+        ]
+      },
+      "name": "Chroma (embedded)",
+      "description": "This runs chroma directly within the worker process.",
+      "root": false,
+      "position": {
+        "x": -250.0,
+        "y": 540.0
+      },
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820"
+    }
+  },
+  {
+    "model": "chains.chainnode",
+    "pk": "4565d9d9-6531-48d6-8ac2-28e16aa3b36e",
+    "fields": {
+      "class_path": "langchain.document_loaders.web_base.WebBaseLoader",
+      "node_type": "7477a8ad-ca83-4714-aeaf-4df8cbb900ea",
+      "config": {
+        "web_path": "https://raw.githubusercontent.com/kreneskyp/ix/master/README.md",
+        "verify_ssl": true,
+        "continue_on_failure": false
+      },
+      "name": "IX README (web loader)",
+      "description": null,
+      "root": false,
+      "position": {
+        "x": -920.0,
+        "y": 640.0
+      },
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820"
+    }
+  },
+  {
+    "model": "chains.chainnode",
+    "pk": "64bb9280-9dee-4e0a-b207-a6634ae708f2",
+    "fields": {
+      "class_path": "langchain.retrievers.multi_query.MultiQueryRetriever.from_llm",
+      "node_type": "7b954f7c-4449-46b4-9013-382ce3c94c2a",
+      "config": {},
+      "name": null,
+      "description": null,
+      "root": false,
+      "position": {
+        "x": 70.0,
+        "y": 540.0
+      },
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820"
+    }
+  },
+  {
+    "model": "chains.chainnode",
+    "pk": "7514f588-13fb-4fe4-99f9-8ddbdd5a8100",
+    "fields": {
+      "class_path": "langchain.chains.conversational_retrieval.base.ConversationalRetrievalChain.from_llm",
+      "node_type": "dbcd3e60-e809-4074-b69a-042d08aeaf26",
+      "config": {
+        "verbose": false,
+        "output_key": "answer",
+        "rephrase_question": true,
+        "return_source_documents": true
+      },
+      "name": null,
+      "description": null,
+      "root": true,
+      "position": {
+        "x": 440.0,
+        "y": 280.0
+      },
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820"
+    }
+  },
+  {
+    "model": "chains.chainnode",
+    "pk": "902318cb-0944-4aea-b466-a4982e2a25ed",
+    "fields": {
+      "class_path": "langchain.chat_models.openai.ChatOpenAI",
+      "node_type": "bbb7544c-6891-4204-985a-d13d65e02523",
+      "config": {
+        "verbose": false,
+        "streaming": true,
+        "max_tokens": 256,
+        "model_name": "gpt-4-0613",
+        "max_retries": 6,
+        "temperature": 0,
+        "request_timeout": 60
+      },
+      "name": null,
+      "description": null,
+      "root": false,
+      "position": {
+        "x": 70.0,
+        "y": 350.0
+      },
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820"
+    }
+  },
+  {
+    "model": "chains.chainnode",
+    "pk": "b25c086c-2558-46e4-87ac-a34ffdf91a01",
+    "fields": {
+      "class_path": "langchain.embeddings.openai.OpenAIEmbeddings",
+      "node_type": "3ffc030c-f6cb-4fc2-9cd7-ff1cfd3a5c99",
+      "config": {
+        "model": "text-embedding-ada-002",
+        "chunk_size": 1000,
+        "max_retries": "6",
+        "allowed_special": [],
+        "disallowed_special": "all"
+      },
+      "name": null,
+      "description": null,
+      "root": false,
+      "position": {
+        "x": -580.0,
+        "y": 540.0
+      },
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820"
+    }
+  },
+  {
+    "model": "chains.chainnode",
+    "pk": "b75c22ab-a411-4fcc-b290-c4d95ff35bdc",
+    "fields": {
+      "class_path": "langchain.memory.RedisChatMessageHistory",
+      "node_type": "da5e809a-b158-4f34-8867-8ac375967906",
+      "config": {
+        "ttl": 3600,
+        "url": "redis://redis:6379/0",
+        "session_key": "session_id",
+        "session_scope": "",
+        "session_prefix": ""
+      },
+      "name": null,
+      "description": null,
+      "root": false,
+      "position": {
+        "x": -250.0,
+        "y": 440.0
+      },
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820"
+    }
+  },
+  {
+    "model": "chains.chainedge",
+    "pk": "28e03753-3cf5-4346-9b3e-734e3eb7f77d",
+    "fields": {
+      "source": "15f2a320-5a4b-4314-9000-8b777dedcd27",
+      "target": "7514f588-13fb-4fe4-99f9-8ddbdd5a8100",
+      "key": "memory",
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820",
+      "input_map": null,
+      "relation": "PROP"
+    }
+  },
+  {
+    "model": "chains.chainedge",
+    "pk": "358a68a9-f2cd-4d77-b12a-dd9517b7211f",
+    "fields": {
+      "source": "64bb9280-9dee-4e0a-b207-a6634ae708f2",
+      "target": "7514f588-13fb-4fe4-99f9-8ddbdd5a8100",
+      "key": "retriever",
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820",
+      "input_map": null,
+      "relation": "PROP"
+    }
+  },
+  {
+    "model": "chains.chainedge",
+    "pk": "421d353d-c162-41f0-83b1-a8a316cc1151",
+    "fields": {
+      "source": "b25c086c-2558-46e4-87ac-a34ffdf91a01",
+      "target": "24cba13b-6938-499d-bdbd-4ae4dd36727a",
+      "key": "embedding",
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820",
+      "input_map": null,
+      "relation": "PROP"
+    }
+  },
+  {
+    "model": "chains.chainedge",
+    "pk": "8765ac0b-ce02-450e-b887-e24b50ba2678",
+    "fields": {
+      "source": "4565d9d9-6531-48d6-8ac2-28e16aa3b36e",
+      "target": "24caad61-ade3-40a2-b3cb-4d8b23c17a0e",
+      "key": "document_loader",
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820",
+      "input_map": null,
+      "relation": "PROP"
+    }
+  },
+  {
+    "model": "chains.chainedge",
+    "pk": "885a452a-80ea-4dad-ad3d-0ffba09e3692",
+    "fields": {
+      "source": "24cba13b-6938-499d-bdbd-4ae4dd36727a",
+      "target": "64bb9280-9dee-4e0a-b207-a6634ae708f2",
+      "key": "retriever",
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820",
+      "input_map": null,
+      "relation": "PROP"
+    }
+  },
+  {
+    "model": "chains.chainedge",
+    "pk": "91290eed-a300-4e10-808e-42a7c194e951",
+    "fields": {
+      "source": "24caad61-ade3-40a2-b3cb-4d8b23c17a0e",
+      "target": "24cba13b-6938-499d-bdbd-4ae4dd36727a",
+      "key": "documents",
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820",
+      "input_map": null,
+      "relation": "PROP"
+    }
+  },
+  {
+    "model": "chains.chainedge",
+    "pk": "cdcb09a9-6b20-4494-bde0-b67e23cbbcac",
+    "fields": {
+      "source": "0ac2d539-4cbd-4c7c-8196-83d51d610c1c",
+      "target": "64bb9280-9dee-4e0a-b207-a6634ae708f2",
+      "key": "llm",
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820",
+      "input_map": null,
+      "relation": "PROP"
+    }
+  },
+  {
+    "model": "chains.chainedge",
+    "pk": "e42013fa-afaa-4a75-b8b6-16df8d207ce6",
+    "fields": {
+      "source": "902318cb-0944-4aea-b466-a4982e2a25ed",
+      "target": "7514f588-13fb-4fe4-99f9-8ddbdd5a8100",
+      "key": "llm",
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820",
+      "input_map": null,
+      "relation": "PROP"
+    }
+  },
+  {
+    "model": "chains.chainedge",
+    "pk": "ed313087-3457-420b-b0cc-f9a6e5afa87c",
+    "fields": {
+      "source": "b75c22ab-a411-4fcc-b290-c4d95ff35bdc",
+      "target": "15f2a320-5a4b-4314-9000-8b777dedcd27",
+      "key": "chat_memory",
+      "chain": "791ac570-6da8-4ce1-990c-2d4de7ea6820",
+      "input_map": null,
+      "relation": "PROP"
+    }
+  }
+]

--- a/ix/conftest.py
+++ b/ix/conftest.py
@@ -365,6 +365,7 @@ async def aix_agent(anode_types):
     """async version of ix_agent fixture"""
     await sync_to_async(call_command)("loaddata", "agent/ix")
     await sync_to_async(call_command)("loaddata", "agent/code")
+    await sync_to_async(call_command)("loaddata", "agent/readme")
 
 
 @pytest_asyncio.fixture

--- a/ix/server/settings.py
+++ b/ix/server/settings.py
@@ -207,3 +207,9 @@ LOGGING = {
 }
 
 MOCK_CHAT_RESPONSE = os.environ.get("MOCK_CHAT_RESPONSE", False)
+
+# Default agents to include in chats
+DEFAULT_AGENTS = [
+    "b7d8f662-12f6-4525-b07b-c9ea7c10010a",  # @code
+    "cc054ff5-67cd-4489-b0f1-b8b62af2d825",  # @readme
+]

--- a/ix/task_log/management/commands/setup.py
+++ b/ix/task_log/management/commands/setup.py
@@ -12,6 +12,7 @@ class Command(BaseCommand):
             "fake_user",
             "node_types",
             "agent/ix",
+            "agent/readme",
             "agent/code",
             "agent/pirate",
             "agent/wikipedia",


### PR DESCRIPTION
### Description
Adding **@readme** an example RAG that loads IX's README from github


**@readme** uses `Chroma`, `MultiQueryRetriever`, and `WebLoader` in a `ConversationalRetrievalChain`.

![readme-install-howto](https://github.com/kreneskyp/ix/assets/68635/66ff5f44-751d-4b4a-9e1f-17a23f3fbfa3)

![image](https://github.com/kreneskyp/ix/assets/68635/5294a41b-0c05-4597-95fb-ab13a7e03dc5)



### Changes
- cleaned up fixture loading make targets for readability
- default chat agents now load from `settings.DEFAULT_AGENTS`
- adds `agent/readme` fixture
- adds `@readme` as a default chat agent

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
