### PR TITLE
Hidden fields are no longer rendered by JSONSchemaForm

### DIFF
--- a/frontend/json_form/JSONSchemaForm.js
+++ b/frontend/json_form/JSONSchemaForm.js
@@ -54,6 +54,11 @@ export const AutoField = ({
   // Select component based on explicit input type, field type, or default in that order.
   const input_key =
     global?.input_type || field.input_type || TYPE_INPUTS[field.type];
+
+  // do not render hidden fields
+  if (input_key === "hidden") {
+    return null;
+  }
   const FieldComponent = INPUTS[input_key] || Input;
   const value = config && name in config ? config[name] : field.default;
 


### PR DESCRIPTION
### Description
Fields with `input_type` hidden are no longer rendered by JSONSchemaForm.  Supports `HashListForm`.

Note that this should be updated later to differentiate between `hidden` and `not_rendered`.

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
