### PR TITLE
ingest and knowledge agents now added by dev_setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,6 +263,8 @@ agents: cluster components
 	$(LOAD_FIXTURE) agent/klarna
 	$(LOAD_FIXTURE) agent/smithy
 	$(LOAD_FIXTURE) agent/metaphor
+	$(LOAD_FIXTURE) agent/ingest
+	$(LOAD_FIXTURE) agent/knowledge
 
 
 # Generate fixture for NodeTypes defined in python fixtures.


### PR DESCRIPTION
### Description
ingest and knowledge agents (#268) fixtures are now loaded by `dev_setup` make target.

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
