### PR TITLE
Setup command not initializing components

### DIFF
--- a/ix/task_log/management/commands/setup.py
+++ b/ix/task_log/management/commands/setup.py
@@ -8,6 +8,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         print("IX setup running...")
         call_command("migrate")
+        call_command("import_langchain")
         for fixture in [
             "fake_user",
             "agent/ix",


### PR DESCRIPTION
### Description
`ix setup` was not initializing components before loading agent fixtures. 

### Changes
`setup` command now calls `import_langchain` command

### How Tested
manually dropped database before testing `ix setup` this time. 🤦 

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
