### PR TITLE
useTestChat now tracks loaded chain and reloads when a new chain is requested.

### DIFF
--- a/frontend/chains/hooks/useTestChat.js
+++ b/frontend/chains/hooks/useTestChat.js
@@ -2,6 +2,9 @@ import React from "react";
 import { useDetailAPI } from "utils/hooks/useDetailAPI";
 
 export const useTestChat = (chain_id) => {
+  // tracks loaded chat
+  const [loadedChainId, setLoadedChainId] = React.useState(null);
+
   // api query: load chat
   const {
     call: loadChat,
@@ -12,7 +15,9 @@ export const useTestChat = (chain_id) => {
   const chat = chain_id === undefined ? null : response?.data;
 
   React.useEffect(() => {
-    if (chain_id && !chat) {
+    if (chain_id && loadedChainId != chain_id) {
+      console.log("useTestChat: loading chat: ", chain_id)
+      setLoadedChainId(chain_id);
       loadChat();
     }
   }, [chain_id]);


### PR DESCRIPTION
### Description
Editor test chat managed by `useTestChat ` wasn't loading the new chain's chat when switching from one chain to another. `useTestChat` wasn't tracking the loaded chain so it couldn't detect the change

Regression caused by #260

### Changes
- `useTestChat` now tracks the loaded chain to detect a new chain is requested.

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
