### PR TITLE
chores(requirements.txt): Upgrade Chroma dev version to reflect docker-compose version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ celery==5.3.4
 celery-singleton==0.3.1
 channels==4.0.0
 channels_redis==4.1.0
-chromadb==0.4.12
+chromadb==0.4.13
 colorlog==6.7.0
 daphne==4.0.0
 django==4.2.6


### PR DESCRIPTION
### Description
Align Chroma dev version with `docker-compose.yml` version so devs make use of user's version.

### Changes
- Chroma from 0.4.12 to 0.4.13 in `requirements.txt`

### How Tested
- `make dev_setup` in OSX (M2).

