### PR TITLE
fix(docker-compose.yml): Upgrade Chroma to solve `log_config.yml` not found issue

### DIFF
--- a/client_config/docker-compose.yml
+++ b/client_config/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     image: redis/redis-stack-server:latest
 
   chroma:
-    image: ghcr.io/chroma-core/chroma:0.4.11
+    image: ghcr.io/chroma-core/chroma:0.4.12
     ports:
       - "8020:8000"
 

--- a/client_config/docker-compose.yml
+++ b/client_config/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     image: redis/redis-stack-server:latest
 
   chroma:
-    image: ghcr.io/chroma-core/chroma:0.4.12
+    image: ghcr.io/chroma-core/chroma:0.4.13
     ports:
       - "8020:8000"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
     image: redis/redis-stack-server:latest
 
   chroma:
-    image: ghcr.io/chroma-core/chroma:0.4.12
+    image: ghcr.io/chroma-core/chroma:0.4.13
     ports:
       - "8020:8000"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
     image: redis/redis-stack-server:latest
 
   chroma:
-    image: ghcr.io/chroma-core/chroma:0.4.11
+    image: ghcr.io/chroma-core/chroma:0.4.12
     ports:
       - "8020:8000"
 


### PR DESCRIPTION
### Description
See for details: https://github.com/chroma-core/chroma/issues/1164

### Changes
- Upgrade Chroma image from 0.4.11 to 0.4.13.

### How Tested
`ix up` with 0.4.12 in `docker-compose.yml` allows Chroma to start successfully. Upgraded to 0.4.13.

