### PR TITLE
Chat message rendering fixes

### DIFF
--- a/frontend/components/HighlightText.js
+++ b/frontend/components/HighlightText.js
@@ -68,11 +68,12 @@ const HighlightText = ({ content }) => {
     }
 
     let segments = [content];
+    let key = 0;
 
     regexComponentPairs.forEach(({ regex, component }) => {
       let newSegments = [];
-      segments.forEach((segment, idx) => {
-        if (typeof segment === "string") {
+      segments.forEach((segment) => {
+        if (typeof segment === "string") {;
           let lastIndex = 0;
           let match;
           regex.lastIndex = 0; // Reset lastIndex due to the 'g' flag
@@ -83,7 +84,7 @@ const HighlightText = ({ content }) => {
             lastIndex = regex.lastIndex;
 
             if (prefix) newSegments.push(prefix);
-            newSegments.push(component(matchedText, idx, match));
+            newSegments.push(component(matchedText, key++, match));
           }
 
           const postfix = segment.substring(lastIndex);

--- a/frontend/components/HighlightText.js
+++ b/frontend/components/HighlightText.js
@@ -15,6 +15,12 @@ const HighlightText = ({ content }) => {
   const regexComponentPairs = React.useMemo(
     () => [
       {
+        regex: /`([^`]+)`/g,
+        component: (match, idx, execResult) => (
+          <Code key={idx}>{execResult[1]}</Code>
+        ),
+      },
+      {
         regex: /@\w+/g,
         component: (match, idx) => (
           <Text as="span" sx={mention} key={idx}>
@@ -52,12 +58,7 @@ const HighlightText = ({ content }) => {
           return <HighlightedCode text={codeText} />;
         },
       },
-      {
-        regex: /`([^`]+)`/g,
-        component: (match, idx, execResult) => (
-          <Code key={idx}>{execResult[1]}</Code>
-        ),
-      },
+
     ],
     [mention, artifact]
   );


### PR DESCRIPTION
### Description
Fixing two minor bugs in Chat message rendering:
- `HighlightText` now renders inline code before other highlights. There were frequent overlaps where a section of code was highlighted as a mention or artifact and then wrapped in an inline code block. It rendered weird and was hard to read

    This affected this section of output from the readme where the mentions are in a codeblock because github markdown doesn't highlight mentions.
    ![image](https://github.com/kreneskyp/ix/assets/68635/47f7033a-60bb-4503-9b57-c68f43c4c1be)


- `HighlightText` was not generating unique key props for components. This may have resulted in strange rendering (dropped messages, etc)

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
