### PR TITLE
TypeAutoField: Dicts

### DIFF
--- a/frontend/chains/flow/TypeAutoFields.js
+++ b/frontend/chains/flow/TypeAutoFields.js
@@ -11,6 +11,7 @@ import {
 } from "@chakra-ui/react";
 import SliderInput from "components/SliderInput";
 import { useEditorColorMode } from "chains/editor/useColorMode";
+import { DictForm } from "components/DictForm";
 
 const getLabel = (field) => field.label || labelify(field.name || "");
 
@@ -163,6 +164,24 @@ const AutoFieldSelect = ({ field, value, onChange }) => {
   );
 };
 
+const AutoFieldDict = ({ field, value, onChange }) => {
+  const handleChange = useCallback(
+    (newValue) => {
+      // Check if newValue is null or undefined, if so, set it to an empty object
+      newValue = newValue || {};
+      onChange(field.name, newValue);
+    },
+    [field, onChange]
+  );
+
+  // Check if value is null or undefined, if so, set it to an empty object
+  value = value || {};
+
+  return (
+    <DictForm dict={value} onChange={handleChange} label={getLabel(field)} />
+  );
+};
+
 // explicit input types
 const INPUTS = {
   select: AutoFieldSelect,
@@ -171,12 +190,14 @@ const INPUTS = {
   input: AutoFieldInput,
   secret: AutoFieldSecret,
   textarea: AutoFieldTextArea,
+  dict: AutoFieldDict,
 };
 
 // type specific default inputs
 const TYPE_INPUTS = {
   boolean: "checkbox",
   bool: "checkbox",
+  dict: "dict",
 };
 
 const DEFAULT_COMPONENT = AutoFieldInput;

--- a/frontend/components/DictForm.js
+++ b/frontend/components/DictForm.js
@@ -14,12 +14,10 @@ import { useEditorColorMode } from "chains/editor/useColorMode";
  * @param {function} onChange - The callback function that is called when the dictionary is changed.
  */
 export const DictForm = ({ label, dict, onChange }) => {
-  console.log("dict: ", dict);
   let entries = Object.entries(dict);
   if (entries.length === 0) {
     entries = [["", ""]];
   }
-  console.log("entries: ", entries);
   const colorMode = useEditorColorMode();
 
   /**
@@ -50,7 +48,7 @@ export const DictForm = ({ label, dict, onChange }) => {
   return (
     <Box width="100%">
       <HStack>
-        <FormLabel justify="start" whiteSpace="nowrap">
+        <FormLabel justify="start" whiteSpace="nowrap" mr={0} pr={0}>
           {label}
         </FormLabel>
         <Text as="span" color={"green.300"}>

--- a/frontend/components/DictForm.js
+++ b/frontend/components/DictForm.js
@@ -1,0 +1,92 @@
+import React from "react";
+import { Box, Input, VStack, HStack, FormLabel, Text } from "@chakra-ui/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTrash, faPlusCircle } from "@fortawesome/free-solid-svg-icons";
+import { useEditorColorMode } from "chains/editor/useColorMode";
+
+/**
+ * DictForm is a functional component that takes a dictionary and a callback function as props.
+ * It renders a form that allows the user to edit the dictionary. The form consists of a list of inputs
+ * for each key-value pair in the dictionary, and buttons to add or remove key-value pairs.
+ * When a key-value pair is added, removed, or changed, the callback function is called with the new dictionary.
+ *
+ * @param {Object} dict - The dictionary to be edited.
+ * @param {function} onChange - The callback function that is called when the dictionary is changed.
+ */
+export const DictForm = ({ label, dict, onChange }) => {
+  console.log("dict: ", dict);
+  let entries = Object.entries(dict);
+  if (entries.length === 0) {
+    entries = [["", ""]];
+  }
+  console.log("entries: ", entries);
+  const colorMode = useEditorColorMode();
+
+  /**
+   * Updates the dictionary entries when an input field is changed.
+   *
+   * @param {Object} e - The event object from the input field.
+   * @param {number} index - The index of the key-value pair in the dictionary entries.
+   */
+  const handleInputChange = (e, index, isKey) => {
+    const { value } = e.target;
+    const updatedEntries = [...entries];
+    updatedEntries[index] = isKey
+      ? [value, updatedEntries[index][1]]
+      : [updatedEntries[index][0], value];
+    onChange(Object.fromEntries(updatedEntries));
+  };
+
+  const handleRemoveClick = (index) => {
+    const updatedEntries = entries.filter((entry, i) => i !== index);
+    onChange(Object.fromEntries(updatedEntries));
+  };
+
+  const handleAddClick = () => {
+    const updatedEntries = [...entries, ["", ""]];
+    onChange(Object.fromEntries(updatedEntries));
+  };
+
+  return (
+    <Box width="100%">
+      <HStack>
+        <FormLabel justify="start" whiteSpace="nowrap">
+          {label}
+        </FormLabel>
+        <Text as="span" color={"green.300"}>
+          <FontAwesomeIcon
+            icon={faPlusCircle}
+            onClick={handleAddClick}
+            cursor="pointer"
+          />
+        </Text>
+      </HStack>
+
+      <VStack align="stretch" pl={4}>
+        {entries.map(([key, value], index) => (
+          <HStack key={index}>
+            <Input
+              value={key}
+              onChange={(e) => handleInputChange(e, index, true)}
+              placeholder="Key"
+              {...colorMode.input}
+            />
+            <Input
+              value={value}
+              onChange={(e) => handleInputChange(e, index, false)}
+              placeholder="Value"
+              {...colorMode.input}
+            />
+            <FontAwesomeIcon
+              icon={faTrash}
+              onClick={() => handleRemoveClick(index)}
+              cursor="pointer"
+            />
+          </HStack>
+        ))}
+      </VStack>
+    </Box>
+  );
+};
+
+export default DictForm;

--- a/ix/chains/fixture_src/llm.py
+++ b/ix/chains/fixture_src/llm.py
@@ -68,6 +68,10 @@ OPENAI_LLM = {
             "type": "boolean",
             "default": True,
         },
+        {
+            "name": "metadata",
+            "type": "dict",
+        }
     ],
 }
 

--- a/ix/chains/fixture_src/llm.py
+++ b/ix/chains/fixture_src/llm.py
@@ -71,7 +71,7 @@ OPENAI_LLM = {
         {
             "name": "metadata",
             "type": "dict",
-        }
+        },
     ],
 }
 

--- a/test_data/snapshots/components/langchain.chat_models.openai.ChatOpenAI.json
+++ b/test_data/snapshots/components/langchain.chat_models.openai.ChatOpenAI.json
@@ -14,6 +14,10 @@
                 "default": 256,
                 "type": "number"
             },
+            "metadata": {
+                "default": null,
+                "type": "object"
+            },
             "model_name": {
                 "default": "gpt-4-0613",
                 "enum": [
@@ -51,7 +55,8 @@
             "temperature",
             "max_tokens",
             "verbose",
-            "streaming"
+            "streaming",
+            "metadata"
         ],
         "type": "object"
     },
@@ -127,6 +132,10 @@
             "default": true,
             "name": "streaming",
             "type": "boolean"
+        },
+        {
+            "name": "metadata",
+            "type": "dict"
         }
     ],
     "name": "OpenAI LLM",


### PR DESCRIPTION
### Description
Adding a generic form widget for `dict` fields. The widget supports an arbitrary `Dict[str, str]`.  This enables collecting llm and chain `metadata`, request `headers` for various tools authentication.  

![image](https://github.com/kreneskyp/ix/assets/68635/b17149f7-93e8-409f-bad5-b3a94f6797d3)
![image](https://github.com/kreneskyp/ix/assets/68635/ab7b5a17-87b7-4003-a728-6422dea48a71)


### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
