### PR TITLE
IX will now write files to ./workdir when started with ix client

### DIFF
--- a/client_config/docker-compose.yml
+++ b/client_config/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     env_file:
       - ${IX_ENV}
     volumes:
+      - ../workdir/:/var/app/workdir/
       - static:/var/static/
       - ./certs/:/vault/certs:ro,Z
     environment:
@@ -47,6 +48,7 @@ services:
       - chroma
     volumes:
       - ./certs/-/:/vault/certs:ro,Z
+      - ../workdir/:/var/app/workdir/
     env_file:
       - ${IX_ENV}
 


### PR DESCRIPTION
### Description
IX will now write artifact files to ./workdir when started with ix client

![image](https://github.com/kreneskyp/ix/assets/68635/f44e5903-58bc-4fc5-8257-f183fdb47e95)

### Changes
- added `workdir` mount to docker-compose.yml used by ix client

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
