### PR TITLE
Edges will now reload on colormode change to refresh line color

### DIFF
--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -72,6 +72,11 @@ const ChainGraphEditor = ({ graph, rightSidebarDisclosure }) => {
     event.dataTransfer.dropEffect = "move";
   }, []);
 
+  // rebuild edges if colorMode toggles
+  React.useEffect(() => {
+    setEdges(reactFlowGraph.edges);
+  }, [colorMode]);
+
   const onNodeSaved = useCallback(
     (response) => {
       // first node creates the new chain


### PR DESCRIPTION
### Description
Edge line color now updates with light/dark mode change without a page refresh

![image](https://github.com/kreneskyp/ix/assets/68635/c412a2ad-ca44-4b39-9ff9-8596f110dc13)

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
