### PR TITLE
Right Sidebar 

### DIFF
--- a/frontend/chains/ChainEditorView.js
+++ b/frontend/chains/ChainEditorView.js
@@ -84,8 +84,6 @@ export const ChainEditorView = () => {
   const graph =
     isNew || id !== response?.data?.chain?.id ? null : response?.data;
 
-  const rightSidebarDisclosure = useDisclosure({ defaultIsOpen: true });
-
   const onAPIError = useCallback((err) => {
     toast({
       title: "Error",
@@ -98,21 +96,11 @@ export const ChainEditorView = () => {
 
   let content;
   if (isNew) {
-    content = (
-      <ChainGraphEditor
-        key={idRef}
-        rightSidebarDisclosure={rightSidebarDisclosure}
-      />
-    );
+    content = <ChainGraphEditor key={idRef} />;
   } else if (isLoading || !graph) {
     content = <Spinner />;
   } else {
-    content = (
-      <ChainGraphEditor
-        graph={graph}
-        rightSidebarDisclosure={rightSidebarDisclosure}
-      />
-    );
+    content = <ChainGraphEditor graph={graph} />;
   }
 
   return (
@@ -136,7 +124,7 @@ export const ChainEditorView = () => {
               >
                 {content}
               </VStack>
-              <EditorRightSidebar {...rightSidebarDisclosure} />
+              <EditorRightSidebar />
             </HStack>
           </LayoutContent>
         </Layout>

--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -34,6 +34,7 @@ import { useConnectionValidator } from "chains/hooks/useConnectionValidator";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faRightLeft } from "@fortawesome/free-solid-svg-icons";
 import { useChainUpdate } from "chains/hooks/useChainUpdate";
+import { useRightSidebarContext } from "site/sidebar/context";
 
 // Nodes are either a single node or a group of nodes
 // ConfigNode renders class_path specific content
@@ -49,7 +50,7 @@ const getExpectedTypes = (connector) => {
     : new Set([connector.source_type]);
 };
 
-const ChainGraphEditor = ({ graph, rightSidebarDisclosure }) => {
+const ChainGraphEditor = ({ graph }) => {
   const reactFlowWrapper = useRef(null);
   const edgeUpdate = useRef(true);
   const { call: loadChain } = useAxios();
@@ -142,7 +143,7 @@ const ChainGraphEditor = ({ graph, rightSidebarDisclosure }) => {
           // create flow edge to validate and add to ReactFlow
           const edgeId = uuid4();
           const flowNodeType = nodeType.type;
-          const style = getEdgeStyle(colorMode, flowNodeType);
+          const style = getEdgeStyle(colorMode);
           flowEdge = {
             id: edgeId,
             source: isOutput ? node.id : newNodeID,
@@ -361,6 +362,7 @@ const ChainGraphEditor = ({ graph, rightSidebarDisclosure }) => {
     }
   }, [graph?.chain?.id]);
 
+  const { toggleSidebar } = useRightSidebarContext();
   return (
     <Box height="93vh">
       <Box display="flex" alignItems="center">
@@ -382,7 +384,7 @@ const ChainGraphEditor = ({ graph, rightSidebarDisclosure }) => {
         <IconButton
           ml="auto"
           icon={<FontAwesomeIcon icon={faRightLeft} />}
-          onClick={rightSidebarDisclosure.onOpen}
+          onClick={toggleSidebar}
           aria-label="Open Sidebar"
           title={"Open Sidebar"}
         />

--- a/frontend/chains/editor/ChatPane.js
+++ b/frontend/chains/editor/ChatPane.js
@@ -123,9 +123,9 @@ export const ChatPane = ({ chatId }) => {
       {isLoading || !graph ? (
         <Spinner />
       ) : (
-        <Box mt={0}>
+        <Box mt={0} mt={2}>
           <ChatInterface graph={graph} />
-          <Box width={"100%"} bg={"gray.800"} p={1}>
+          <Box width={"100%"} bg={"gray.800"} p={1} m={0}>
             <IconButton
               icon={<FontAwesomeIcon icon={faTrash} bg={"gray.800"} />}
               onClick={clearMessages}

--- a/frontend/chains/editor/EditorRightSidebar.js
+++ b/frontend/chains/editor/EditorRightSidebar.js
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import { Tab, TabPanel, Tooltip } from "@chakra-ui/react";
+import { Box, Tab, TabPanel, Tooltip } from "@chakra-ui/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faComments,
@@ -10,16 +10,14 @@ import { ConfigEditorPane } from "chains/editor/ConfigEditorPane";
 import { ChainEditorPane } from "chains/editor/ChainEditorPane";
 import { TestChatPane } from "chains/editor/TestChatPane";
 import { SelectedNodeContext } from "chains/editor/contexts";
-import { RightSidebar } from "site/RightSidebar";
 import {
   SidebarTabList,
   SidebarTabPanels,
   SidebarTabs,
 } from "site/SidebarTabs";
+import Sidebar from "site/sidebar/Sidebar";
 
-const SIZES = ["sm", "xl", "xs"];
-
-export const EditorRightSidebar = ({ isOpen, onClose }) => {
+export const EditorRightSidebar = () => {
   // Tabs state
   const [tabIndex, setTabIndex] = React.useState(1);
 
@@ -33,7 +31,7 @@ export const EditorRightSidebar = ({ isOpen, onClose }) => {
   }, [selectedNode]);
 
   return (
-    <RightSidebar isOpen={isOpen} onClose={onClose} sizes={SIZES}>
+    <Sidebar position={"right"}>
       <SidebarTabs index={tabIndex} onChange={setTabIndex}>
         <SidebarTabList>
           <Tooltip label="Node" aria-label="Node">
@@ -66,6 +64,7 @@ export const EditorRightSidebar = ({ isOpen, onClose }) => {
             flex="1"
             flexDirection="column"
             justifyContent="flex-end"
+            height={"calc(100vh)"}
           >
             <TestChatPane />
           </TabPanel>
@@ -77,6 +76,6 @@ export const EditorRightSidebar = ({ isOpen, onClose }) => {
           </TabPanel>
         </SidebarTabPanels>
       </SidebarTabs>
-    </RightSidebar>
+    </Sidebar>
   );
 };

--- a/frontend/site/Layout.js
+++ b/frontend/site/Layout.js
@@ -6,6 +6,7 @@ import { CenteredSpinner } from "site/CenteredSpinner";
 import { NewChatButton } from "chat/buttons/NewChatButton";
 import { NewAgentButton } from "agents/NewAgentButton";
 import Navigation from "site/Navigation";
+import SidebarProvider from "site/sidebar/context";
 
 export const LayoutLeftPane = ({ children }) => {
   return children;
@@ -26,38 +27,40 @@ export const Layout = ({ children }) => {
   );
 
   return (
-    <Flex h="100vh" overflowX="hidden">
-      <VStack
-        bg={colorMode === "light" ? "gray.200" : "blackAlpha.200"}
-        p={1}
-        minH="100vh"
-        align="left"
-        borderRightColor={colorMode === "light" ? "gray.300" : "transparent"}
-        borderRightWidth={1}
-      >
-        {/* left sidebar */}
-        <NewChatButton />
-        <NewAgentButton />
-        <Divider
-          borderColor={colorMode === "light" ? "gray.400" : "whiteAlpha.400"}
-        />
-        {leftPane}
-        <Spacer />
-        <Divider
-          borderColor={colorMode === "light" ? "gray.400" : "whiteAlpha.400"}
-        />
-        <Navigation />
-        <ColorModeButton />
-      </VStack>
-      <Flex
-        direction="column"
-        flex="1"
-        h="100%"
-        bg={colorMode === "light" ? "gray.100" : "gray.800"}
-      >
-        {/* main content area */}
-        <Suspense fallback={<CenteredSpinner />}>{content}</Suspense>
+    <SidebarProvider>
+      <Flex h="100vh" overflowX="hidden">
+        <VStack
+          bg={colorMode === "light" ? "gray.200" : "blackAlpha.200"}
+          p={1}
+          minH="100vh"
+          align="left"
+          borderRightColor={colorMode === "light" ? "gray.300" : "transparent"}
+          borderRightWidth={1}
+        >
+          {/* left sidebar */}
+          <NewChatButton />
+          <NewAgentButton />
+          <Divider
+            borderColor={colorMode === "light" ? "gray.400" : "whiteAlpha.400"}
+          />
+          {leftPane}
+          <Spacer />
+          <Divider
+            borderColor={colorMode === "light" ? "gray.400" : "whiteAlpha.400"}
+          />
+          <Navigation />
+          <ColorModeButton />
+        </VStack>
+        <Flex
+          direction="column"
+          flex="1"
+          h="100%"
+          bg={colorMode === "light" ? "gray.100" : "gray.800"}
+        >
+          {/* main content area */}
+          <Suspense fallback={<CenteredSpinner />}>{content}</Suspense>
+        </Flex>
       </Flex>
-    </Flex>
+    </SidebarProvider>
   );
 };

--- a/frontend/site/css.js
+++ b/frontend/site/css.js
@@ -13,3 +13,21 @@ export const SCROLLBAR_CSS = {
     background: "#555",
   },
 };
+
+export const NO_SCROLLBAR_CSS = {
+  "&::-webkit-scrollbar": {
+    width: "0px",
+    background: "transparent",
+  },
+  "&::-webkit-scrollbar-track": {
+    background: "transparent",
+    width: "0px",
+  },
+  "&::-webkit-scrollbar-thumb": {
+    background: "transparent",
+  },
+  "&::-webkit-scrollbar-thumb:hover": {
+    width: "0px",
+    background: "transparent",
+  },
+};

--- a/frontend/site/sidebar/RightSidebarSizer.js
+++ b/frontend/site/sidebar/RightSidebarSizer.js
@@ -1,0 +1,48 @@
+import React from "react";
+import { Box, HStack, IconButton } from "@chakra-ui/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faRightLeft, faCircle } from "@fortawesome/free-solid-svg-icons";
+import { useRightSidebarContext } from "site/sidebar/context";
+import { useSideBarStyle } from "site/sidebar/useSidebarStyle";
+
+const SidebarSizer = () => {
+  const { sizes, isOpen, size, setSize, toggleSidebar } =
+    useRightSidebarContext();
+  const style = useSideBarStyle();
+
+  console.log("sizes", Object.keys(sizes || {}));
+  const sizeMap = {
+    ...Object.fromEntries(sizes),
+  };
+
+  return (
+    <HStack {...style.headerContainer}>
+      <IconButton
+        aria-label="hide"
+        bg={"transparent"}
+        icon={<FontAwesomeIcon icon={faRightLeft} />}
+        size={"xs"}
+        title={"Toggle sidebar"}
+        onClick={toggleSidebar}
+        {...style.header}
+      />
+      />
+      {sizes?.map(([key, _], i) => (
+        <Box
+          key={i}
+          as={"span"}
+          color={size === key ? "green.400" : "gray"}
+          fontSize={8}
+        >
+          <FontAwesomeIcon
+            icon={faCircle}
+            onClick={() => setSize(key)}
+            style={{ cursor: "pointer" }}
+          />
+        </Box>
+      ))}
+    </HStack>
+  );
+};
+
+export default SidebarSizer;

--- a/frontend/site/sidebar/Sidebar.js
+++ b/frontend/site/sidebar/Sidebar.js
@@ -1,0 +1,91 @@
+import React from "react";
+import { Box } from "@chakra-ui/react";
+import {
+  useLeftSidebarContext,
+  useRightSidebarContext,
+} from "site/sidebar/context";
+import RightSidebarSizer from "site/sidebar/RightSidebarSizer";
+import { useSideBarStyle } from "site/sidebar/useSidebarStyle";
+import { NO_SCROLLBAR_CSS } from "site/css";
+
+const TRANSITION_VISIBLE = {
+  opacity: 1,
+  transition: "opacity 0.2s ease-out",
+};
+
+const TRANSITION_HIDDEN = {
+  opacity: 0,
+  transition: "opacity 0.2s ease-out",
+};
+
+/**
+ *
+ * Hook to delay showing content until sidebar is fully open to
+ */
+const useDelayContent = (value, visibleProps, hiddenProps) => {
+  const [isVisible, setVisible] = React.useState(value);
+
+  // Immediately hides content is hidden
+  // Delay showing content if it is visible
+  React.useEffect(() => {
+    if (!value) {
+      setVisible(false);
+    } else {
+      const timer = setTimeout(() => setVisible(true), 300);
+      return () => clearTimeout(timer);
+    }
+  }, [value]);
+
+  const style = isVisible
+    ? visibleProps || TRANSITION_VISIBLE
+    : hiddenProps || TRANSITION_HIDDEN;
+  return { isVisible, style };
+};
+
+const SideBar = ({ position, children }) => {
+  const leftContext = useLeftSidebarContext();
+  const rightContext = useRightSidebarContext();
+
+  const style = useSideBarStyle();
+  const { sizes, isOpen, size } =
+    position === "left" ? leftContext : rightContext;
+  const { style: delayedContentStyle } = useDelayContent(isOpen);
+
+  // convert list of tuples to map
+  const sizeMap = {
+    ...Object.fromEntries(sizes),
+  };
+
+  const sidebarStyle = {
+    width: isOpen ? sizeMap[size] || sizeMap.md : 0,
+    height: "100vh",
+    padding: isOpen ? "0" : "0",
+    position: "fixed",
+    top: "0",
+    overflowY: "auto",
+    zIndex: 10,
+    [position]: "0",
+
+    // add left/right shadow
+    boxShadow: isOpen ? "0 0 10px rgba(0,0,0,0.5)" : "none",
+
+    // no scrollbars
+    scrollbarWidth: "none",
+    msOverflowStyle: "none",
+    "&::WebkitScrollbar": {
+      width: "0 !important",
+      background: "transparent !important",
+    },
+
+    transition: "width 0.2s ease-in",
+  };
+
+  return (
+    <Box style={sidebarStyle} {...style.content} css={NO_SCROLLBAR_CSS}>
+      <RightSidebarSizer />
+      <Box style={delayedContentStyle}>{children}</Box>
+    </Box>
+  );
+};
+
+export default SideBar;

--- a/frontend/site/sidebar/context.js
+++ b/frontend/site/sidebar/context.js
@@ -1,0 +1,93 @@
+import React, { createContext, useState, useContext } from "react";
+
+const SidebarContext = createContext(null);
+
+export const DEFAULT_SIZES_LEFT = [
+  ["icons", "75px"],
+  ["text", "150px"],
+];
+
+export const DEFAULT_SIZES_RIGHT = [
+  ["xl", "650px"],
+  ["lg", "450px"],
+  ["md", "350px"],
+  ["sm", "250px"],
+];
+
+export const DEFAULT_SIZES_RIGHT_ORDER = ["sm", "md", "lg", "xl"];
+
+// Hook for accessing the entire sidebar context
+export const useSidebarContext = () => useContext(SidebarContext);
+
+// Hook for accessing the left sidebar's context
+export const useLeftSidebarContext = () => {
+  const context = useContext(SidebarContext);
+  if (!context) {
+    throw new Error(
+      "useLeftSidebarContext must be used within a SidebarProvider"
+    );
+  }
+  return context.left;
+};
+
+// Hook for accessing the right sidebar's context
+export const useRightSidebarContext = () => {
+  const context = useContext(SidebarContext);
+  if (!context) {
+    throw new Error(
+      "useRightSidebarContext must be used within a SidebarProvider"
+    );
+  }
+  return context.right;
+};
+
+export const SidebarProvider = ({ sizes_left, sizes_right, children }) => {
+  // State for the left sidebar
+  const [isLeftOpen, setLeftIsOpen] = useState(true);
+  const [leftSize, setLeftSize] = useState("icons");
+  const toggleLeftSidebar = () => setLeftIsOpen(!isLeftOpen);
+
+  // State for the right sidebar
+  const [isRightOpen, setRightIsOpen] = useState(true);
+  const [rightSize, setRightSize] = useState("md");
+  const toggleRightSidebar = () => setRightIsOpen(!isRightOpen);
+
+  const leftWidth = isLeftOpen
+    ? sizes_left.find((s) => s[0] === leftSize)[1]
+    : "0px";
+  const rightWidth = isRightOpen
+    ? sizes_right.find((s) => s[0] === rightSize)[1]
+    : "0px";
+
+  return (
+    <SidebarContext.Provider
+      value={{
+        left: {
+          sizes: sizes_left,
+          isOpen: isLeftOpen,
+          size: leftSize,
+          setSize: setLeftSize,
+          width: leftWidth,
+          toggleSidebar: toggleLeftSidebar,
+        },
+        right: {
+          sizes: sizes_right,
+          isOpen: isRightOpen,
+          size: rightSize,
+          setSize: setRightSize,
+          width: rightWidth,
+          toggleSidebar: toggleRightSidebar,
+        },
+      }}
+    >
+      {children}
+    </SidebarContext.Provider>
+  );
+};
+
+SidebarProvider.defaultProps = {
+  sizes_left: DEFAULT_SIZES_LEFT,
+  sizes_right: DEFAULT_SIZES_RIGHT,
+};
+
+export default SidebarProvider;

--- a/frontend/site/sidebar/useSidebarStyle.js
+++ b/frontend/site/sidebar/useSidebarStyle.js
@@ -1,0 +1,38 @@
+import { useColorMode } from "@chakra-ui/color-mode";
+
+export const useSideBarStyle = () => {
+  const { colorMode } = useColorMode();
+  const dark = {
+    header: {
+      color: "gray.500",
+    },
+    headerContainer: {
+      borderBottom: "1px solid",
+      borderColor: "blackAlpha.100",
+      bg: "blackAlpha.400",
+    },
+    content: {
+      bg: "gray.700",
+    },
+    icon: {
+      color: "gray.500",
+    },
+  };
+  const light = {
+    header: {
+      color: "gray.500",
+    },
+    headerContainer: {
+      borderBottom: "1px solid",
+      borderColor: "blackAlpha.200",
+      bg: "blackAlpha.50",
+    },
+    content: {
+      bg: "white",
+    },
+    icon: {
+      color: "gray.400",
+    },
+  };
+  return colorMode === "dark" ? dark : light;
+};


### PR DESCRIPTION
### Description
Implemented a custom `Sidebar` to replace the Chakra `Drawyer` based sidebar. The old sidebar created an overlay that broke scrolling in other components. This new sidebar fixes that.

The new side bar also adds:
- size bubbles for selecting preferred size
- show/hide toggle now preserves selected size
- includes context and hook for managing state of left & right sidebars
- sidebar sizes are customizable.

##### Right Sidebar Sizer
![image](https://github.com/kreneskyp/ix/assets/68635/97e1b717-7463-4167-b442-2def9b1715d9)

##### Full sidebar
![image](https://github.com/kreneskyp/ix/assets/68635/9e781c35-0f3d-4320-b0fa-162193768f23)


### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
