### PR TITLE
Component config now renders set and list as array property

### DIFF
--- a/test_data/snapshots/components/ix.chains.agent_interaction.DelegateToAgentChain.json
+++ b/test_data/snapshots/components/ix.chains.agent_interaction.DelegateToAgentChain.json
@@ -4,18 +4,30 @@
     "config_schema": {
         "properties": {
             "delegate_inputs": {
-                "type": "object"
+                "items": [
+                    {
+                        "type": "string"
+                    }
+                ],
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
             },
             "output_key": {
                 "default": "delegate_to",
                 "type": "string"
             },
             "tags": {
-                "default": [],
-                "style": {
-                    "width": "100%"
-                },
-                "type": "object"
+                "items": [
+                    {
+                        "type": "string"
+                    }
+                ],
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
             },
             "target_alias": {
                 "type": "string"

--- a/test_data/snapshots/components/ix.chains.components.vectorstores.AsyncChromaVectorstore.json
+++ b/test_data/snapshots/components/ix.chains.components.vectorstores.AsyncChromaVectorstore.json
@@ -9,12 +9,15 @@
                 "type": "boolean"
             },
             "allowed_search_types": {
-                "default": [
-                    "similarity",
-                    "similarity_score_threshold",
-                    "mmr"
+                "items": [
+                    {
+                        "type": "string"
+                    }
                 ],
-                "type": "object"
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
             },
             "anonymized_telemetry": {
                 "default": true,

--- a/test_data/snapshots/components/ix.chains.components.vectorstores.AsyncRedisVectorstore.json
+++ b/test_data/snapshots/components/ix.chains.components.vectorstores.AsyncRedisVectorstore.json
@@ -4,12 +4,15 @@
     "config_schema": {
         "properties": {
             "allowed_search_types": {
-                "default": [
-                    "similarity",
-                    "similarity_score_threshold",
-                    "mmr"
+                "items": [
+                    {
+                        "type": "string"
+                    }
                 ],
-                "type": "object"
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
             },
             "content_key": {
                 "default": "content",

--- a/test_data/snapshots/components/ix.chains.routing.MapSubchain.json
+++ b/test_data/snapshots/components/ix.chains.routing.MapSubchain.json
@@ -4,7 +4,15 @@
     "config_schema": {
         "properties": {
             "input_variables": {
-                "type": "object"
+                "items": [
+                    {
+                        "type": "string"
+                    }
+                ],
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
             },
             "map_input": {
                 "type": "string"

--- a/test_data/snapshots/components/langchain.chains.SequentialChain.json
+++ b/test_data/snapshots/components/langchain.chains.SequentialChain.json
@@ -4,11 +4,15 @@
     "config_schema": {
         "properties": {
             "input_variables": {
-                "default": [],
-                "style": {
-                    "width": "100%"
-                },
-                "type": "object"
+                "items": [
+                    {
+                        "type": "string"
+                    }
+                ],
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
             },
             "verbose": {
                 "default": false,

--- a/test_data/snapshots/components/langchain.document_loaders.generic.GenericLoader.from_filesystem.json
+++ b/test_data/snapshots/components/langchain.document_loaders.generic.GenericLoader.from_filesystem.json
@@ -14,7 +14,15 @@
                 "type": "string"
             },
             "suffixes": {
-                "type": "object"
+                "items": [
+                    {
+                        "type": "string"
+                    }
+                ],
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
             }
         },
         "required": [

--- a/test_data/snapshots/components/langchain.document_loaders.web_base.WebBaseLoader.json
+++ b/test_data/snapshots/components/langchain.document_loaders.web_base.WebBaseLoader.json
@@ -12,11 +12,15 @@
                 "type": "boolean"
             },
             "web_path": {
-                "description": "URL(s) of the web page",
-                "style": {
-                    "width": "100%"
-                },
-                "type": "object"
+                "items": [
+                    {
+                        "type": "string"
+                    }
+                ],
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
             }
         },
         "required": [],

--- a/test_data/snapshots/components/langchain.embeddings.openai.OpenAIEmbeddings.json
+++ b/test_data/snapshots/components/langchain.embeddings.openai.OpenAIEmbeddings.json
@@ -4,15 +4,30 @@
     "config_schema": {
         "properties": {
             "allowed_special": {
-                "type": "object"
+                "items": [
+                    {
+                        "type": "string"
+                    }
+                ],
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
             },
             "chunk_size": {
                 "default": 1000,
                 "type": "number"
             },
             "disallowed_special": {
-                "default": "all",
-                "type": "object"
+                "items": [
+                    {
+                        "type": "string"
+                    }
+                ],
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
             },
             "max_retries": {
                 "default": "6",

--- a/test_data/snapshots/components/langchain.prompts.chat.ChatPromptTemplate.json
+++ b/test_data/snapshots/components/langchain.prompts.chat.ChatPromptTemplate.json
@@ -4,14 +4,15 @@
     "config_schema": {
         "properties": {
             "messages": {
-                "default": [
+                "items": [
                     {
-                        "input_variables": [],
-                        "role": "system",
-                        "template": ""
+                        "type": "string"
                     }
                 ],
-                "type": "object"
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
             }
         },
         "required": [],

--- a/test_data/snapshots/components/langchain.vectorstores.base.VectorStoreRetriever.json
+++ b/test_data/snapshots/components/langchain.vectorstores.base.VectorStoreRetriever.json
@@ -4,12 +4,15 @@
     "config_schema": {
         "properties": {
             "allowed_search_types": {
-                "default": [
-                    "similarity",
-                    "similarity_score_threshold",
-                    "mmr"
+                "items": [
+                    {
+                        "type": "string"
+                    }
                 ],
-                "type": "object"
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
             },
             "search_type": {
                 "default": "similarity",


### PR DESCRIPTION
### Description
NodeType config schemas now convert `set` and `list` properties to `array`.  Nested types aren't yet handled well but this is good enough to support `ListForm` (#296)

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
