### PR TITLE
ix-client wasn't configured to start the external chroma instance

### DIFF
--- a/client_config/docker-compose.yml
+++ b/client_config/docker-compose.yml
@@ -44,6 +44,7 @@ services:
     links:
       - db
       - redis
+      - chroma
     volumes:
       - ./certs/-/:/vault/certs:ro,Z
     env_file:


### PR DESCRIPTION
### Description
ix-client wasn't configured to start the external chroma instance

### Changes
- add `chroma` container as dependency to `worker` container

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
