### PR TITLE
Lazy loading chain branches with NodeTemplate

### DIFF
--- a/ix/api/components/types.py
+++ b/ix/api/components/types.py
@@ -343,6 +343,14 @@ class Connector(BaseModel):
     # be converted to another type. e.g. VectorStore.as_retriever()
     as_type: Optional[NodeTypes]
 
+    # Indicate this connector expects a template that will be lazy loaded.
+    # Loading the root component will initiate this property as a NodeTemplate
+    # instance with a reference to the connected node. The component may then
+    # initialize node and any nodes that branch from it at runtime by calling
+    # the NodeTemplate.format(input=variables) method. Given variables will
+    # replace {variables} in any of the node's config values.
+    template: Optional[bool] = False
+
     # Allow more than one connection to this connector
     multiple: bool = False
 

--- a/ix/chains/loaders/core.py
+++ b/ix/chains/loaders/core.py
@@ -10,6 +10,7 @@ from langchain.chains.base import Chain as LangchainChain
 
 from ix.chains.loaders.prompts import load_prompt
 from ix.chains.models import NodeType, ChainNode, ChainEdge
+from ix.utils.config import format_config
 from ix.utils.importlib import import_class
 
 import_node_class = import_class
@@ -76,7 +77,7 @@ def get_sequence_inputs(sequence: List[LangchainChain]) -> List[str]:
     return list(input_variables)
 
 
-def load_node(node: ChainNode, context: IxContext, root=True) -> Any:
+def load_node(node: ChainNode, context: IxContext, root=True, variables=None) -> Any:
     """
     Generic loader for loading the Langchain component a ChainNode represents.
 
@@ -90,10 +91,15 @@ def load_node(node: ChainNode, context: IxContext, root=True) -> Any:
     node_type: NodeType = node.node_type
     config = node.config.copy() if node.config else {}
 
-    # resolve secrets and settings
     # TODO: implement resolve secrets from vault and settings from vocabulary
     #       neither of these subsystems are implemented yet. For now load all
     #       values as text from config dict
+    # resolve secrets and settings
+    # format the config in this order:
+    # 1. format with context variables
+    # 2. format with secrets
+    if variables:
+        config = format_config(config, variables)
 
     # load type specific config options. This is generally for loading
     # ix specific features into the config dict

--- a/ix/chains/loaders/templates.py
+++ b/ix/chains/loaders/templates.py
@@ -1,0 +1,69 @@
+from typing import TypeVar, Generic, Dict, Any, Set, Type
+
+from asgiref.sync import sync_to_async, async_to_sync
+from pydantic import BaseModel, create_model
+
+from ix.chains.loaders.context import IxContext
+from ix.chains.models import ChainNode
+from ix.utils.config import get_config_variables
+
+T = TypeVar("T")
+
+
+class NodeTemplate(Generic[T]):
+    """
+    A template for a node in a chain. This is used to create a node from a graph whose
+    nodes contain $variables.
+
+    Templates containing $variables are used as placeholders to delay instantiation
+    until request time. This allows for dynamic configuration of nodes from chain
+    inputs.
+
+    The most common example is a document loader. Document loaders are used to load
+    documents into a vectorstore. Document loaders generally require a path or URL
+    to the source document. Using a template, document loaders can be reused
+    for different source documents.
+    """
+
+    def __init__(self, node: ChainNode, context: IxContext):
+        self.node = node
+        self.context = context
+
+    def format(self, input: Dict[str, Any]) -> T:
+        from ix.chains.loaders.core import load_node
+
+        return load_node(self.node, self.context, variables=input)
+
+    async def aformat(self, input: Dict[str, Any]) -> T:
+        from ix.chains.loaders.core import load_node
+
+        return await sync_to_async(load_node)(self.node, self.context, variables=input)
+
+    async def get_variables(self, node: ChainNode = None) -> Set[str]:
+        """
+        Helper recursive function to extract config variables.
+        """
+        node = node if node else self.node
+        variables = get_config_variables(node.config if node.config else {})
+
+        # Recursively traverse for all connected nodes
+        connected_edges = node.incoming_edges.filter(relation="PROP").order_by("key")
+        async for edge in connected_edges.aiterator():
+            connected_node = await ChainNode.objects.aget(pk=edge.source_id)
+            variables.update(await self.get_variables(connected_node))
+
+        return variables
+
+    def get_args_schema(self) -> Type[BaseModel]:
+        """
+        Dynamically create a Pydantic model class with fields for each variable in the template.
+        """
+        # Use dictionary comprehension to define fields with type annotations
+        field_definitions = {
+            field: (str, ...) for field in async_to_sync(self.get_variables)()
+        }
+
+        # Create and return the new Pydantic model class using the 'type' function
+        DynamicArgsSchema = create_model("DynamicArgsSchema", **field_definitions)
+
+        return DynamicArgsSchema

--- a/ix/utils/config.py
+++ b/ix/utils/config.py
@@ -1,0 +1,31 @@
+import re
+from typing import Any, Dict
+
+
+def format_config(config: Any, variables: Dict[str, Any]) -> Any:
+    """
+    Recursively update the `config` object by replacing $variables.
+
+    Parameters:
+    config (Any): The configuration object. It can be a nested structure containing dictionaries and lists.
+    variables (Dict[str, Any]): The dictionary containing the variable names and their corresponding values.
+
+    Returns:
+    Any: The updated configuration object.
+    """
+    if isinstance(config, dict):
+        return {k: format_config(v, variables) for k, v in config.items()}
+    elif isinstance(config, list):
+        return [format_config(elem, variables) for elem in config]
+    elif isinstance(config, str):
+
+        def replacer(match):
+            whole, escaped, var = match.groups()
+            if escaped:
+                return whole
+            return str(variables.get(var, whole))
+
+        pattern = r"(\$\$)?\${([^}]*)}"
+        return re.sub(pattern, replacer, config)
+    else:
+        return config

--- a/ix/utils/config.py
+++ b/ix/utils/config.py
@@ -1,10 +1,23 @@
 import re
-from typing import Any, Dict
+from typing import Any, Dict, Set
+
+
+class TemplateException(Exception):
+    pass
+
+
+# matches {variables} but not {{escaped_variables}}
+VARIABLE_REGEX = r"(?<!\{)\{(\w+)\}"
+
+# matches {{escaped_variables}}
+ESCAPED_VARIABLE_REGEX = r"\{\{(\w+)\}?\}"
 
 
 def format_config(config: Any, variables: Dict[str, Any]) -> Any:
     """
     Recursively update the `config` object by replacing $variables.
+
+    Escaped variables $$variable will be replaced with $variable.
 
     Parameters:
     config (Any): The configuration object. It can be a nested structure containing dictionaries and lists.
@@ -18,14 +31,40 @@ def format_config(config: Any, variables: Dict[str, Any]) -> Any:
     elif isinstance(config, list):
         return [format_config(elem, variables) for elem in config]
     elif isinstance(config, str):
+        # Handle regular variables
+        def regular_replacer(match):
+            var_name = match.group(1)
+            if var_name not in variables:
+                raise TemplateException(f"Missing variable: {var_name}")
+            return str(variables.get(var_name))
 
-        def replacer(match):
-            whole, escaped, var = match.groups()
-            if escaped:
-                return whole
-            return str(variables.get(var, whole))
+        config = re.sub(VARIABLE_REGEX, regular_replacer, config)
 
-        pattern = r"(\$\$)?\${([^}]*)}"
-        return re.sub(pattern, replacer, config)
+        # Handle escaped variables second
+        def escaped_replacer(match):
+            return "{" + match.group(1) + "}"
+
+        config = re.sub(ESCAPED_VARIABLE_REGEX, escaped_replacer, config)
+
+        return config
     else:
         return config
+
+
+def get_config_variables(config: Dict[str, Any]) -> Set[str]:
+    """
+    Get all variables from a config dict.
+    Will search recursively through nested dicts and lists.
+    """
+    variables = set()
+    if isinstance(config, dict):
+        for key, value in config.items():
+            variables.update(get_config_variables(value))
+    elif isinstance(config, list):
+        for item in config:
+            variables.update(get_config_variables(item))
+    elif isinstance(config, str):
+        matches = re.findall(VARIABLE_REGEX, config)
+        for match in matches:
+            variables.add(match)
+    return variables

--- a/ix/utils/tests/test_config.py
+++ b/ix/utils/tests/test_config.py
@@ -1,0 +1,64 @@
+import pytest
+
+from ix.utils.config import format_config, get_config_variables, TemplateException
+
+
+@pytest.fixture
+def sample_config():
+    return {
+        "name": "{username}",
+        "details": {"age": "{age}", "address": "{address}"},
+        "hobbies": ["{hobby1}", "{hobby2}"],
+        "escape_test1": "{{escaped_double_braces}}",
+        "escape_test2": "{{escaped_single_braces}",
+    }
+
+
+@pytest.fixture
+def sample_variables():
+    return {
+        "username": "John",
+        "age": "25",
+        "address": "1234 Elm St",
+        "hobby1": "reading",
+        "hobby2": "writing",
+    }
+
+
+class TestFormatConfig:
+    def test_format(self, sample_config, sample_variables):
+        formatted_config = format_config(sample_config, sample_variables)
+        assert formatted_config["name"] == "John"
+        assert formatted_config["details"]["age"] == "25"
+        assert formatted_config["details"]["address"] == "1234 Elm St"
+        assert formatted_config["hobbies"] == ["reading", "writing"]
+        assert formatted_config["escape_test1"] == "{escaped_double_braces}"
+        assert formatted_config["escape_test2"] == "{escaped_single_braces}"
+
+    def test_format_with_missing_variables(self, sample_config):
+        variables = {"username": "John"}
+        with pytest.raises(TemplateException, match="Missing variable: age"):
+            format_config(sample_config, variables)
+
+    def test_format_with_non_string_values(self):
+        config = {
+            "integer": 123,
+            "float": 123.45,
+            "boolean": True,
+        }
+        formatted_config = format_config(config, {})
+        assert formatted_config == config
+
+
+class TestGetConfigVariables:
+    def test_get_variables(self, sample_config):
+        variables = get_config_variables(sample_config)
+        assert variables == {"username", "age", "address", "hobby1", "hobby2"}
+
+    def test_get_variables_with_no_variables(self):
+        config = {
+            "escape_test1": "{{escaped_double_braces}}",
+            "escape_test2": "{{escaped_single_braces}",
+        }
+        variables = get_config_variables(config)
+        assert not variables


### PR DESCRIPTION
### Description
This PR introduces `Connectors` that are lazy loaded templates. The entire branch stemming from the connector is lazy loaded. Component nodes within the branch may define any property as a `{variable}`.  The component will `format` those variables at runtime and may use user input or derive the value in a function call.

This system is designed to enable generic tools whose settings are defined at runtime. This differs from a standard chain that requires values to be hardcoded at runtime.

Note, that only templated branches support variables. Components must explicitly implement support for templates. A NodeTemplate can't replace the actual object (i.e. a stock LangChain component usually requires the actual object with it is instantiated.)


#### General Usage
Basic example to enable a templated node.

1. Define template property as `NodeTemplate[type]` type.
```
Bar(BaseModel):
    xoo: str

Foo(BaseModel):
    # templated property
    bar: NodeTemplate[Bar]
```

2. Define connector with `template=True`.
```
BAR_CONNECTOR = Connector(
    key="bar",
    type="target",
    source_type="bar"
    template=True,
)
```

3. implement `run` and `arun` methods to load the node at runtime with variables.  The variables are hardcoded in this example but could pull from `kwargs` to use inputs that an agent has created. (e.g. search the web and then ingest the `{URL}`)

```
class Foo(BaseModel):

def run(*args, **kwargs):
    component = self.bar.format(input={"xoo": "runtime value!"})
    
    # do something with the component

async def arun(*args, **kwargs):
    component = await self.bar.aformat(input={"xoo": "runtime value!"})
    
    # do something with the component
```

This component could then be added to an agent graph. The `xoo` property could be defined as `{xoo}`. When `bar.format()` is called the config will be updated with `runtime vaules!`


#### Example: IngestionTool

The prototype IngestionTool (coming in a future PR) defines `document_template` connector that is a template. The entire document loading branch is lazy-loaded.  This enables the `URL`, `PATH`, or other identifying variable to be set by the agent function call.

https://github.com/kreneskyp/ix/assets/68635/f236f36b-44f1-40d9-a2a7-e6c9cefcebd6

### Changes
- Add NodeTemplate
- Add lower level utility functions for working with templated configs
- updated load_node to lazy_load and format templated connectors.

### How Tested
New unittests

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
