### PR TITLE
Adding HashListForm that provides stable ordered references to lists …

### DIFF
--- a/frontend/components/HashListForm.js
+++ b/frontend/components/HashListForm.js
@@ -1,0 +1,76 @@
+import React from "react";
+import { v4 as uuidv4 } from "uuid";
+import { Box, Input, VStack, HStack, FormLabel } from "@chakra-ui/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTrash } from "@fortawesome/free-solid-svg-icons";
+import { useEditorColorMode } from "chains/editor/useColorMode";
+
+/**
+ * HashListForm is a functional component that takes an object with list and hash_list as props.
+ * It renders a form that allows the user to edit the list with corresponding UUIDs.
+ */
+export const HashListForm = ({
+  label,
+  list,
+  hash_list,
+  onChange,
+  onDelete,
+}) => {
+  const colorMode = useEditorColorMode();
+
+  const handleInputChange = (e, index) => {
+    const { value } = e.target;
+    const updatedItems = [...list];
+    const updatedHashes = [...hash_list];
+
+    if (index < list.length) {
+      updatedItems[index] = value;
+    } else {
+      updatedItems.push(value);
+      updatedHashes.push(uuidv4());
+    }
+
+    onChange({
+      list: updatedItems,
+      hash_list: updatedHashes,
+    });
+  };
+
+  const handleRemoveClick = (index) => {
+    onChange({
+      list: list.filter((item, i) => i !== index),
+      hash_list: hash_list.filter((hash, i) => i !== index),
+    });
+    onDelete(hash_list[index], list[index]);
+  };
+
+  // Add empty element here so the rendered structure and input focus sticks
+  // while typing in the new item.
+  const list_plus_new = list ? [...list, ""] : [""];
+
+  return (
+    <Box width="100%">
+      <FormLabel>{label}</FormLabel>
+      <VStack align="stretch">
+        {list_plus_new?.map((value, index) => (
+          <HStack key={index}>
+            <Input
+              value={value}
+              onChange={(e) => handleInputChange(e, index)}
+              placeholder={`Item ${index + 1}`}
+              {...colorMode.input}
+            />
+            <FontAwesomeIcon
+              icon={faTrash}
+              onClick={() => handleRemoveClick(index)}
+              cursor={index < list.length ? "pointer" : "default"}
+              color={index < list.length ? "inherit" : "transparent"}
+            />
+          </HStack>
+        ))}
+      </VStack>
+    </Box>
+  );
+};
+
+export default HashListForm;

--- a/frontend/json_form/JSONSchemaForm.js
+++ b/frontend/json_form/JSONSchemaForm.js
@@ -11,6 +11,7 @@ import { List } from "json_form/fields/List";
 import { SecretSelect } from "json_form/fields/SecretSelect";
 import { useDisplayGroups } from "chains/hooks/useDisplayGroups";
 import { CollapsibleSection } from "chains/flow/CollapsibleSection";
+import { HashList } from "json_form/fields/HashList";
 
 // explicit input types
 const INPUTS = {
@@ -23,6 +24,7 @@ const INPUTS = {
   textarea: TextArea,
   dict: Dict,
   list: List,
+  hash_list: HashList,
 };
 
 // type specific default inputs

--- a/frontend/json_form/fields/HashList.js
+++ b/frontend/json_form/fields/HashList.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { getLabel } from "json_form/utils";
+import HashListForm from "components/HashListForm";
+
+export const HashList = ({
+  name,
+  field,
+  isRequired,
+  config,
+  onChange,
+  onDelete,
+}) => {
+  const hashField = `${name}_hash`;
+
+  const handleChange = React.useCallback(
+    (newValue) => {
+      const updatedFields = {
+        [name]: newValue.list,
+        [hashField]: newValue.hash_list,
+      };
+      onChange(updatedFields);
+    },
+    [field, onChange]
+  );
+
+  return (
+    <HashListForm
+      list={config[name]}
+      hash_list={config[hashField]}
+      onChange={handleChange}
+      onDelete={onDelete}
+      label={getLabel(name)}
+      isRequired
+    />
+  );
+};


### PR DESCRIPTION
### Description
Adding a `HashListForm` component to provide a list-like interface on top of an ordered "hash list". List values may change without affecting the underlying `uuid` key. Reference the key to maintain a reference to the row even if the order changes, a row is inserted, or a row is deleted.

List auto-expands as user types in the last row.

![image](https://github.com/kreneskyp/ix/assets/68635/78bf04bc-dfd1-49f9-bb91-3609f83e405f)

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
