### PR TITLE
Bugfix: dropping node while connector-less-node is selected

### DIFF
--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -124,7 +124,7 @@ const ChainGraphEditor = ({ graph, rightSidebarDisclosure }) => {
           // Only Node selected:
           // select the first open connector accepting the node type
           const targetType = selectedNode.data.type;
-          edgeConnector = targetType.connectors.find((connector) =>
+          edgeConnector = targetType.connectors?.find((connector) =>
             getExpectedTypes(connector).has(nodeType.type)
           );
         }


### PR DESCRIPTION
### Description
dropping node while connector-less-node is selected now works again. There was a bug in auto-connect logic that failed when a node had no connectors.

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
