### PR TITLE
Restart worker target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,10 +271,6 @@ LOAD_FIXTURE = docker-compose exec -T web ./manage.py loaddata
 dev_fixtures: cluster components agents
 	$(LOAD_FIXTURE) fake_user
 
-.PHONY: components
-components: cluster
-	@echo "\nrestoring components from fixtures"
-	${DOCKER_COMPOSE_RUN} ./manage.py import_langchain
 
 .PHONY: agents
 agents: cluster components

--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,12 @@ down: compose
 .PHONY: restart
 restart: compose down up
 
+.PHONY: restart-worker
+restart-worker: compose
+	@echo restarting worker...
+	@docker-compose up -d --scale worker=0
+	@docker-compose up -d --scale worker=1
+
 
 # run backend and frontend. This starts uvicorn for asgi+websockers
 # and nginx to serve static files


### PR DESCRIPTION
### Description
adding a `restart-worker` make target so the entire cluster does not need to be restarted.

This can eventually be deprecated when faststream is introduced since it has auto-reloading

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
