### PR TITLE
vscode config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,26 @@ compile_relay: nodejs
 # =========================================================
 
 
+.PHONY: db
+db: compose
+	@echo starting IX dev db
+	@if [ -z "$$(docker ps -q -f name=ix_db_vscode)" ]; then docker-compose run --name ix_db_vscode -d -p 5432:5432 db; else echo "Container ix_db_vscode already running."; fi
+
+.PHONY: redis
+redis: compose
+	@echo starting IX dev redis
+	@if [ -z "$$(docker ps -q -f name=ix_redis_vscode)" ]; then docker-compose run --name ix_redis_vscode -d -p 6379:6379 redis; else echo "Container ix_redis_vscode already running."; fi
+
+.PHONY: vscode
+vscode: db redis
+
+.PHONY: vscode-down
+vscode-down: compose
+	@echo stopping and removing IX dev vscode, db and redis
+	@if [ ! -z "$$(docker ps -q -f name=ix_db_vscode)" ]; then docker stop ix_db_vscode; docker rm -f ix_db_vscode; else echo "Container ix_db_vscode is not running."; fi
+	@if [ ! -z "$$(docker ps -q -f name=ix_redis_vscode)" ]; then docker stop ix_redis_vscode; docker rm -f ix_redis_vscode; else echo "Container ix_redis_vscode is not running."; fi
+
+
 .PHONY: cluster
 cluster: compose
 	@echo starting IX dev cluster

--- a/ix.code-workspace
+++ b/ix.code-workspace
@@ -1,0 +1,21 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"terminal.integrated.env.osx": {
+			"DJANGO_SETTING_MODULE": "ix.server.vscode_settings",
+			"DJANGO_SECRET_KEY": "NOT_A_SECRET_KEY"
+		},
+		"terminal.integrated.env.linux": {
+			"DJANGO_SETTING_MODULE": "ix.server.vscode_settings",
+			"DJANGO_SECRET_KEY": "NOT_A_SECRET_KEY"
+		},
+		"terminal.integrated.env.windows": {
+			"DJANGO_SETTING_MODULE": "ix.server.vscode_settings",
+			"DJANGO_SECRET_KEY": "NOT_A_SECRET_KEY"
+		}
+	}
+}

--- a/ix.code-workspace
+++ b/ix.code-workspace
@@ -7,15 +7,21 @@
 	"settings": {
 		"terminal.integrated.env.osx": {
 			"DJANGO_SETTING_MODULE": "ix.server.vscode_settings",
-			"DJANGO_SECRET_KEY": "NOT_A_SECRET_KEY"
+			"DJANGO_SECRET_KEY": "NOT_A_SECRET_KEY",
+			"DATABASE_HOST": "localhost",
+			"REDIS_HOST": "localhost",
 		},
 		"terminal.integrated.env.linux": {
 			"DJANGO_SETTING_MODULE": "ix.server.vscode_settings",
-			"DJANGO_SECRET_KEY": "NOT_A_SECRET_KEY"
+			"DJANGO_SECRET_KEY": "NOT_A_SECRET_KEY",
+			"DATABASE_HOST": "localhost",
+			"REDIS_HOST": "localhost",
 		},
 		"terminal.integrated.env.windows": {
 			"DJANGO_SETTING_MODULE": "ix.server.vscode_settings",
-			"DJANGO_SECRET_KEY": "NOT_A_SECRET_KEY"
+			"DJANGO_SECRET_KEY": "NOT_A_SECRET_KEY",
+			"DATABASE_HOST": "localhost",
+			"REDIS_HOST": "localhost",
 		}
 	}
 }

--- a/ix/agents/tests/test_history.py
+++ b/ix/agents/tests/test_history.py
@@ -18,7 +18,7 @@ class TestAgentProcessHistory(MessageTeardown):
     MSG_3 = {"type": "COMMAND", "message": "THIS IS A TEST 3"}
     MSG_4 = {"type": "COMMAND", "message": "THIS IS A TEST 4"}
 
-    @pytest.mark.parametrize("content_type", TaskHistory.EXCLUDED_MSG_TYPES)
+    @pytest.mark.parametrize("content_type", sorted(TaskHistory.EXCLUDED_MSG_TYPES))
     def test_query_message_excludes_msgs(self, content_type, task):
         """Test that non-relevant messages are excluded from history"""
         msg = fake_task_log_msg_type(content_type, task=task)

--- a/ix/chains/tests/test_config.py
+++ b/ix/chains/tests/test_config.py
@@ -12,7 +12,7 @@ class ChoicesEnum(str, Enum):
     GO = "go"
 
 
-class TestModel(BaseModel):
+class MockModel(BaseModel):
     field1: str
     field2: int
     field3: bool = False
@@ -209,7 +209,7 @@ class GetFieldsBase:
 
 
 class TestGetFieldsFromModel(GetFieldsBase):
-    field_source = TestModel
+    field_source = MockModel
 
     def test_exclude_non_allowed_type(self, field_overrides):
         # Extend TestModel with a field of non-allowed type
@@ -217,7 +217,7 @@ class TestGetFieldsFromModel(GetFieldsBase):
             field1: str
             field2: int
             field3: bool = False
-            field4: TestModel  # non-allowed type
+            field4: MockModel  # non-allowed type
 
         expected_fields = [
             NodeTypeField(
@@ -235,7 +235,7 @@ class TestGetFieldsFromModel(GetFieldsBase):
 
 
 class TestGetFieldsFromMethod(GetFieldsBase):
-    field_source = TestModel.loader
+    field_source = MockModel.loader
 
 
 class TestGetFieldsFromABC(GetFieldsBase):

--- a/ix/conftest.py
+++ b/ix/conftest.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Dict, Any, List
 from unittest.mock import MagicMock
+from django.conf import settings
 
 import pytest
 import pytest_asyncio
@@ -50,7 +51,7 @@ async def arequest_user(mocker):
 @pytest.fixture
 def clean_redis():
     """Ensure redis is clean before and after tests"""
-    redis_client = redis.Redis(host="redis", port=6379, db=0)
+    redis_client = redis.Redis(**settings.REDIS)
     redis_client.flushall()
     yield
     redis_client.flushall()

--- a/ix/server/settings.py
+++ b/ix/server/settings.py
@@ -89,14 +89,16 @@ WSGI_APPLICATION = "ix.server.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/4.1/ref/settings/#databases
 
+DATABASE_HOST = os.environ.get("DATABASE_HOST", default="db")
+DATABASE_PORT = os.environ.get("DATABASE_PORT", default=5432)
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
         "NAME": "ix",
         "USER": "ix",
         "PASSWORD": "ix",
-        "HOST": "db",
-        "PORT": "5432",
+        "HOST": DATABASE_HOST,
+        "PORT": DATABASE_PORT,
     }
 }
 
@@ -160,23 +162,36 @@ GRAPHENE = {"SCHEMA": "ix.schema.schema"}
 
 ASGI_APPLICATION = "ix.server.asgi.application"
 
+REDIS_HOST = os.environ.get("REDIS_HOST", default="redis")
+REDIS_PORT = os.environ.get("REDIS_PORT", default=6379)
+REDIS_DB = os.environ.get("REDIS_DB", default=0)
+REDIS = {
+    "host": REDIS_HOST,
+    "port": REDIS_PORT,
+    "db": REDIS_DB,
+}
+
+REDIS_DB_CHANNEL_LAYERS = os.environ.get("REDIS_DB_CHANNEL_LAYERS", default=0)
+REDIS_DB_CELERY = os.environ.get("REDIS_DB_CELERY", default=2)
+REDIS_DB_CACHES = os.environ.get("REDIS_DB_CACHES", default=1)
+
 CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
-            "hosts": [("redis", 6379)],
+            "hosts": [(REDIS_HOST, REDIS_PORT)],
         },
     },
 }
 
 # Celery configuration
-CELERY_BROKER_URL = "redis://redis:6379/2"
-CELERY_RESULT_BACKEND = "redis://redis:6379/2"
+CELERY_BROKER_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB_CELERY}"
+CELERY_RESULT_BACKEND = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB_CELERY}"
 
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "redis://redis:6379/1",
+        "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB_CACHES}",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -ra --cov=ix --cov-report=term-missing --no-cov-on-fail -p no:warnings --ds=ix.server.test_settings
-norecursedirs = py_code pycode .git
+addopts = -ra --cov=ix --cov-report=term-missing --no-cov-on-fail -n6 --dist=loadfile -p no:warnings --ds=ix.server.test_settings
+norecursedirs = py_code pycode .git langchain tmp .vault_file
 asyncio_mode=auto
 pytest_plugins=pytest_asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ pytest-cov==4.1.0
 pytest-django==4.5.2
 pytest-mock==3.11.1
 pytest-snapshot==0.9.0
+pytest-xdist==2.4.0
 redis==5.0.0
 requests==2.31.0
 tiktoken==0.5.1


### PR DESCRIPTION
### Description
vscode workspace config plus some related config changes and tools. Trying to make this a bit easier to run in cursor.so/vscode.

### Changes
- makefile targets to start/stop docker containers needed for tests (db, redis)
- vscode workspace config
- adding pytest-xdist to run pytests on multiple cores
- other minor cleanup

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
Will tackle these in followup PRs:
- pytest doesnt work yet. Can't seem to get it to set django settings without `--ds` flag.  Trying to move settings to environment variables so both docker and vscode can share the same settings file
- still a few failing tests when running in vscode