### PR TITLE
Various fixes to NodeType schemas

### DIFF
--- a/ix/api/components/types.py
+++ b/ix/api/components/types.py
@@ -1,4 +1,5 @@
 import inspect
+import re
 from abc import ABC
 from dataclasses import dataclass
 from enum import Enum
@@ -62,6 +63,23 @@ def parse_enum_choices(enum_cls: Enum) -> List[Dict[str, str]]:
         {"label": name, "value": value.value}
         for name, value in enum_cls.__members__.items()
     ]
+
+
+def parse_type(type_string: str) -> str:
+    # Pattern to match Optional or Optional[List]
+    pattern = re.compile(r"(typing\.)?Optional\[(List\[\w+\]|\w+)\]")
+
+    match = pattern.match(type_string)
+    if match:
+        # If it's Optional[List[T]], return 'list'
+        if match.group(2).startswith("List"):
+            return "list"
+        # If it's Optional[T], return T
+        else:
+            return match.group(2)
+    # If no match, return the original string
+    else:
+        return type_string
 
 
 class NodeTypeField(BaseModel):
@@ -260,6 +278,14 @@ class NodeTypeField(BaseModel):
                 root_field = str
             elif _is_optional:
                 root_field = get_args(field.type_)[0]
+            elif isinstance(root_field, type) and issubclass(
+                root_field, (str, int, float, bool, list, Enum)
+            ):
+                pass
+            elif root_field in {"str", "int", "float", "bool", "list"}:
+                pass
+            elif isinstance(root_field, str):
+                root_field = parse_type(root_field)
 
             if root_field is bool:
                 # Backwards compatibility for "boolean" type

--- a/ix/api/components/types.py
+++ b/ix/api/components/types.py
@@ -119,7 +119,7 @@ class NodeTypeField(BaseModel):
     choices: Optional[List[Choice]] = None
 
     # form & display properties
-    input_type: Optional[InputType] = None
+    input_type: Optional[str] = None
     min: Optional[float] = None
     max: Optional[float] = None
     step: Optional[float] = None

--- a/ix/chains/fixture_src/document_loaders.py
+++ b/ix/chains/fixture_src/document_loaders.py
@@ -102,6 +102,9 @@ JSON_LOADER = {
             "jq_schema": {
                 "input_type": "textarea",
             },
+            "file_path": {
+                "type": "str",
+            },
         },
     ),
 }

--- a/ix/chains/fixture_src/embeddings.py
+++ b/ix/chains/fixture_src/embeddings.py
@@ -21,7 +21,7 @@ OPENAI_EMBEDDINGS = {
         {
             "name": "disallowed_special",
             "type": "list",
-            "default": "all",
+            "default": ["all"],
         },
         {
             "name": "chunk_size",

--- a/ix/chains/fixtures/agent/ingest.json
+++ b/ix/chains/fixtures/agent/ingest.json
@@ -32,7 +32,7 @@
         "langchain.document_loaders.web_base.WebBaseLoader"
       ],
       "config": {
-        "web_path": "{URL}",
+        "web_path": ["{URL}"],
         "verify_ssl": true,
         "continue_on_failure": false
       },
@@ -192,7 +192,7 @@
         "chunk_size": 1000,
         "max_retries": "6",
         "allowed_special": [],
-        "disallowed_special": "all"
+        "disallowed_special": ["all"]
       },
       "name": null,
       "description": null,

--- a/ix/chains/fixtures/agent/knowledge.json
+++ b/ix/chains/fixtures/agent/knowledge.json
@@ -36,7 +36,7 @@
         "chunk_size": 1000,
         "max_retries": "6",
         "allowed_special": [],
-        "disallowed_special": "all"
+        "disallowed_special": ["all"]
       },
       "name": null,
       "description": null,

--- a/ix/chains/fixtures/agent/readme.json
+++ b/ix/chains/fixtures/agent/readme.json
@@ -134,7 +134,7 @@
         "langchain.document_loaders.web_base.WebBaseLoader"
       ],
       "config": {
-        "web_path": "https://raw.githubusercontent.com/kreneskyp/ix/master/README.md",
+        "web_path": ["https://raw.githubusercontent.com/kreneskyp/ix/master/README.md"],
         "verify_ssl": true,
         "continue_on_failure": false
       },
@@ -231,7 +231,7 @@
         "chunk_size": 1000,
         "max_retries": "6",
         "allowed_special": [],
-        "disallowed_special": "all"
+        "disallowed_special": ["all"]
       },
       "name": null,
       "description": null,

--- a/ix/chains/tests/test_config.py
+++ b/ix/chains/tests/test_config.py
@@ -1,10 +1,16 @@
 from abc import ABC
 from enum import Enum
 from typing import Literal, Optional
+
+from langchain.chains.conversational_retrieval.base import (
+    BaseConversationalRetrievalChain,
+)
 from langchain.chat_models.base import BaseChatModel
+from langchain.llms.llamacpp import LlamaCpp
 from langchain.vectorstores.base import VectorStoreRetriever
 
 import pytest
+from langchain.vectorstores.chroma import Chroma
 from pydantic import BaseModel
 from ix.api.components.types import NodeTypeField, InputType
 
@@ -297,3 +303,52 @@ class TestTroubleCases:
         )
         assert fields[0]["type"] == "boolean"
         assert fields[0]["input_type"] is None
+
+    def test_optional_str(self):
+        """Testing Optional[str] field from Chroma.__init__"""
+        actual = NodeTypeField.get_fields(
+            Chroma.__init__,
+            include=[
+                "persist_directory",
+            ],
+        )
+
+        assert actual[0]["required"] is False
+        assert actual[0]["default"] is None
+        assert actual[0]["type"] == "str"
+
+    def test_optional_bool(self):
+        """Testing Optional[bool] field from BaseConversationalRetrievalChain"""
+        actual = NodeTypeField.get_fields(
+            BaseConversationalRetrievalChain,
+            include=[
+                "rephrase_question",
+            ],
+        )
+        assert actual[0]["required"] is False
+        assert actual[0]["default"] is True
+        assert actual[0]["type"] == "bool"
+
+    def test_optional_int(self):
+        """Testing Optional[int] field from LlamaCpp"""
+        actual = NodeTypeField.get_fields(
+            LlamaCpp,
+            include=[
+                "top_k",
+            ],
+        )
+        assert actual[0]["required"] is False
+        assert actual[0]["default"] is 40
+        assert actual[0]["type"] == "int"
+
+    def test_optional_list(self):
+        """Testing Optional[List[str]] field from LlamaCpp"""
+        actual = NodeTypeField.get_fields(
+            LlamaCpp,
+            include=[
+                "stop",
+            ],
+        )
+        assert actual[0]["required"] is False
+        assert actual[0]["default"] == []
+        assert actual[0]["type"] == "list"

--- a/ix/chains/tests/test_config.py
+++ b/ix/chains/tests/test_config.py
@@ -338,7 +338,7 @@ class TestTroubleCases:
             ],
         )
         assert actual[0]["required"] is False
-        assert actual[0]["default"] is 40
+        assert actual[0]["default"] == 40
         assert actual[0]["type"] == "int"
 
     def test_optional_list(self):

--- a/test_data/snapshots/components/ix.chains.components.vectorstores.AsyncChromaVectorstore.json
+++ b/test_data/snapshots/components/ix.chains.components.vectorstores.AsyncChromaVectorstore.json
@@ -50,7 +50,7 @@
             },
             "persist_directory": {
                 "default": "./chroma",
-                "type": "object"
+                "type": "string"
             },
             "search_type": {
                 "default": "similarity",
@@ -117,7 +117,7 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "Optional[str]"
+            "type": "str"
         },
         {
             "choices": null,

--- a/test_data/snapshots/components/langchain.agents.agent_toolkits.file_management.toolkit.FileManagementToolkit.json
+++ b/test_data/snapshots/components/langchain.agents.agent_toolkits.file_management.toolkit.FileManagementToolkit.json
@@ -6,7 +6,7 @@
         "properties": {
             "root_dir": {
                 "default": "/var/app/workdir",
-                "type": "object"
+                "type": "string"
             }
         },
         "required": [
@@ -32,7 +32,7 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "Optional[str]"
+            "type": "str"
         }
     ],
     "name": "File Management",

--- a/test_data/snapshots/components/langchain.chains.conversational_retrieval.base.ConversationalRetrievalChain.from_llm.json
+++ b/test_data/snapshots/components/langchain.chains.conversational_retrieval.base.ConversationalRetrievalChain.from_llm.json
@@ -5,7 +5,7 @@
         "display_groups": null,
         "properties": {
             "max_tokens_limit": {
-                "type": "object"
+                "type": "number"
             },
             "output_key": {
                 "default": "answer",
@@ -175,7 +175,7 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "Optional[int]"
+            "type": "int"
         }
     ],
     "name": "ConversationalRetrievalChain",

--- a/test_data/snapshots/components/langchain.chat_models.openai.ChatOpenAI.json
+++ b/test_data/snapshots/components/langchain.chat_models.openai.ChatOpenAI.json
@@ -93,7 +93,7 @@
                 "style": {
                     "width": "100%"
                 },
-                "type": "object"
+                "type": "string"
             },
             "openai_organization": {
                 "style": {
@@ -208,7 +208,7 @@
             "style": {
                 "width": "100%"
             },
-            "type": "Optional[str]"
+            "type": "str"
         },
         {
             "choices": null,

--- a/test_data/snapshots/components/langchain.document_loaders.JSONLoader.json
+++ b/test_data/snapshots/components/langchain.document_loaders.JSONLoader.json
@@ -8,7 +8,7 @@
                 "type": "string"
             },
             "file_path": {
-                "type": "object"
+                "type": "string"
             },
             "jq_schema": {
                 "input_type": "textarea",
@@ -47,7 +47,7 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "Union"
+            "type": "str"
         },
         {
             "choices": null,

--- a/test_data/snapshots/components/langchain.embeddings.openai.OpenAIEmbeddings.json
+++ b/test_data/snapshots/components/langchain.embeddings.openai.OpenAIEmbeddings.json
@@ -93,7 +93,9 @@
         },
         {
             "choices": null,
-            "default": "all",
+            "default": [
+                "all"
+            ],
             "description": null,
             "input_type": null,
             "label": "",

--- a/test_data/snapshots/components/langchain.llms.llamacpp.LlamaCpp.json
+++ b/test_data/snapshots/components/langchain.llms.llamacpp.LlamaCpp.json
@@ -9,7 +9,7 @@
             },
             "echo": {
                 "default": false,
-                "type": "object"
+                "type": "boolean"
             },
             "f16_kv": {
                 "default": true,
@@ -17,21 +17,21 @@
             },
             "last_n_tokens_size": {
                 "default": 64,
-                "type": "object"
+                "type": "number"
             },
             "logits_all": {
                 "default": false,
                 "type": "boolean"
             },
             "logprobs": {
-                "type": "object"
+                "type": "number"
             },
             "lora_base": {
-                "type": "object"
+                "type": "string"
             },
             "max_tokens": {
                 "default": 256,
-                "type": "object"
+                "type": "number"
             },
             "metadata": {
                 "type": "object"
@@ -41,25 +41,25 @@
             },
             "n_batch": {
                 "default": 8,
-                "type": "object"
+                "type": "number"
             },
             "n_ctx": {
                 "default": 512,
                 "type": "number"
             },
             "n_gpu_layers": {
-                "type": "object"
+                "type": "number"
             },
             "n_parts": {
                 "default": -1,
                 "type": "number"
             },
             "n_threads": {
-                "type": "object"
+                "type": "number"
             },
             "repeat_penalty": {
                 "default": 1.1,
-                "type": "object"
+                "type": "number"
             },
             "rope_freq_base": {
                 "default": 10000.0,
@@ -74,15 +74,22 @@
                 "type": "number"
             },
             "stop": {
-                "default": [],
-                "type": "object"
+                "items": [
+                    {
+                        "type": "string"
+                    }
+                ],
+                "maxItems": null,
+                "minItems": null,
+                "type": "array",
+                "uniqueItems": false
             },
             "streaming": {
                 "default": true,
                 "type": "boolean"
             },
             "suffix": {
-                "type": "object"
+                "type": "string"
             },
             "tags": {
                 "items": [
@@ -97,11 +104,11 @@
             },
             "temperature": {
                 "default": 0.8,
-                "type": "object"
+                "type": "number"
             },
             "top_p": {
                 "default": 0.95,
-                "type": "object"
+                "type": "number"
             },
             "use_mlock": {
                 "default": false,
@@ -109,7 +116,7 @@
             },
             "use_mmap": {
                 "default": true,
-                "type": "object"
+                "type": "boolean"
             },
             "verbose": {
                 "type": "boolean"
@@ -183,7 +190,7 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "Optional[str]"
+            "type": "str"
         },
         {
             "choices": null,
@@ -311,7 +318,7 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "Optional[int]"
+            "type": "int"
         },
         {
             "choices": null,
@@ -327,7 +334,7 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "Optional[int]"
+            "type": "int"
         },
         {
             "choices": null,
@@ -343,7 +350,7 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "Optional[int]"
+            "type": "int"
         },
         {
             "choices": null,
@@ -359,7 +366,7 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "Optional[str]"
+            "type": "str"
         },
         {
             "choices": null,
@@ -375,7 +382,7 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "Optional[int]"
+            "type": "int"
         },
         {
             "choices": null,
@@ -391,7 +398,7 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "Optional[float]"
+            "type": "float"
         },
         {
             "choices": null,
@@ -407,7 +414,7 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "Optional[float]"
+            "type": "float"
         },
         {
             "choices": null,
@@ -423,7 +430,7 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "Optional[int]"
+            "type": "int"
         },
         {
             "choices": null,
@@ -439,7 +446,7 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "Optional[bool]"
+            "type": "bool"
         },
         {
             "choices": null,
@@ -455,7 +462,7 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "Optional[List[str]]"
+            "type": "list"
         },
         {
             "choices": null,
@@ -471,7 +478,7 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "Optional[float]"
+            "type": "float"
         },
         {
             "choices": null,
@@ -487,7 +494,7 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "Optional[int]"
+            "type": "int"
         },
         {
             "choices": null,
@@ -503,7 +510,7 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "Optional[bool]"
+            "type": "bool"
         },
         {
             "choices": null,


### PR DESCRIPTION
### Description
A number of NodeTypes and Agents had malformed schemas and config due to parsing errors with `Optional[T]`, `Optional[List[T]]`, and `Union[T, Z]` types. 

### Changes
- Fixed parsing
- updated agent fixtures
- hardcoded a few fields

### How Tested
- new unittests + manual testing

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
