### PR TITLE
Chains as Chains

### DIFF
--- a/frontend/agents/AgentCard.js
+++ b/frontend/agents/AgentCard.js
@@ -1,16 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
-import {
-  Box,
-  Button,
-  Card,
-  CardBody,
-  HStack,
-  Text,
-  VStack,
-} from "@chakra-ui/react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPencil } from "@fortawesome/free-solid-svg-icons";
+import { Box, Card, CardBody, HStack, Text, VStack } from "@chakra-ui/react";
 
 import AssistantAvatar from "chat/avatars/AssistantAvatar";
 import { useColorMode } from "@chakra-ui/color-mode";

--- a/frontend/chains/ChainCard.js
+++ b/frontend/chains/ChainCard.js
@@ -9,13 +9,16 @@ import {
 } from "@chakra-ui/react";
 import { useColorMode } from "@chakra-ui/color-mode";
 import { ChainEditButton } from "chains/ChainEditButton";
+import { ModalClose } from "components/Modal";
 
 const ChainCard = ({ chain, children, ...props }) => {
+  const close = React.useContext(ModalClose);
+  const { colorMode } = useColorMode();
+
   if (chain == null) {
     return null;
   }
 
-  const { colorMode } = useColorMode();
   let sx = {
     border: "1px solid transparent",
     borderColor: colorMode === "light" ? "gray.300" : "transparent",
@@ -52,7 +55,7 @@ const ChainCard = ({ chain, children, ...props }) => {
           </Text>
         </VStack>
         <HStack spacing={2} pt={4} display="flex" justifyContent="flex-end">
-          <ChainEditButton chain={chain} />
+          <ChainEditButton chain={chain} onClick={close} />
         </HStack>
       </CardBody>
     </Card>

--- a/frontend/chains/ChainCard.js
+++ b/frontend/chains/ChainCard.js
@@ -1,39 +1,45 @@
 import React from "react";
 import {
-  Box,
   Card,
   CardBody,
   Heading,
-  useColorModeValue,
+  Text,
+  HStack,
   VStack,
 } from "@chakra-ui/react";
+import { useColorMode } from "@chakra-ui/color-mode";
+import { ChainEditButton } from "chains/ChainEditButton";
 
-const ChainCard = ({ chain }) => {
+const ChainCard = ({ chain, children, ...props }) => {
   if (chain == null) {
     return null;
   }
 
-  const borderColor = useColorModeValue("gray.400", "whiteAlpha.50");
-  const bg = useColorModeValue("gray.100", "gray.700");
+  const { colorMode } = useColorMode();
+  let sx = {
+    border: "1px solid transparent",
+    borderColor: colorMode === "light" ? "gray.300" : "transparent",
+  };
 
   return (
     <Card
       overflow="hidden"
       boxShadow="sm"
-      width="100%"
-      cursor="pointer"
-      border="1px solid"
-      borderColor={borderColor}
-      bg={bg}
+      width={360}
+      bg={colorMode === "light" ? "gray.200" : "blackAlpha.500"}
+      sx={sx}
+      {...props}
     >
-      <CardBody>
+      <CardBody px={5} pt={5} pb={2}>
         <VStack alignItems="start" spacing={2}>
           <Heading as="h5" size="xs">
             {chain.name}
           </Heading>
-          <Box
+          <Text
             maxWidth="350px"
-            height={75}
+            minHeight={50}
+            maxHeight={75}
+            fontSize="sm"
             overflow="hidden"
             textOverflow="ellipsis"
             css={{
@@ -43,8 +49,11 @@ const ChainCard = ({ chain }) => {
             }}
           >
             {chain.description}
-          </Box>
+          </Text>
         </VStack>
+        <HStack spacing={2} pt={4} display="flex" justifyContent="flex-end">
+          <ChainEditButton chain={chain} />
+        </HStack>
       </CardBody>
     </Card>
   );

--- a/frontend/chains/ChainCardListButton.js
+++ b/frontend/chains/ChainCardListButton.js
@@ -1,0 +1,53 @@
+import React from "react";
+import { Box, IconButton, SimpleGrid } from "@chakra-ui/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faChain } from "@fortawesome/free-solid-svg-icons";
+
+import { ModalTrigger } from "components/Modal";
+import { usePaginatedAPI } from "utils/hooks/usePaginatedAPI";
+import {
+  useEditorColorMode,
+  useSideBarColorMode,
+} from "chains/editor/useColorMode";
+import ChainCard from "chains/ChainCard";
+
+const ChainCardList = ({ chains, Card }) => {
+  const { scrollbar } = useEditorColorMode();
+  return (
+    <Box
+      maxH="calc(100vh - 275px)"
+      overflowY="auto"
+      spacing={5}
+      css={scrollbar}
+      px={3}
+    >
+      <SimpleGrid columns={[1, 2, 3]} spacing="20px" minChildWidth="360px">
+        {chains?.map((chain) => (
+          <Card chain={chain} key={chain.id} />
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+};
+
+export const ChainCardListButton = ({ Card }) => {
+  const style = useSideBarColorMode();
+  const { page, load } = usePaginatedAPI("/api/chains/", {
+    limit: 1000,
+    load: false,
+    args: { is_agent: false },
+  });
+
+  return (
+    <ModalTrigger onOpen={load} title={"Chains"}>
+      <IconButton
+        icon={<FontAwesomeIcon icon={faChain} />}
+        title={"Chains"}
+        {...style.button}
+      />
+      <ModalTrigger.Content title="Manage Chains">
+        <ChainCardList chains={page?.objects} Card={ChainCard} />
+      </ModalTrigger.Content>
+    </ModalTrigger>
+  );
+};

--- a/frontend/chains/ChainEditButton.js
+++ b/frontend/chains/ChainEditButton.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Button } from "@chakra-ui/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPencil } from "@fortawesome/free-solid-svg-icons";
+
+export const ChainEditButton = ({ chain, ...props }) => {
+  return (
+    <Link to={`/chains/${chain.id}`}>
+      <Button size={"sm"} {...props}>
+        <FontAwesomeIcon icon={faPencil} style={{ marginRight: "5px" }} /> Edit
+      </Button>
+    </Link>
+  );
+};

--- a/frontend/chains/ChainEditorView.js
+++ b/frontend/chains/ChainEditorView.js
@@ -31,6 +31,7 @@ import { useChainState } from "chains/hooks/useChainState";
 import { NodeTypeSearchButton } from "chains/editor/NodeTypeSearchButton";
 import { AgentCardListButton } from "agents/AgentCardListButton";
 import { EditorAgentCard } from "chains/editor/sidebar/EditorAgentCard";
+import { ChainCardListButton } from "chains/ChainCardListButton";
 
 const ChainEditorProvider = ({ graph, onError, children }) => {
   const chainState = useChainState(graph);
@@ -120,6 +121,7 @@ export const ChainEditorView = () => {
         <Layout>
           <LayoutLeftPane>
             <AgentCardListButton Card={EditorAgentCard} />
+            <ChainCardListButton />
             <NodeTypeSearchButton />
           </LayoutLeftPane>
           <LayoutContent>

--- a/frontend/chains/editor/ChainEditorPane.js
+++ b/frontend/chains/editor/ChainEditorPane.js
@@ -23,46 +23,59 @@ import { NameField } from "chains/editor/fields/NameField";
 import { DescriptionField } from "chains/editor/fields/DescriptionField";
 import { RequiredAsterisk } from "components/RequiredAsterisk";
 import { useChainUpdate } from "chains/hooks/useChainUpdate";
+import { getLabel } from "json_form/utils";
 
 const ChainExplanation = () => {
   return (
-    <Box>
-      Chains may be used by other agents and chains as tools with a{" "}
+    <FormHelperText fontSize={"xs"}>
+      Chains may be called via the API, or by other agents and chains with a{" "}
       <Text as={"span"} color={"blue.300"}>
         ChainReference
       </Text>{" "}
       component.
-    </Box>
+    </FormHelperText>
   );
 };
 
 const AgentExplanation = () => {
-  const { agent } = useContext(AgentState);
   return (
-    <Box>
-      Agents may be summoned to chat sessions and will respond to messages. This
-      agents responds to the alias{" "}
-      <Text as={"span"} color={"blue.300"}>
-        @{agent}
-      </Text>
-    </Box>
+    <FormHelperText fontSize={"xs"}>
+      Agents may be summoned to chat sessions for conversational interactions.
+    </FormHelperText>
   );
 };
 
-const SaveModeChooser = () => {
-  const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: true });
+const SaveModeChooser = ({ chain, onChange }) => {
   const { isLight, highlight } = useEditorColorMode();
   const color = isLight
     ? { onColor: "#38A169", offColor: "gray.600" }
     : { onColor: "#38A169", offColor: "gray.600" };
+
+  const isAgent = chain?.is_agent;
+  const handleChange = useCallback(
+    (value) => {
+      onChange({
+        ...chain,
+        is_agent: value,
+      });
+    },
+    [chain, onChange]
+  );
+
   return (
-    <Box>
-      <HStack justifyItems={"fle"}>
+    <FormControl>
+      <FormLabel size="sm" justify="start">
+        Chain Type <RequiredAsterisk />
+      </FormLabel>
+      <HStack justifyItems={"flex"}>
         <Box>
           <Button
             size="sm"
-            onClick={onToggle}
-            bg={isOpen ? highlight.agent : color.offColor}
+            onClick={() => {
+              handleChange(true);
+            }}
+            bg={isAgent ? highlight.agent : color.offColor}
+            _hover={{ bg: highlight.agent }}
           >
             <FontAwesomeIcon icon={faRobot} />
             <Text as={"span"} ml={1}>
@@ -73,8 +86,11 @@ const SaveModeChooser = () => {
         <Box>
           <Button
             size="sm"
-            onClick={onToggle}
-            bg={isOpen ? color.offColor : highlight.chain}
+            onClick={() => {
+              handleChange(false);
+            }}
+            bg={isAgent === false ? highlight.chain : color.offColor}
+            _hover={{ bg: highlight.chain }}
           >
             <FontAwesomeIcon icon={faChain} />{" "}
             <Text as={"span"} ml={1}>
@@ -83,18 +99,10 @@ const SaveModeChooser = () => {
           </Button>
         </Box>
       </HStack>
-      <Box
-        border={"1px solid"}
-        borderColor={"gray.600"}
-        fontSize={"xs"}
-        color={"gray.300"}
-        bg={"blackAlpha.300"}
-        p={2}
-        m={5}
-      >
-        {isOpen ? <AgentExplanation /> : <ChainExplanation />}
+      <Box fontSize={"xs"} color={"gray.300"}>
+        {isAgent ? <AgentExplanation /> : <ChainExplanation />}
       </Box>
-    </Box>
+    </FormControl>
   );
 };
 
@@ -156,17 +164,18 @@ export const ChainEditorPane = () => {
   const { scrollbar } = useEditorColorMode();
 
   return (
-    <CollapsibleSection title="General" mt={3} initialShow={true}>
-      <VStack spacing={4}>
+    <VStack spacing={5}>
+      <SaveModeChooser chain={chain} onChange={onChainUpdate} />
+      {chain?.is_agent && (
         <AliasField object={chain} onChange={onChainUpdate} />
-        <NameField object={chain} onChange={onChainUpdate} />
-        <DescriptionField
-          object={chain}
-          onChange={onChainUpdate}
-          minH={550}
-          css={scrollbar}
-        />
-      </VStack>
-    </CollapsibleSection>
+      )}
+      <NameField object={chain} onChange={onChainUpdate} />
+      <DescriptionField
+        object={chain}
+        onChange={onChainUpdate}
+        minH={500}
+        css={scrollbar}
+      />
+    </VStack>
   );
 };

--- a/frontend/site/Navigation.js
+++ b/frontend/site/Navigation.js
@@ -10,7 +10,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Link } from "react-router-dom";
 import { useColorMode } from "@chakra-ui/color-mode";
 import { SecretsMenuItem } from "secrets/SecretsMenuItem";
-import { ChainCardListButton } from "chains/ChainCardListButton";
 
 function Navigation() {
   const { colorMode } = useColorMode();
@@ -35,8 +34,6 @@ function Navigation() {
             {...style}
           />
         </Link>
-        <ChainCardListButton />
-
         {false && (
           <HStack align="center">
             <Link ml={3} to="#">

--- a/frontend/site/Navigation.js
+++ b/frontend/site/Navigation.js
@@ -10,6 +10,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Link } from "react-router-dom";
 import { useColorMode } from "@chakra-ui/color-mode";
 import { SecretsMenuItem } from "secrets/SecretsMenuItem";
+import { ChainCardListButton } from "chains/ChainCardListButton";
 
 function Navigation() {
   const { colorMode } = useColorMode();
@@ -34,6 +35,7 @@ function Navigation() {
             {...style}
           />
         </Link>
+        <ChainCardListButton />
 
         {false && (
           <HStack align="center">

--- a/ix/api/chains/endpoints.py
+++ b/ix/api/chains/endpoints.py
@@ -35,12 +35,16 @@ async def get_chains(
     search: Optional[str] = None,
     limit: int = 10,
     offset: int = 0,
+    is_agent: Optional[bool] = None,
     user: AbstractUser = Depends(get_request_user),
 ):
     query = Chain.filtered_owners(user)
 
     if search:
         query = query.filter(Q(name__icontains=search))
+
+    if is_agent is not None:
+        query = query.filter(is_agent=is_agent)
 
     query = query.order_by("-created_at")
 


### PR DESCRIPTION
### Description
This PR allows `Chain (model)` to be saved as either an agent or a chain. It also adds a new menu item to display them.

##### Agent/Chain selector buttons in editor
![image](https://github.com/kreneskyp/ix/assets/68635/f7a141b7-3f1e-4690-a5f9-1d494097f5c2)


##### Chains popover for opening chains to edit them
![image](https://github.com/kreneskyp/ix/assets/68635/e05426b6-7e40-4f8e-9346-cffe061baf41)


### Changes
- Adding agent/chain selector buttons that toggle `Chain.is_agent`
- Adding menu button and popover for chains

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs

