### PR TITLE
Fireworks.ai LLM

### DIFF
--- a/ix/chains/fixture_src/llm.py
+++ b/ix/chains/fixture_src/llm.py
@@ -1,8 +1,22 @@
 from langchain import LlamaCpp
+from langchain.llms.base import BaseLLM
 from langchain.llms import Ollama
+from langchain.llms.fireworks import Fireworks
 
 from ix.api.components.types import NodeTypeField
 from ix.chains.fixture_src.common import VERBOSE
+
+
+BASE_LLM_FIELDS = NodeTypeField.get_fields(
+    BaseLLM,
+    include=["verbose", "tags", "metadata"],
+    field_options={
+        "metadata": {
+            "type": "dict",
+        }
+    },
+)
+
 
 OPENAI_LLM_CLASS_PATH = "langchain.chat_models.openai.ChatOpenAI"
 OPENAI_LLM = {
@@ -286,4 +300,65 @@ OLLAMA_LLM = {
 }
 
 
-LLMS = [ANTHROPIC_LLM, GOOGLE_PALM, LLAMA_CPP_LLM, OLLAMA_LLM, OPENAI_LLM]
+FIREWORKS_LLM_CLASS_PATH = "langchain.llms.fireworks.Fireworks"
+FIREWORKS_LLM = {
+    "class_path": FIREWORKS_LLM_CLASS_PATH,
+    "type": "llm",
+    "name": "Fireworks.ai",
+    "description": "Fireworks.ai LLM server",
+    "fields": NodeTypeField.get_fields(
+        Fireworks,
+        include=["model", "fireworks_api_key", "max_retries"],
+        field_options={
+            "model": {
+                "style": {"width": "100%"},
+            },
+            "fireworks_api_key": {
+                "input_type": "secret",
+                "style": {"width": "100%"},
+            },
+            "max_retries": {
+                "default": 20,
+                "input_type": "slider",
+                "min": 0,
+                "max": 50,
+                "step": 1,
+            },
+        },
+    )
+    + NodeTypeField.get_fields(
+        Fireworks,
+        parent="model_kwargs",
+        include=[
+            "temperature",
+            "max_tokens",
+            "top_p",
+        ],
+        field_options={
+            "temperature": {
+                "default": 0.8,
+                "input_type": "slider",
+                "min": 0,
+                "max": 1,
+                "step": 0.05,
+            },
+            "top_p": {
+                "default": 0.9,
+                "input_type": "slider",
+                "min": 0,
+                "max": 1,
+                "step": 0.05,
+            },
+        },
+    )
+    + BASE_LLM_FIELDS,
+}
+
+LLMS = [
+    ANTHROPIC_LLM,
+    GOOGLE_PALM,
+    LLAMA_CPP_LLM,
+    OLLAMA_LLM,
+    OPENAI_LLM,
+    FIREWORKS_LLM,
+]

--- a/ix/chains/fixture_src/llm.py
+++ b/ix/chains/fixture_src/llm.py
@@ -300,58 +300,68 @@ OLLAMA_LLM = {
 }
 
 
+FIREWORKS_FIELDS = NodeTypeField.get_fields(
+    Fireworks,
+    include=["model", "fireworks_api_key", "max_retries"],
+    field_options={
+        "model": {
+            "style": {"width": "100%"},
+        },
+        "fireworks_api_key": {
+            "input_type": "secret",
+            "style": {"width": "100%"},
+        },
+        "max_retries": {
+            "default": 20,
+            "input_type": "slider",
+            "min": 0,
+            "max": 50,
+            "step": 1,
+        },
+    },
+) + NodeTypeField.get_fields(
+    Fireworks,
+    parent="model_kwargs",
+    include=[
+        "temperature",
+        "max_tokens",
+        "top_p",
+    ],
+    field_options={
+        "temperature": {
+            "default": 0.8,
+            "input_type": "slider",
+            "min": 0,
+            "max": 1,
+            "step": 0.05,
+        },
+        "top_p": {
+            "default": 0.9,
+            "input_type": "slider",
+            "min": 0,
+            "max": 1,
+            "step": 0.05,
+        },
+    },
+)
+
+
 FIREWORKS_LLM_CLASS_PATH = "langchain.llms.fireworks.Fireworks"
 FIREWORKS_LLM = {
     "class_path": FIREWORKS_LLM_CLASS_PATH,
     "type": "llm",
     "name": "Fireworks.ai",
-    "description": "Fireworks.ai LLM server",
-    "fields": NodeTypeField.get_fields(
-        Fireworks,
-        include=["model", "fireworks_api_key", "max_retries"],
-        field_options={
-            "model": {
-                "style": {"width": "100%"},
-            },
-            "fireworks_api_key": {
-                "input_type": "secret",
-                "style": {"width": "100%"},
-            },
-            "max_retries": {
-                "default": 20,
-                "input_type": "slider",
-                "min": 0,
-                "max": 50,
-                "step": 1,
-            },
-        },
-    )
-    + NodeTypeField.get_fields(
-        Fireworks,
-        parent="model_kwargs",
-        include=[
-            "temperature",
-            "max_tokens",
-            "top_p",
-        ],
-        field_options={
-            "temperature": {
-                "default": 0.8,
-                "input_type": "slider",
-                "min": 0,
-                "max": 1,
-                "step": 0.05,
-            },
-            "top_p": {
-                "default": 0.9,
-                "input_type": "slider",
-                "min": 0,
-                "max": 1,
-                "step": 0.05,
-            },
-        },
-    )
-    + BASE_LLM_FIELDS,
+    "description": "Fireworks.ai LLM",
+    "fields": FIREWORKS_FIELDS + BASE_LLM_FIELDS,
+}
+
+FIREWORKS_CHAT_LLM_CLASS_PATH = "langchain.chat_models.fireworks.ChatFireworks"
+FIREWORKS_CHAT_LLM = {
+    "class_path": FIREWORKS_CHAT_LLM_CLASS_PATH,
+    "type": "llm",
+    "name": "Fireworks.ai (chat)",
+    "description": "Fireworks.ai Chat LLM",
+    "fields": FIREWORKS_FIELDS + BASE_LLM_FIELDS,
 }
 
 LLMS = [
@@ -361,4 +371,5 @@ LLMS = [
     OLLAMA_LLM,
     OPENAI_LLM,
     FIREWORKS_LLM,
+    FIREWORKS_CHAT_LLM,
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ django-channels-graphql-ws==1.0.0rc6
 django_extensions==3.2.3
 django-redis==5.3.0
 Faker==19.6.2
+fireworks-ai==0.4.4
 flake8==6.1.0
 fastapi==0.99.1
 graphene-django==3.1.5

--- a/test_data/snapshots/components/langchain.chat_models.fireworks.ChatFireworks.json
+++ b/test_data/snapshots/components/langchain.chat_models.fireworks.ChatFireworks.json
@@ -1,6 +1,6 @@
 {
     "child_field": null,
-    "class_path": "langchain.llms.fireworks.Fireworks",
+    "class_path": "langchain.chat_models.fireworks.ChatFireworks",
     "config_schema": {
         "properties": {
             "fireworks_api_key": {
@@ -35,7 +35,7 @@
         "type": "object"
     },
     "connectors": null,
-    "description": "Fireworks.ai LLM",
+    "description": "Fireworks.ai Chat LLM",
     "display_type": "node",
     "fields": [
         {
@@ -127,6 +127,6 @@
             "type": "dict"
         }
     ],
-    "name": "Fireworks.ai",
+    "name": "Fireworks.ai (chat)",
     "type": "llm"
 }

--- a/test_data/snapshots/components/langchain.llms.fireworks.Fireworks.json
+++ b/test_data/snapshots/components/langchain.llms.fireworks.Fireworks.json
@@ -1,0 +1,132 @@
+{
+    "child_field": null,
+    "class_path": "langchain.llms.fireworks.Fireworks",
+    "config_schema": {
+        "properties": {
+            "fireworks_api_key": {
+                "default": null,
+                "type": "string"
+            },
+            "max_retries": {
+                "default": 20,
+                "maximum": 50.0,
+                "minimum": 0.0,
+                "multipleOf": 1.0,
+                "type": "number"
+            },
+            "metadata": {
+                "default": null,
+                "type": "object"
+            },
+            "model": {
+                "default": "accounts/fireworks/models/llama-v2-7b-chat",
+                "type": "string"
+            },
+            "tags": {
+                "default": null,
+                "type": "object"
+            },
+            "verbose": {
+                "default": null,
+                "type": "boolean"
+            }
+        },
+        "required": [],
+        "type": "object"
+    },
+    "connectors": null,
+    "description": "Fireworks.ai LLM server",
+    "display_type": "node",
+    "fields": [
+        {
+            "choices": null,
+            "default": "accounts/fireworks/models/llama-v2-7b-chat",
+            "input_type": null,
+            "label": "Model",
+            "max": null,
+            "min": null,
+            "name": "model",
+            "parent": null,
+            "required": false,
+            "step": null,
+            "style": {
+                "width": "100%"
+            },
+            "type": "str"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "input_type": "secret",
+            "label": "Fireworks_api_key",
+            "max": null,
+            "min": null,
+            "name": "fireworks_api_key",
+            "parent": null,
+            "required": false,
+            "step": null,
+            "style": {
+                "width": "100%"
+            },
+            "type": "str"
+        },
+        {
+            "choices": null,
+            "default": 20,
+            "input_type": "slider",
+            "label": "Max_retries",
+            "max": 50.0,
+            "min": 0.0,
+            "name": "max_retries",
+            "parent": null,
+            "required": false,
+            "step": 1.0,
+            "style": null,
+            "type": "int"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "input_type": null,
+            "label": "Verbose",
+            "max": null,
+            "min": null,
+            "name": "verbose",
+            "parent": null,
+            "required": false,
+            "step": null,
+            "style": null,
+            "type": "bool"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "input_type": null,
+            "label": "Tags",
+            "max": null,
+            "min": null,
+            "name": "tags",
+            "parent": null,
+            "required": false,
+            "step": null,
+            "style": null,
+            "type": "Optional[List[str]]"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "input_type": null,
+            "label": "Metadata",
+            "max": null,
+            "min": null,
+            "name": "metadata",
+            "parent": null,
+            "required": false,
+            "step": null,
+            "style": null,
+            "type": "dict"
+        }
+    ],
+    "name": "Fireworks.ai",
+    "type": "llm"
+}


### PR DESCRIPTION
### Description
Adds support for [fireworks.ai](https://app.fireworks.ai/). 

![image](https://github.com/kreneskyp/ix/assets/68635/221f6c59-1a85-4a3a-9744-9d306921f868)

### Changes
- Adds component definition for fireworks LLM

### How Tested
- [ ] needs a smoke test to load the component

### TODOs
- [x] The LLM is processing the request successfully but the message isn't being written to the `TaskLogMessage`. This is due to IX still using callback handler to process messages. This is the first LLM model that's been used ~so it is probably missing a callback. ~

    ~It's also not streaming even though the component appears to support it.  Might need to implement the newer style streaming method for that to work.~

    ![image](https://github.com/kreneskyp/ix/assets/68635/45d22d81-93a7-4bce-8e87-173c41bec36e)
    ![image](https://github.com/kreneskyp/ix/assets/68635/1cdba5b6-3413-437b-bd92-41755f14281f)
    
    Issue here is that `LLMChain` doesn't support streaming and callback manager only streams for OpenAI LLMs.  Can use `LLMReply` for non-streaming responses.  Streaming will need an upstream fix.

- [ ] (non-blocker) Tested with a ChatPromptTemplate which works due to how the `prompt` connection loader works but this would be better suited with a `PromptTemplate`
