### PR TITLE
LangChain 0.0.329

### DIFF
--- a/ix/api/components/types.py
+++ b/ix/api/components/types.py
@@ -17,7 +17,8 @@ from typing import (
     Union,
 )
 from uuid import UUID, uuid4
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, model_validator, SecretStr
+from pydantic.v1 import SecretStr as SecretStrV1
 from pydantic_core import PydanticUndefined
 
 from ix.utils.pydantic import get_model_fields, create_args_model
@@ -311,6 +312,10 @@ class NodeTypeField(BaseModel):
             elif isinstance(root_field, type) and issubclass(root_field, Enum):
                 field_info["type"] = "str"
                 field_info["choices"] = parse_enum_choices(root_field)
+
+            if root_field in {SecretStr, SecretStrV1, "SecretStr"}:
+                field_info["type"] = "str"
+                field_info["input_type"] = "secret"
 
             if field_info.get("choices", None):
                 field_info["input_type"] = "select"

--- a/ix/chains/components/tools.py
+++ b/ix/chains/components/tools.py
@@ -3,9 +3,9 @@ from typing import Any
 
 from langchain.document_loaders.base import BaseLoader
 from langchain.schema import BaseRetriever
+from langchain.schema.vectorstore import VectorStore
 from langchain.text_splitter import TextSplitter
 from langchain.tools import BaseTool
-from langchain.vectorstores import VectorStore
 
 from ix.chains.loaders.templates import NodeTemplate
 from ix.chains.loaders.text_splitter import TextSplitterShim

--- a/ix/chains/components/vectorstores.py
+++ b/ix/chains/components/vectorstores.py
@@ -3,7 +3,8 @@ from typing import Any, List, Iterable, Optional
 from asgiref.sync import sync_to_async
 from langchain.callbacks.manager import AsyncCallbackManagerForRetrieverRun
 from langchain.schema import Document
-from langchain.vectorstores import Redis, Chroma, VectorStore
+from langchain.schema.vectorstore import VectorStore
+from langchain.vectorstores import Redis, Chroma
 from langchain.vectorstores.redis.base import RedisVectorStoreRetriever
 
 

--- a/ix/chains/fixture_src/tools.py
+++ b/ix/chains/fixture_src/tools.py
@@ -1,18 +1,16 @@
 from ix.chains.fixture_src.targets import (
     CHAIN_TARGET,
 )
-from langchain import (
-    GoogleSearchAPIWrapper,
-    GoogleSerperAPIWrapper,
-    ArxivAPIWrapper,
-    WikipediaAPIWrapper,
-)
 from langchain.utilities import (
+    ArxivAPIWrapper,
     BingSearchAPIWrapper,
     DuckDuckGoSearchAPIWrapper,
+    GoogleSearchAPIWrapper,
+    GoogleSerperAPIWrapper,
     GraphQLAPIWrapper,
     LambdaWrapper,
     PubMedAPIWrapper,
+    WikipediaAPIWrapper,
     ZapierNLAWrapper,
 )
 

--- a/ix/chains/loaders/retriever.py
+++ b/ix/chains/loaders/retriever.py
@@ -3,7 +3,7 @@ from typing import List
 
 from asgiref.sync import sync_to_async
 from langchain.schema import BaseRetriever
-from langchain.vectorstores import VectorStore
+from langchain.schema.vectorstore import VectorStore
 
 from ix.chains.fixture_src.vectorstores import get_vectorstore_retriever_fieldnames
 from ix.chains.loaders.context import IxContext

--- a/ix/chains/loaders/vectorstore.py
+++ b/ix/chains/loaders/vectorstore.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from typing import Dict, Any, Type
 
 from langchain.document_loaders.base import BaseLoader
-from langchain.vectorstores import VectorStore
+from langchain.schema.vectorstore import VectorStore
 
 from ix.chains.fixture_src.vectorstores import get_vectorstore_retriever_fieldnames
 from ix.chains.loaders.text_splitter import TextSplitterShim

--- a/ix/chains/tests/components/test_vectorstores.py
+++ b/ix/chains/tests/components/test_vectorstores.py
@@ -1,5 +1,6 @@
 import pytest
-from langchain.vectorstores import Chroma, VectorStore
+from langchain.schema.vectorstore import VectorStore
+from langchain.vectorstores import Chroma
 
 from ix.chains.fixture_src.document_loaders import GENERIC_LOADER_CLASS_PATH
 from ix.chains.fixture_src.text_splitter import RECURSIVE_CHARACTER_SPLITTER_CLASS_PATH

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ isort==5.12.0
 jq==1.4.1
 jsonpath-ng==1.6.0
 jsonschema==4.19.1
-langchain==0.0.319
+langchain==0.0.329
 langchain-experimental==0.0.32
 llama-cpp-python==0.1.79
 metaphor-python==0.1.16

--- a/test_data/snapshots/components/langchain.document_loaders.parsers.language.language_parser.LanguageParser.json
+++ b/test_data/snapshots/components/langchain.document_loaders.parsers.language.language_parser.LanguageParser.json
@@ -24,7 +24,8 @@
                     "latex",
                     "html",
                     "sol",
-                    "csharp"
+                    "csharp",
+                    "cobol"
                 ],
                 "input_type": "select",
                 "type": "string"
@@ -118,6 +119,10 @@
                 {
                     "label": "CSHARP",
                     "value": "csharp"
+                },
+                {
+                    "label": "COBOL",
+                    "value": "cobol"
                 }
             ],
             "default": null,

--- a/test_data/snapshots/components/langchain.text_splitter.RecursiveCharacterTextSplitter.from_language.json
+++ b/test_data/snapshots/components/langchain.text_splitter.RecursiveCharacterTextSplitter.from_language.json
@@ -41,7 +41,8 @@
                     "latex",
                     "html",
                     "sol",
-                    "csharp"
+                    "csharp",
+                    "cobol"
                 ],
                 "input_type": "select",
                 "type": "string"
@@ -144,6 +145,10 @@
                 {
                     "label": "CSHARP",
                     "value": "csharp"
+                },
+                {
+                    "label": "COBOL",
+                    "value": "cobol"
                 }
             ],
             "default": "python",


### PR DESCRIPTION
### Description
Updating to LangChain `0.0.339`

### Changes
- Update to LangChain `0.0.339`
- Fix import deprecations
- Fields typed `SecretStr` now parse into secret fields automatically.

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
