### PR TITLE
LLM config options

### DIFF
--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -170,6 +170,8 @@ const ChainGraphEditor = ({ graph, rightSidebarDisclosure }) => {
         id: newNodeID,
         chain_id: chain?.id || null,
         class_path: nodeType.class_path,
+        name: "",
+        description: "",
         position: position,
         config: getDefaults(nodeType),
       };

--- a/frontend/json_form/JSONSchemaForm.js
+++ b/frontend/json_form/JSONSchemaForm.js
@@ -68,7 +68,7 @@ export const getDefaults = (nodeType) => {
   const defaults = {};
   nodeType.fields?.forEach(
     (field) =>
-      (defaults[name] = field.default || FIELD_TYPE_DEFAULTS[field.type])
+      (defaults[field.name] = field.default || FIELD_TYPE_DEFAULTS[field.type])
   );
   return defaults;
 };

--- a/ix/chains/fixture_src/llm.py
+++ b/ix/chains/fixture_src/llm.py
@@ -1,4 +1,5 @@
 from langchain import LlamaCpp
+from langchain.chat_models import ChatOpenAI
 from langchain.llms.base import BaseLLM
 from langchain.llms import Ollama
 from langchain.llms.fireworks import Fireworks
@@ -9,14 +10,33 @@ from ix.chains.fixture_src.common import VERBOSE
 
 BASE_LLM_FIELDS = NodeTypeField.get_fields(
     BaseLLM,
-    include=["verbose", "tags", "metadata"],
+    include=["cache", "verbose", "tags", "metadata"],
     field_options={
         "metadata": {
             "type": "dict",
-        }
+        },
+        "cache": {
+            "type": "boolean",
+        },
+        "tags": {
+            "type": "list",
+        },
     },
 )
 
+REQUEST_TIMEOUT = {
+    "name": "request_timeout",
+    "label": "Timeout (sec)",
+    "type": "number",
+    "description": "Request Timeout",
+    "default": 60,
+}
+
+STREAMING = {
+    "name": "streaming",
+    "type": "boolean",
+    "default": True,
+}
 
 OPENAI_LLM_CLASS_PATH = "langchain.chat_models.openai.ChatOpenAI"
 OPENAI_LLM = {
@@ -40,13 +60,47 @@ OPENAI_LLM = {
                 {"label": "GPT-3.5 16k", "value": "gpt-3.5-turbo-16k-0613"},
             ],
         },
-        {
-            "name": "request_timeout",
-            "label": "Timeout (sec)",
-            "type": "number",
-            "description": "Request Timeout",
-            "default": 60,
+    ]
+    + NodeTypeField.get_fields(
+        ChatOpenAI,
+        include=[
+            "openai_api_key",
+            "openai_organization",
+            "openai_api_base",
+            "openai_proxy",
+            "max_tokens",
+        ],
+        field_options={
+            "openai_api_key": {
+                "input_type": "secret",
+                "label": "API Key",
+                "style": {"width": "100%"},
+            },
+            "openai_organization": {
+                "type": "string",
+                "label": "Organization",
+                "style": {"width": "100%"},
+            },
+            "openai_api_base": {
+                "type": "string",
+                "label": "API Base URL",
+                "description": "OpenAI API Base URL",
+                "style": {"width": "100%"},
+            },
+            "openai_proxy": {
+                "type": "string",
+                "label": "Proxy URL",
+                "description": "OpenAI Proxy URL",
+                "style": {"width": "100%"},
+            },
+            "max_tokens": {
+                "type": "string",
+            },
         },
+    )
+    + [
+        STREAMING,
+        REQUEST_TIMEOUT,
         {
             "name": "max_retries",
             "type": "number",
@@ -67,26 +121,8 @@ OPENAI_LLM = {
             "max": 2,
             "step": 0.05,
         },
-        {
-            "name": "max_tokens",
-            "type": "number",
-            "default": 256,
-        },
-        {
-            "name": "verbose",
-            "type": "boolean",
-            "default": False,
-        },
-        {
-            "name": "streaming",
-            "type": "boolean",
-            "default": True,
-        },
-        {
-            "name": "metadata",
-            "type": "dict",
-        },
-    ],
+    ]
+    + BASE_LLM_FIELDS,
 }
 
 GOOGLE_PALM = {
@@ -155,12 +191,8 @@ GOOGLE_PALM = {
             "max": 5,
             "step": 1,
         },
-        {
-            "name": "verbose",
-            "type": "boolean",
-            "default": False,
-        },
-    ],
+    ]
+    + BASE_LLM_FIELDS,
 }
 
 ANTHROPIC_LLM = {
@@ -193,7 +225,8 @@ ANTHROPIC_LLM = {
             "description": "API URL",
             "default": "https://api.anthropic.com",
         },
-    ],
+    ]
+    + BASE_LLM_FIELDS,
 }
 
 LLAMA_CPP_LLM_CLASS_PATH = "langchain.llms.llamacpp.LlamaCpp"
@@ -232,9 +265,9 @@ LLAMA_CPP_LLM = {
             "rope_freq_base",
             # "model_kwargs",
             "streaming",
-            "verbose",
         ],
-    ),
+    )
+    + BASE_LLM_FIELDS,
 }
 
 OLLAMA_LLM_CLASS_PATH = "langchain.llms.ollama.Ollama"
@@ -296,7 +329,8 @@ OLLAMA_LLM = {
                 "style": {"width": "100%"},
             },
         },
-    ),
+    )
+    + BASE_LLM_FIELDS,
 }
 
 

--- a/test_data/snapshots/components/langchain.chat_models.anthropic.ChatAnthropic.json
+++ b/test_data/snapshots/components/langchain.chat_models.anthropic.ChatAnthropic.json
@@ -19,6 +19,23 @@
                 },
                 "type": "string"
             },
+            "cache": {
+                "type": "boolean"
+            },
+            "metadata": {
+                "type": "object"
+            },
+            "tags": {
+                "items": [
+                    {
+                        "type": "string"
+                    }
+                ],
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
+            },
             "temperature": {
                 "default": 0,
                 "description": "Temperature",
@@ -27,9 +44,17 @@
                 "minimum": 0.0,
                 "multipleOf": 0.05,
                 "type": "number"
+            },
+            "verbose": {
+                "type": "boolean"
             }
         },
-        "required": [],
+        "required": [
+            "cache",
+            "verbose",
+            "tags",
+            "metadata"
+        ],
         "type": "object"
     },
     "connectors": null,
@@ -63,6 +88,66 @@
                 "width": "100%"
             },
             "type": "string"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Cache",
+            "max": null,
+            "min": null,
+            "name": "cache",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "boolean"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Verbose",
+            "max": null,
+            "min": null,
+            "name": "verbose",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "bool"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Tags",
+            "max": null,
+            "min": null,
+            "name": "tags",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "list"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Metadata",
+            "max": null,
+            "min": null,
+            "name": "metadata",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "dict"
         }
     ],
     "name": "Anthropic",

--- a/test_data/snapshots/components/langchain.chat_models.fireworks.ChatFireworks.json
+++ b/test_data/snapshots/components/langchain.chat_models.fireworks.ChatFireworks.json
@@ -3,6 +3,9 @@
     "class_path": "langchain.chat_models.fireworks.ChatFireworks",
     "config_schema": {
         "properties": {
+            "cache": {
+                "type": "boolean"
+            },
             "fireworks_api_key": {
                 "input_type": "secret",
                 "style": {
@@ -29,13 +32,22 @@
                 "type": "string"
             },
             "tags": {
-                "type": "object"
+                "items": [
+                    {
+                        "type": "string"
+                    }
+                ],
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
             },
             "verbose": {
                 "type": "boolean"
             }
         },
         "required": [
+            "cache",
             "verbose",
             "tags",
             "metadata"
@@ -100,6 +112,21 @@
             "default": null,
             "description": null,
             "input_type": null,
+            "label": "Cache",
+            "max": null,
+            "min": null,
+            "name": "cache",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "boolean"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
             "label": "Verbose",
             "max": null,
             "min": null,
@@ -123,7 +150,7 @@
             "required": true,
             "step": null,
             "style": null,
-            "type": "Optional[List[str]]"
+            "type": "list"
         },
         {
             "choices": null,

--- a/test_data/snapshots/components/langchain.chat_models.google_palm.ChatGooglePalm.json
+++ b/test_data/snapshots/components/langchain.chat_models.google_palm.ChatGooglePalm.json
@@ -3,10 +3,16 @@
     "class_path": "langchain.chat_models.google_palm.ChatGooglePalm",
     "config_schema": {
         "properties": {
+            "cache": {
+                "type": "boolean"
+            },
             "google_api_key": {
                 "description": "Google API key",
                 "input_type": "secret",
                 "type": "string"
+            },
+            "metadata": {
+                "type": "object"
             },
             "model_name": {
                 "default": "gpt-4",
@@ -25,6 +31,17 @@
                 "minimum": 1.0,
                 "multipleOf": 1.0,
                 "type": "number"
+            },
+            "tags": {
+                "items": [
+                    {
+                        "type": "string"
+                    }
+                ],
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
             },
             "temperature": {
                 "default": 0,
@@ -54,12 +71,15 @@
                 "type": "number"
             },
             "verbose": {
-                "default": false,
                 "type": "boolean"
             }
         },
         "required": [
-            "model_name"
+            "model_name",
+            "cache",
+            "verbose",
+            "tags",
+            "metadata"
         ],
         "type": "object"
     },
@@ -131,9 +151,64 @@
             "type": "number"
         },
         {
-            "default": false,
-            "name": "verbose",
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Cache",
+            "max": null,
+            "min": null,
+            "name": "cache",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
             "type": "boolean"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Verbose",
+            "max": null,
+            "min": null,
+            "name": "verbose",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "bool"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Tags",
+            "max": null,
+            "min": null,
+            "name": "tags",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "list"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Metadata",
+            "max": null,
+            "min": null,
+            "name": "metadata",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "dict"
         }
     ],
     "name": "Google PaLM",

--- a/test_data/snapshots/components/langchain.chat_models.openai.ChatOpenAI.json
+++ b/test_data/snapshots/components/langchain.chat_models.openai.ChatOpenAI.json
@@ -3,6 +3,9 @@
     "class_path": "langchain.chat_models.openai.ChatOpenAI",
     "config_schema": {
         "properties": {
+            "cache": {
+                "type": "boolean"
+            },
             "max_retries": {
                 "default": 6,
                 "description": "Max Retries",
@@ -13,8 +16,7 @@
                 "type": "number"
             },
             "max_tokens": {
-                "default": 256,
-                "type": "number"
+                "type": "string"
             },
             "metadata": {
                 "type": "object"
@@ -31,6 +33,33 @@
                 "input_type": "select",
                 "type": "string"
             },
+            "openai_api_base": {
+                "description": "OpenAI API Base URL",
+                "style": {
+                    "width": "100%"
+                },
+                "type": "string"
+            },
+            "openai_api_key": {
+                "input_type": "secret",
+                "style": {
+                    "width": "100%"
+                },
+                "type": "object"
+            },
+            "openai_organization": {
+                "style": {
+                    "width": "100%"
+                },
+                "type": "string"
+            },
+            "openai_proxy": {
+                "description": "OpenAI Proxy URL",
+                "style": {
+                    "width": "100%"
+                },
+                "type": "string"
+            },
             "request_timeout": {
                 "default": 60,
                 "description": "Request Timeout",
@@ -39,6 +68,17 @@
             "streaming": {
                 "default": true,
                 "type": "boolean"
+            },
+            "tags": {
+                "items": [
+                    {
+                        "type": "string"
+                    }
+                ],
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
             },
             "temperature": {
                 "default": 0,
@@ -50,12 +90,20 @@
                 "type": "number"
             },
             "verbose": {
-                "default": false,
                 "type": "boolean"
             }
         },
         "required": [
-            "model_name"
+            "model_name",
+            "openai_api_key",
+            "openai_api_base",
+            "openai_organization",
+            "openai_proxy",
+            "max_tokens",
+            "cache",
+            "verbose",
+            "tags",
+            "metadata"
         ],
         "type": "object"
     },
@@ -91,6 +139,94 @@
             "type": "string"
         },
         {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": "secret",
+            "label": "API Key",
+            "max": null,
+            "min": null,
+            "name": "openai_api_key",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": {
+                "width": "100%"
+            },
+            "type": "Optional[str]"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": "OpenAI API Base URL",
+            "input_type": null,
+            "label": "API Base URL",
+            "max": null,
+            "min": null,
+            "name": "openai_api_base",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": {
+                "width": "100%"
+            },
+            "type": "string"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Organization",
+            "max": null,
+            "min": null,
+            "name": "openai_organization",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": {
+                "width": "100%"
+            },
+            "type": "string"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": "OpenAI Proxy URL",
+            "input_type": null,
+            "label": "Proxy URL",
+            "max": null,
+            "min": null,
+            "name": "openai_proxy",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": {
+                "width": "100%"
+            },
+            "type": "string"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Max_tokens",
+            "max": null,
+            "min": null,
+            "name": "max_tokens",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "string"
+        },
+        {
+            "default": true,
+            "name": "streaming",
+            "type": "boolean"
+        },
+        {
             "default": 60,
             "description": "Request Timeout",
             "label": "Timeout (sec)",
@@ -118,22 +254,63 @@
             "type": "number"
         },
         {
-            "default": 256,
-            "name": "max_tokens",
-            "type": "number"
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Cache",
+            "max": null,
+            "min": null,
+            "name": "cache",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "boolean"
         },
         {
-            "default": false,
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Verbose",
+            "max": null,
+            "min": null,
             "name": "verbose",
-            "type": "boolean"
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "bool"
         },
         {
-            "default": true,
-            "name": "streaming",
-            "type": "boolean"
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Tags",
+            "max": null,
+            "min": null,
+            "name": "tags",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "list"
         },
         {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Metadata",
+            "max": null,
+            "min": null,
             "name": "metadata",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
             "type": "dict"
         }
     ],

--- a/test_data/snapshots/components/langchain.llms.fireworks.Fireworks.json
+++ b/test_data/snapshots/components/langchain.llms.fireworks.Fireworks.json
@@ -3,6 +3,9 @@
     "class_path": "langchain.llms.fireworks.Fireworks",
     "config_schema": {
         "properties": {
+            "cache": {
+                "type": "boolean"
+            },
             "fireworks_api_key": {
                 "input_type": "secret",
                 "style": {
@@ -29,13 +32,22 @@
                 "type": "string"
             },
             "tags": {
-                "type": "object"
+                "items": [
+                    {
+                        "type": "string"
+                    }
+                ],
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
             },
             "verbose": {
                 "type": "boolean"
             }
         },
         "required": [
+            "cache",
             "verbose",
             "tags",
             "metadata"
@@ -100,6 +112,21 @@
             "default": null,
             "description": null,
             "input_type": null,
+            "label": "Cache",
+            "max": null,
+            "min": null,
+            "name": "cache",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "boolean"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
             "label": "Verbose",
             "max": null,
             "min": null,
@@ -123,7 +150,7 @@
             "required": true,
             "step": null,
             "style": null,
-            "type": "Optional[List[str]]"
+            "type": "list"
         },
         {
             "choices": null,

--- a/test_data/snapshots/components/langchain.llms.llamacpp.LlamaCpp.json
+++ b/test_data/snapshots/components/langchain.llms.llamacpp.LlamaCpp.json
@@ -3,6 +3,9 @@
     "class_path": "langchain.llms.llamacpp.LlamaCpp",
     "config_schema": {
         "properties": {
+            "cache": {
+                "type": "boolean"
+            },
             "echo": {
                 "default": false,
                 "type": "object"
@@ -27,6 +30,9 @@
             },
             "max_tokens": {
                 "default": 256,
+                "type": "object"
+            },
+            "metadata": {
                 "type": "object"
             },
             "model_path": {
@@ -77,6 +83,17 @@
             "suffix": {
                 "type": "object"
             },
+            "tags": {
+                "items": [
+                    {
+                        "type": "string"
+                    }
+                ],
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
+            },
             "temperature": {
                 "default": 0.8,
                 "type": "object"
@@ -94,7 +111,6 @@
                 "type": "object"
             },
             "verbose": {
-                "default": true,
                 "type": "boolean"
             },
             "vocab_only": {
@@ -108,7 +124,11 @@
             "n_threads",
             "n_gpu_layers",
             "suffix",
-            "logprobs"
+            "logprobs",
+            "cache",
+            "verbose",
+            "tags",
+            "metadata"
         ],
         "type": "object"
     },
@@ -498,7 +518,22 @@
         },
         {
             "choices": null,
-            "default": true,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Cache",
+            "max": null,
+            "min": null,
+            "name": "cache",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "boolean"
+        },
+        {
+            "choices": null,
+            "default": null,
             "description": null,
             "input_type": null,
             "label": "Verbose",
@@ -506,10 +541,40 @@
             "min": null,
             "name": "verbose",
             "parent": null,
-            "required": false,
+            "required": true,
             "step": null,
             "style": null,
             "type": "bool"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Tags",
+            "max": null,
+            "min": null,
+            "name": "tags",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "list"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Metadata",
+            "max": null,
+            "min": null,
+            "name": "metadata",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "dict"
         }
     ],
     "name": "Llama Cpp",

--- a/test_data/snapshots/components/langchain.llms.ollama.Ollama.json
+++ b/test_data/snapshots/components/langchain.llms.ollama.Ollama.json
@@ -7,6 +7,12 @@
                 "default": "http://localhost:11434",
                 "type": "string"
             },
+            "cache": {
+                "type": "boolean"
+            },
+            "metadata": {
+                "type": "object"
+            },
             "mirostat": {
                 "type": "number"
             },
@@ -46,6 +52,17 @@
                 },
                 "type": "object"
             },
+            "tags": {
+                "items": [
+                    {
+                        "type": "string"
+                    }
+                ],
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
+            },
             "temperature": {
                 "default": 0.8,
                 "input_type": "slider",
@@ -66,11 +83,15 @@
                 "type": "number"
             },
             "verbose": {
-                "default": false,
                 "type": "boolean"
             }
         },
-        "required": [],
+        "required": [
+            "cache",
+            "verbose",
+            "tags",
+            "metadata"
+        ],
         "type": "object"
     },
     "connectors": null,
@@ -293,6 +314,66 @@
             "step": 0.05,
             "style": null,
             "type": "int"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Cache",
+            "max": null,
+            "min": null,
+            "name": "cache",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "boolean"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Verbose",
+            "max": null,
+            "min": null,
+            "name": "verbose",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "bool"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Tags",
+            "max": null,
+            "min": null,
+            "name": "tags",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "list"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Metadata",
+            "max": null,
+            "min": null,
+            "name": "metadata",
+            "parent": null,
+            "required": true,
+            "step": null,
+            "style": null,
+            "type": "dict"
         }
     ],
     "name": "Ollama",


### PR DESCRIPTION
### Description
Adding `tags`, `metadata`, `verbose` to all LLM components.
Also adding `api_key`, `base_url`, and `proxy_url` to Chat OpenAI

![image](https://github.com/kreneskyp/ix/assets/68635/208b097e-c0a7-4ddf-ae40-e5bd6c9f8cbd)

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
- These new fields + the JSONSchemaForm (#299) has made the config options for LLMs overwhelming. Field groups are being worked on as part of secrets UI to make forms with lots of options more approachable.
