### PR TITLE
Fixing chroma field imports

### DIFF
--- a/ix/chains/fixture_src/vectorstores.py
+++ b/ix/chains/fixture_src/vectorstores.py
@@ -87,11 +87,16 @@ CHROMA = {
     "description": "Chroma vector database",
     "connectors": VECTORSTORE_CONNECTORS,
     "fields": NodeTypeField.get_fields(
-        Chroma,
+        Chroma.__init__,
         include=[
             "collection_name",
             "persist_directory",
         ],
+        field_options={
+            "persist_directory": {
+                "default": "./chroma",
+            }
+        },
     )
     + NodeTypeField.get_fields(
         chromadb.config.Settings,

--- a/test_data/snapshots/components/ix.chains.components.vectorstores.AsyncChromaVectorstore.json
+++ b/test_data/snapshots/components/ix.chains.components.vectorstores.AsyncChromaVectorstore.json
@@ -35,6 +35,14 @@
                 "default": false,
                 "type": "boolean"
             },
+            "collection_name": {
+                "default": "langchain",
+                "type": "string"
+            },
+            "persist_directory": {
+                "default": "./chroma",
+                "type": "object"
+            },
             "search_type": {
                 "default": "similarity",
                 "type": "string"
@@ -60,6 +68,34 @@
     "description": "Chroma vector database",
     "display_type": "node",
     "fields": [
+        {
+            "choices": null,
+            "default": "langchain",
+            "input_type": null,
+            "label": "Collection_name",
+            "max": null,
+            "min": null,
+            "name": "collection_name",
+            "parent": null,
+            "required": false,
+            "step": null,
+            "style": null,
+            "type": "str"
+        },
+        {
+            "choices": null,
+            "default": "./chroma",
+            "input_type": null,
+            "label": "Persist_directory",
+            "max": null,
+            "min": null,
+            "name": "persist_directory",
+            "parent": null,
+            "required": false,
+            "step": null,
+            "style": null,
+            "type": "Optional[str]"
+        },
         {
             "choices": null,
             "default": "172.17.42.1",


### PR DESCRIPTION
### Description
Chroma was missing `collection_name` and `persist_directory` fields.

![image](https://github.com/kreneskyp/ix/assets/68635/49b314cf-7c65-4ca3-b48d-9dbcd4b63fb4)


### Changes
- CHROMA config fixture now imports fields from `Choma.__init__`

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
