### PR TITLE
ConversationalRetrievalChain now indicates memory is required

### DIFF
--- a/ix/chains/fixture_src/chains.py
+++ b/ix/chains/fixture_src/chains.py
@@ -90,7 +90,7 @@ CONVERSATIONAL_RETRIEVAL_CHAIN = {
     "description": "Chain for having a conversation based on retrieved documents.",
     "connectors": [
         LLM_TARGET,
-        MEMORY_TARGET,
+        dict(**MEMORY_TARGET, required=True),
         PROMPT_TARGET,
         RETRIEVER_TARGET,
     ],

--- a/test_data/snapshots/components/langchain.chains.conversational_retrieval.base.ConversationalRetrievalChain.from_llm.json
+++ b/test_data/snapshots/components/langchain.chains.conversational_retrieval.base.ConversationalRetrievalChain.from_llm.json
@@ -43,6 +43,7 @@
         {
             "key": "memory",
             "multiple": true,
+            "required": true,
             "source_type": "memory",
             "type": "target"
         },


### PR DESCRIPTION
### Description
ConversationalRetrievalChain now indicates that a memory component is required. 

![image](https://github.com/kreneskyp/ix/assets/68635/a45a657b-7ada-4848-a350-31108df87f67)

### Changes
- `ConversationalRetrievalChain.memory` is now required. 

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
