### PR TITLE
Add empty directories for dev static files.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,15 @@ ENV APP=/var/app
 ENV PATH=$PATH:/usr/bin/ix
 RUN mkdir -p /usr/bin/ix
 COPY bin/* /usr/bin/ix/
+
+# create useful directories
 RUN mkdir -p $APP
 RUN mkdir -p /var/wheels
+
+# create directies needed for dev mode - these aren't used in production
+# but raise warnings if they aren't there. (harmless but yellow and scary)
+RUN mkdir -p $APP/.compiled-static
+RUN mkdir -p $APP/frontend/static
 
 RUN apt update -y && \
     apt install -y curl postgresql-client && \


### PR DESCRIPTION

### Description
Directories used for static files in dev builds raise warnings in published images.  Harmless but the warning is big and yellow so it's being silenced.

![image](https://github.com/kreneskyp/ix/assets/68635/23b9d1c7-59c5-41a1-bc12-ec385830a687)


### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
