### PR TITLE
Initial isLoading value for usePaginatedAPI is wrong when auto-loading query

### DIFF
--- a/frontend/utils/hooks/usePaginatedAPI.js
+++ b/frontend/utils/hooks/usePaginatedAPI.js
@@ -7,7 +7,7 @@ export function usePaginatedAPI(
   { offset = 0, limit = 10, load = true, loadDependencies = [] } = {}
 ) {
   const [page, setPage] = useState(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(load);
 
   const _load = useCallback(
     async (args = {}) => {


### PR DESCRIPTION


### Description
initial state or `usePaginatedAPI.isLoading` is now based on auto load flag. Fixes some janky display of spinner.

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
