### PR TITLE
Handle ``` code blocks ``` in chat

### DIFF
--- a/frontend/components/HighlightText.js
+++ b/frontend/components/HighlightText.js
@@ -1,7 +1,9 @@
 import React from "react";
 import { Box, Text, Link, Code } from "@chakra-ui/react";
 import PropTypes from "prop-types";
+
 import { useChatColorMode } from "chains/editor/useColorMode";
+import { HighlightedCode } from "components/HighlightedCode";
 
 /**
  * HighlightText is a component that takes a string and returns a Chakra Text component with
@@ -41,6 +43,14 @@ const HighlightText = ({ content }) => {
             {execResult[1]}
           </Link>
         ),
+      },
+      {
+        regex: /```([\w\s]*?)\n([\s\S]*?)(```|$)/g,
+        component: (match, idx, execResult) => {
+          // execResult[2] contains the actual code content
+          const codeText = execResult[2].replace(/\s+$/, "");
+          return <HighlightedCode text={codeText} />;
+        },
       },
       {
         regex: /`([^`]+)`/g,

--- a/frontend/components/HighlightedCode.js
+++ b/frontend/components/HighlightedCode.js
@@ -1,0 +1,76 @@
+import React, { useState, useEffect, useCallback } from "react";
+import SyntaxHighlighter from "react-syntax-highlighter";
+import {
+  stackoverflowDark,
+  stackoverflowLight,
+} from "react-syntax-highlighter/dist/cjs/styles/hljs";
+import { useColorMode, Box, Text } from "@chakra-ui/react";
+import copy from "copy-to-clipboard";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faClipboard, faCheck } from "@fortawesome/free-solid-svg-icons";
+
+export const HighlightedCode = ({ text }) => {
+  const { colorMode } = useColorMode();
+  const syntaxTheme =
+    colorMode === "light" ? stackoverflowLight : stackoverflowDark;
+
+  const style =
+    colorMode === "light"
+      ? { color: "gray.600", _hover: { color: "blue.400" } }
+      : { color: "gray.500", _hover: { color: "blue.400" } };
+
+  const copiedStyle =
+    colorMode === "light"
+      ? { color: "green.600", fontWeight: "bold" }
+      : { color: "green.300" };
+
+  const [showCopied, setShowCopied] = useState(false);
+
+  const copyToClipboard = useCallback(() => {
+    copy(text);
+    setShowCopied(true);
+  }, [text]);
+
+  useEffect(() => {
+    let timer;
+    if (showCopied) {
+      timer = setTimeout(() => {
+        setShowCopied(false);
+      }, 2500);
+    }
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [showCopied]);
+
+  return (
+    <Box position="relative" mt={2}>
+      {/* Button for copy to clipboard */}
+      <Box
+        {...style}
+        position="absolute"
+        top="1"
+        right="1"
+        zIndex="1"
+        fontSize={"xs"}
+        onClick={copyToClipboard}
+        cursor="pointer"
+      >
+        {showCopied ? (
+          <Text {...copiedStyle}>
+            <FontAwesomeIcon icon={faCheck} /> copied!
+          </Text>
+        ) : (
+          <>
+            <FontAwesomeIcon icon={faClipboard} /> copy
+          </>
+        )}
+      </Box>
+
+      {/* Code highlighter */}
+      <SyntaxHighlighter style={syntaxTheme} wrapLines={true}>
+        {text}
+      </SyntaxHighlighter>
+    </Box>
+  );
+};

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.4.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "axios": "^1.4.0",
+    "copy-to-clipboard": "^3.3.3",
     "dagre": "^0.8.5",
     "package.json": "^2.0.1",
     "qs": "^6.11.2",


### PR DESCRIPTION
### Description
Codeblocks indicated by ``` are now rendered with syntax highlighting as they stream. The code block now includes a copy button.

![image](https://github.com/kreneskyp/ix/assets/68635/22bdcd46-bc87-4ebc-aea4-c9108a58f2b3)
![image](https://github.com/kreneskyp/ix/assets/68635/b6f57738-0353-4979-8f8a-2d8e585a286d)


### Changes
- Adds `HighlightCode` component to encapsulate highlighted code block + addon features like copying.
- Adds regex pattern to `HighlightText` to handle markdown style triple backtick code blocks

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
