### PR TITLE
LangChain 0.0.319, adds pydantic 2 support for OpenAPI specs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,12 +25,12 @@ isort==5.12.0
 jq==1.4.1
 jsonpath-ng==1.6.0
 jsonschema==4.19.1
-langchain==0.0.314
-langchain-experimental==0.0.29
+langchain==0.0.319
+langchain-experimental==0.0.32
 llama-cpp-python==0.1.79
 metaphor-python==0.1.16
 openai==0.28.0
-openapi-schema-pydantic==1.2.4
+openapi-pydantic==0.3.2
 pinecone-client==2.2.4
 psycopg==3.1.10
 pypdf==3.15.2


### PR DESCRIPTION
### Description
LangChain 0.0.319 adds pydantic 2 support for OpenAPI specs.

Should unblock: #180 

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
