### PR TITLE
LangChain 0.0.299

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ ipython==8.13.2
 isort==5.12.0
 jsonpath-ng==1.5.3
 jsonschema==4.0.1
-langchain==0.0.281
+langchain==0.0.299
 llama-cpp-python==0.1.79
 metaphor-python==0.1.16
 openai==0.27.8

--- a/test_data/snapshots/components/langchain.chains.llm_symbolic_math.base.LLMSymbolicMathChain.from_llm.json
+++ b/test_data/snapshots/components/langchain.chains.llm_symbolic_math.base.LLMSymbolicMathChain.from_llm.json
@@ -40,7 +40,7 @@
             "type": "target"
         }
     ],
-    "description": "Chain that interprets a prompt and executes python code to do symbolic math.\n\n    Example:\n        .. code-block:: python\n\n            from langchain import LLMSymbolicMathChain, OpenAI\n            llm_symbolic_math = LLMSymbolicMathChain.from_llm(OpenAI())\n    ",
+    "description": "Chain that interprets a prompt and executes python code to do symbolic math.\n\n    Example:\n        .. code-block:: python\n\n            from langchain.chains import LLMSymbolicMathChain\n            from langchain.llms import OpenAI\n            llm_symbolic_math = LLMSymbolicMathChain.from_llm(OpenAI())\n    ",
     "display_type": "node",
     "fields": [
         {

--- a/test_data/snapshots/components/langchain.document_loaders.parsers.language.language_parser.LanguageParser.json
+++ b/test_data/snapshots/components/langchain.document_loaders.parsers.language.language_parser.LanguageParser.json
@@ -21,7 +21,8 @@
                     "markdown",
                     "latex",
                     "html",
-                    "sol"
+                    "sol",
+                    "csharp"
                 ],
                 "type": "string"
             },
@@ -102,6 +103,10 @@
                 {
                     "label": "SOL",
                     "value": "sol"
+                },
+                {
+                    "label": "CSHARP",
+                    "value": "csharp"
                 }
             ],
             "default": null,

--- a/test_data/snapshots/components/langchain.text_splitter.RecursiveCharacterTextSplitter.from_language.json
+++ b/test_data/snapshots/components/langchain.text_splitter.RecursiveCharacterTextSplitter.from_language.json
@@ -37,7 +37,8 @@
                     "markdown",
                     "latex",
                     "html",
-                    "sol"
+                    "sol",
+                    "csharp"
                 ],
                 "type": "string"
             }
@@ -123,6 +124,10 @@
                 {
                     "label": "SOL",
                     "value": "sol"
+                },
+                {
+                    "label": "CSHARP",
+                    "value": "csharp"
                 }
             ],
             "default": "python",


### PR DESCRIPTION
### Description
Updating to LangChain 0.0.299.  No breaking changes found.

Few minor updates to component definitions. Snapshot test added in #244 did it's job identifying the changes.

### Changes
- `langchain==0.0.299` and related changes

### How Tested
- unittests
- manual smoke tests of different agent/chain types.

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
