### PR TITLE
Issues with saving agent

### DIFF
--- a/frontend/chains/ChainEditorView.js
+++ b/frontend/chains/ChainEditorView.js
@@ -73,28 +73,15 @@ const ChainEditorProvider = ({ graph, onError, children }) => {
 export const ChainEditorView = () => {
   const { id } = useParams();
   const { response, call, isLoading } = useDetailAPI(`/api/chains/${id}/graph`);
-  const { isNew, idRef, wasCreated, setWasCreated } = useObjectEditorView(
-    id,
-    call
-  );
+  const { isNew, idRef } = useObjectEditorView(id, call);
   const toast = useToast();
 
-  // Defer to isNew and wasCreated to determine if graph response is current for
+  // Defer to isNew to determine if graph response is current for
   // UX state. This is necessary because the graph response is not cleared when
   // switching to a new chain. Also check that the id matches the response id.
   // to avoid rendering stale state when first loading a newly created chain.
   const graph =
-    (isNew && !wasCreated) || id !== response?.data?.chain?.id
-      ? null
-      : response?.data;
-
-  // load graph when chain is created to ensure graph exists
-  // whether this was a new chain or an existing chain
-  useEffect(() => {
-    if (wasCreated) {
-      call();
-    }
-  }, [wasCreated, call]);
+    isNew || id !== response?.data?.chain?.id ? null : response?.data;
 
   const rightSidebarDisclosure = useDisclosure({ defaultIsOpen: true });
 
@@ -114,7 +101,6 @@ export const ChainEditorView = () => {
       <ChainGraphEditor
         key={idRef}
         rightSidebarDisclosure={rightSidebarDisclosure}
-        onCreate={setWasCreated}
       />
     );
   } else if (isLoading || !graph) {

--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -49,7 +49,7 @@ const getExpectedTypes = (connector) => {
     : new Set([connector.source_type]);
 };
 
-const ChainGraphEditor = ({ graph, rightSidebarDisclosure, onCreate }) => {
+const ChainGraphEditor = ({ graph, rightSidebarDisclosure }) => {
   const reactFlowWrapper = useRef(null);
   const edgeUpdate = useRef(true);
   const { call: loadChain } = useAxios();
@@ -77,7 +77,6 @@ const ChainGraphEditor = ({ graph, rightSidebarDisclosure, onCreate }) => {
       // first node creates the new chain
       // redirect to the correct URL
       if (chain?.id === undefined) {
-        onCreate(true);
         navigate(`/chains/${response.data.chain_id}`, { replace: true });
         loadChain(`/api/chains/${response.data.chain_id}`, {
           onSuccess: (response) => {

--- a/frontend/chains/editor/PromptEditor.js
+++ b/frontend/chains/editor/PromptEditor.js
@@ -1,12 +1,5 @@
 import React, { useCallback, useState } from "react";
-import {
-  Button,
-  Flex,
-  Select,
-  VStack,
-  HStack,
-  Text,
-} from "@chakra-ui/react";
+import { Button, Flex, Select, VStack, HStack, Text } from "@chakra-ui/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faTrashAlt,

--- a/frontend/chains/hooks/useTestChat.js
+++ b/frontend/chains/hooks/useTestChat.js
@@ -16,7 +16,6 @@ export const useTestChat = (chain_id) => {
 
   React.useEffect(() => {
     if (chain_id && loadedChainId != chain_id) {
-      console.log("useTestChat: loading chat: ", chain_id)
       setLoadedChainId(chain_id);
       loadChat();
     }


### PR DESCRIPTION
### Description
New chains/agents couldn't be created by entering alias, name, or description first.   This was a regression introduced by prior attempts to fix the editor initialization state.

This PR greatly simplifies that state and fixes those bugs, including all of the back and forth between new and existing chains.  however, it reintroduces the flicker post-save for new agents.



### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
The post-save flicker is solvable but requires wider changes.  Will handle in a follow-up because it's an annoyance but not a blocker:
- need to track `loadedId` and set it when initializing it to the internal `idRef` for a blank form
- this will allow the load to be skipped when `loadedId` matches the change to `id`. The id will already match indicating it has been loaded.
- This doesnt work presently because the internal idRef isn't used when creating the chain.  An entirely new UUID is created by the API backend. If the frontend can pass in the internal `idRef` as the new `chain_id` then it can detect that no loading is needed..  This fix requires a bunch of changes for the frontend to send the id and for the backend to use it.
