### PR TITLE
Adding full suite of hugging face embeddings

### DIFF
--- a/ix/chains/fixture_src/embeddings.py
+++ b/ix/chains/fixture_src/embeddings.py
@@ -1,3 +1,13 @@
+from langchain.embeddings import (
+    HuggingFaceInstructEmbeddings,
+    HuggingFaceEmbeddings,
+    HuggingFaceInferenceAPIEmbeddings,
+    HuggingFaceBgeEmbeddings,
+    HuggingFaceHubEmbeddings,
+)
+
+from ix.api.components.types import NodeTypeField
+
 OPENAI_EMBEDDINGS_CLASS_PATH = "langchain.embeddings.openai.OpenAIEmbeddings"
 OPENAI_EMBEDDINGS = {
     "name": "OpenAI Embeddings",
@@ -160,43 +170,106 @@ VERTEXAI_EMBEDDINGS = {
     ],
 }
 
+HUGGINGFACE_EMBEDDINGS_CLASS_PATH = (
+    "langchain.embeddings.huggingface.HuggingFaceEmbeddings"
+)
 HUGGINGFACE_EMBEDDINGS = {
-    "class_path": "langchain.embeddings.huggingface.HuggingFaceEmbeddings",
+    "class_path": HUGGINGFACE_EMBEDDINGS_CLASS_PATH,
     "type": "embeddings",
     "name": "HuggingFace Embeddings",
     "description": "HuggingFace Embeddings",
-    "fields": [
-        {
-            "name": "model_name",
-            "label": "Model",
-            "type": "string",
-            "default": "sentence-transformers/all-mpnet-base-v2",
-            "description": "Model name to use",
-            "choices": [
-                {
-                    "label": "all-mpnet-base-v2",
-                    "value": "sentence-transformers/all-mpnet-base-v2",
-                },
-            ],
-            "style": {"width": "100%"},
-        },
-        {
-            "name": "cache_folder",
-            "type": "string",
-            "description": "Path to store models",
-        },
-        {
-            "name": "model_kwargs",
-            "type": "dictionary",
-            "description": "Key word arguments to pass to the model",
-        },
-        {
-            "name": "encode_kwargs",
-            "type": "dictionary",
-            "description": "Key word arguments to pass when calling the `encode` method of the model",
-        },
-    ],
+    "fields": NodeTypeField.get_fields(
+        HuggingFaceEmbeddings,
+        include=[
+            "model_name",
+            "cache_folder",
+            "model_kwargs",
+            "encode_kwargs",
+            "multi_process",
+        ],
+    ),
 }
+
+HUGGINGFACE_INSTRUCT_EMBEDDINGS_CLASS_PATH = (
+    "langchain.embeddings.huggingface.HuggingFaceInstructEmbeddings"
+)
+HUGGINGFACE_INSTRUCT_EMBEDDINGS = {
+    "class_path": HUGGINGFACE_INSTRUCT_EMBEDDINGS_CLASS_PATH,
+    "type": "embeddings",
+    "name": "HuggingFace Instruct Embeddings",
+    "description": "HuggingFace Instruct Embeddings",
+    "fields": NodeTypeField.get_fields(
+        HuggingFaceInstructEmbeddings,
+        include=[
+            "model_name",
+            "cache_folder",
+            "encode_kwargs",
+            "embed_instruction",
+            "query_instruction",
+        ],
+    ),
+}
+
+HUGGINGFACE_BGE_EMBEDDINGS_CLASS_PATH = (
+    "langchain.embeddings.huggingface.HuggingFaceBgeEmbeddings"
+)
+HUGGINGFACE_BGE_EMBEDDINGS = {
+    "class_path": HUGGINGFACE_BGE_EMBEDDINGS_CLASS_PATH,
+    "type": "embeddings",
+    "name": "HuggingFace BGE Embeddings",
+    "description": "HuggingFace BGE Embeddings",
+    "fields": NodeTypeField.get_fields(
+        HuggingFaceBgeEmbeddings,
+        include=[
+            "model_name",
+            "cache_folder",
+            "model_kwargs",
+            "encode_kwargs",
+            "query_instruction",
+        ],
+    ),
+}
+
+
+HUGGINGFACE_INFERENCE_API_EMBEDDINGS_CLASS_PATH = (
+    "langchain.embeddings.huggingface.HuggingFaceInferenceAPIEmbeddings"
+)
+HUGGINGFACE_INFERENCE_API_EMBEDDINGS = {
+    "class_path": HUGGINGFACE_INFERENCE_API_EMBEDDINGS_CLASS_PATH,
+    "type": "embeddings",
+    "name": "HuggingFace Inference API Embeddings",
+    "description": "HuggingFace Inference API Embeddings",
+    "fields": NodeTypeField.get_fields(
+        HuggingFaceInferenceAPIEmbeddings,
+        include=["api_key", "model_name"],
+        field_options={
+            "api_key": {
+                "input_type": "secret",
+            }
+        },
+    ),
+}
+
+
+HUGGINGFACE_HUB_EMBEDDINGS_CLASS_PATH = (
+    "langchain.embeddings.huggingface_hub.HuggingFaceHubEmbeddings"
+)
+HUGGINGFACE_HUB_EMBEDDINGS = {
+    "class_path": HUGGINGFACE_HUB_EMBEDDINGS_CLASS_PATH,
+    "type": "embeddings",
+    "name": "HuggingFace Hub Embeddings",
+    "description": "HuggingFace Hub Embeddings",
+    "fields": NodeTypeField.get_fields(
+        HuggingFaceHubEmbeddings,
+        include=["repo_id", "huggingfacehub_api_token", "task", "model_kwargs"],
+        field_options={
+            "huggingfacehub_api_token": {
+                "input_type": "secret",
+            }
+        },
+    ),
+}
+
 
 MOSAICML_INSTRUCTOR_EMBEDDINGS = {
     "class_path": "langchain.embeddings.mosaicml.MosaicMLInstructorEmbeddings",
@@ -238,3 +311,16 @@ MOSAICML_INSTRUCTOR_EMBEDDINGS = {
         },
     ],
 }
+
+EMBEDDINGS = [
+    OPENAI_EMBEDDINGS,
+    GOOGLE_PALM_EMBEDDINGS,
+    LLAMA_CPP_EMBEDDINGS,
+    VERTEXAI_EMBEDDINGS,
+    HUGGINGFACE_EMBEDDINGS,
+    HUGGINGFACE_INSTRUCT_EMBEDDINGS,
+    HUGGINGFACE_BGE_EMBEDDINGS,
+    HUGGINGFACE_INFERENCE_API_EMBEDDINGS,
+    HUGGINGFACE_HUB_EMBEDDINGS,
+    MOSAICML_INSTRUCTOR_EMBEDDINGS,
+]

--- a/ix/chains/management/commands/import_langchain.py
+++ b/ix/chains/management/commands/import_langchain.py
@@ -12,14 +12,7 @@ from ix.chains.fixture_src.chat_memory_backend import (
 )
 from ix.chains.fixture_src.dalle import DALLE
 from ix.chains.fixture_src.document_loaders import DOCUMENT_LOADERS
-from ix.chains.fixture_src.embeddings import (
-    OPENAI_EMBEDDINGS,
-    GOOGLE_PALM_EMBEDDINGS,
-    LLAMA_CPP_EMBEDDINGS,
-    VERTEXAI_EMBEDDINGS,
-    HUGGINGFACE_EMBEDDINGS,
-    MOSAICML_INSTRUCTOR_EMBEDDINGS,
-)
+from ix.chains.fixture_src.embeddings import EMBEDDINGS
 from ix.chains.fixture_src.ix import CHAT_MODERATOR_TYPE
 from ix.chains.fixture_src.llm import LLMS
 from ix.chains.fixture_src.memory import (
@@ -48,16 +41,7 @@ from ix.secrets.models import SecretType
 COMPONENTS = []
 
 # Embeddings
-COMPONENTS.extend(
-    [
-        OPENAI_EMBEDDINGS,
-        GOOGLE_PALM_EMBEDDINGS,
-        LLAMA_CPP_EMBEDDINGS,
-        VERTEXAI_EMBEDDINGS,
-        HUGGINGFACE_EMBEDDINGS,
-        MOSAICML_INSTRUCTOR_EMBEDDINGS,
-    ]
-)
+COMPONENTS.extend(EMBEDDINGS)
 
 # Agents
 COMPONENTS.extend(AGENTS)

--- a/ix/chains/tests/components/test_embeddings.py
+++ b/ix/chains/tests/components/test_embeddings.py
@@ -1,0 +1,75 @@
+import pytest
+from langchain.embeddings import (
+    HuggingFaceEmbeddings,
+    HuggingFaceBgeEmbeddings,
+    HuggingFaceInstructEmbeddings,
+    HuggingFaceHubEmbeddings,
+    HuggingFaceInferenceAPIEmbeddings,
+)
+
+from ix.chains.fixture_src.embeddings import (
+    HUGGINGFACE_EMBEDDINGS_CLASS_PATH,
+    HUGGINGFACE_INSTRUCT_EMBEDDINGS_CLASS_PATH,
+    HUGGINGFACE_BGE_EMBEDDINGS_CLASS_PATH,
+    HUGGINGFACE_INFERENCE_API_EMBEDDINGS_CLASS_PATH,
+    HUGGINGFACE_HUB_EMBEDDINGS_CLASS_PATH,
+)
+
+
+@pytest.mark.skip(reason="dependencies not installed by default")
+@pytest.mark.django_db
+class TestHugggingFaceEmbeddings:
+    """Smoke tests for HuggingFace Embeddings."""
+
+    async def test_huggingface_embeddings(self, aload_chain):
+        config = {
+            "class_path": HUGGINGFACE_EMBEDDINGS_CLASS_PATH,
+            "config": {},
+        }
+
+        component = await aload_chain(config)
+        assert isinstance(component, HuggingFaceEmbeddings)
+
+    async def test_huggingface_instruct_embeddings(self, aload_chain):
+        config = {
+            "class_path": HUGGINGFACE_INSTRUCT_EMBEDDINGS_CLASS_PATH,
+            "config": {},
+        }
+
+        component = await aload_chain(config)
+        assert isinstance(component, HuggingFaceInstructEmbeddings)
+
+    async def test_huggingface_bge_embeddings(self, aload_chain):
+        config = {
+            "class_path": HUGGINGFACE_BGE_EMBEDDINGS_CLASS_PATH,
+            "config": {},
+        }
+
+        component = await aload_chain(config)
+        assert isinstance(component, HuggingFaceBgeEmbeddings)
+
+    async def test_huggingface_inference_api_embeddings(
+        self, aload_chain, mock_config_secrets
+    ):
+        config = {
+            "class_path": HUGGINGFACE_INFERENCE_API_EMBEDDINGS_CLASS_PATH,
+            "config": {
+                "api_key": "fake_key",
+            },
+        }
+        config = await mock_config_secrets(config, ["api_key"])
+
+        component = await aload_chain(config)
+        assert isinstance(component, HuggingFaceInferenceAPIEmbeddings)
+
+    async def test_huggingface_hub_embeddings(self, aload_chain, mock_config_secrets):
+        config = {
+            "class_path": HUGGINGFACE_HUB_EMBEDDINGS_CLASS_PATH,
+            "config": {
+                "huggingfacehub_api_token": "fake_token",
+            },
+        }
+
+        config = await mock_config_secrets(config, ["huggingfacehub_api_token"])
+        component = await aload_chain(config)
+        assert isinstance(component, HuggingFaceHubEmbeddings)

--- a/test_data/snapshots/components/langchain.embeddings.huggingface.HuggingFaceBgeEmbeddings.json
+++ b/test_data/snapshots/components/langchain.embeddings.huggingface.HuggingFaceBgeEmbeddings.json
@@ -1,0 +1,118 @@
+{
+    "child_field": null,
+    "class_path": "langchain.embeddings.huggingface.HuggingFaceBgeEmbeddings",
+    "config_schema": {
+        "display_groups": null,
+        "properties": {
+            "cache_folder": {
+                "type": "string"
+            },
+            "encode_kwargs": {
+                "type": "object"
+            },
+            "model_kwargs": {
+                "type": "object"
+            },
+            "model_name": {
+                "default": "BAAI/bge-large-en",
+                "type": "string"
+            },
+            "query_instruction": {
+                "default": "Represent this question for searching relevant passages: ",
+                "type": "string"
+            }
+        },
+        "required": [
+            "model_kwargs",
+            "encode_kwargs"
+        ],
+        "type": "object"
+    },
+    "connectors": null,
+    "description": "HuggingFace BGE Embeddings",
+    "display_type": "node",
+    "fields": [
+        {
+            "choices": null,
+            "default": "BAAI/bge-large-en",
+            "description": null,
+            "input_type": null,
+            "label": "Model_name",
+            "max": null,
+            "min": null,
+            "name": "model_name",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "str"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Cache_folder",
+            "max": null,
+            "min": null,
+            "name": "cache_folder",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "str"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Model_kwargs",
+            "max": null,
+            "min": null,
+            "name": "model_kwargs",
+            "parent": null,
+            "required": true,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "Dict"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Encode_kwargs",
+            "max": null,
+            "min": null,
+            "name": "encode_kwargs",
+            "parent": null,
+            "required": true,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "Dict"
+        },
+        {
+            "choices": null,
+            "default": "Represent this question for searching relevant passages: ",
+            "description": null,
+            "input_type": null,
+            "label": "Query_instruction",
+            "max": null,
+            "min": null,
+            "name": "query_instruction",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "str"
+        }
+    ],
+    "name": "HuggingFace BGE Embeddings",
+    "type": "embeddings"
+}

--- a/test_data/snapshots/components/langchain.embeddings.huggingface.HuggingFaceEmbeddings.json
+++ b/test_data/snapshots/components/langchain.embeddings.huggingface.HuggingFaceEmbeddings.json
@@ -5,30 +5,27 @@
         "display_groups": null,
         "properties": {
             "cache_folder": {
-                "description": "Path to store models",
                 "type": "string"
             },
             "encode_kwargs": {
-                "description": "Key word arguments to pass when calling the `encode` method of the model",
                 "type": "object"
             },
             "model_kwargs": {
-                "description": "Key word arguments to pass to the model",
                 "type": "object"
             },
             "model_name": {
                 "default": "sentence-transformers/all-mpnet-base-v2",
-                "description": "Model name to use",
-                "enum": [
-                    "sentence-transformers/all-mpnet-base-v2"
-                ],
-                "style": {
-                    "width": "100%"
-                },
                 "type": "string"
+            },
+            "multi_process": {
+                "default": false,
+                "type": "boolean"
             }
         },
-        "required": [],
+        "required": [
+            "model_kwargs",
+            "encode_kwargs"
+        ],
         "type": "object"
     },
     "connectors": null,
@@ -36,16 +33,11 @@
     "display_type": "node",
     "fields": [
         {
-            "choices": [
-                {
-                    "label": "all-mpnet-base-v2",
-                    "value": "sentence-transformers/all-mpnet-base-v2"
-                }
-            ],
+            "choices": null,
             "default": "sentence-transformers/all-mpnet-base-v2",
-            "description": "Model name to use",
+            "description": null,
             "input_type": null,
-            "label": "Model",
+            "label": "Model_name",
             "max": null,
             "min": null,
             "name": "model_name",
@@ -53,17 +45,15 @@
             "required": false,
             "secret_key": null,
             "step": null,
-            "style": {
-                "width": "100%"
-            },
-            "type": "string"
+            "style": null,
+            "type": "str"
         },
         {
             "choices": null,
             "default": null,
-            "description": "Path to store models",
+            "description": null,
             "input_type": null,
-            "label": "",
+            "label": "Cache_folder",
             "max": null,
             "min": null,
             "name": "cache_folder",
@@ -72,39 +62,55 @@
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "string"
+            "type": "str"
         },
         {
             "choices": null,
             "default": null,
-            "description": "Key word arguments to pass to the model",
+            "description": null,
             "input_type": null,
-            "label": "",
+            "label": "Model_kwargs",
             "max": null,
             "min": null,
             "name": "model_kwargs",
             "parent": null,
-            "required": false,
+            "required": true,
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "dictionary"
+            "type": "Dict"
         },
         {
             "choices": null,
             "default": null,
-            "description": "Key word arguments to pass when calling the `encode` method of the model",
+            "description": null,
             "input_type": null,
-            "label": "",
+            "label": "Encode_kwargs",
             "max": null,
             "min": null,
             "name": "encode_kwargs",
+            "parent": null,
+            "required": true,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "Dict"
+        },
+        {
+            "choices": null,
+            "default": false,
+            "description": null,
+            "input_type": null,
+            "label": "Multi_process",
+            "max": null,
+            "min": null,
+            "name": "multi_process",
             "parent": null,
             "required": false,
             "secret_key": null,
             "step": null,
             "style": null,
-            "type": "dictionary"
+            "type": "boolean"
         }
     ],
     "name": "HuggingFace Embeddings",

--- a/test_data/snapshots/components/langchain.embeddings.huggingface.HuggingFaceInferenceAPIEmbeddings.json
+++ b/test_data/snapshots/components/langchain.embeddings.huggingface.HuggingFaceInferenceAPIEmbeddings.json
@@ -1,0 +1,60 @@
+{
+    "child_field": null,
+    "class_path": "langchain.embeddings.huggingface.HuggingFaceInferenceAPIEmbeddings",
+    "config_schema": {
+        "display_groups": null,
+        "properties": {
+            "api_key": {
+                "input_type": "secret",
+                "type": "string"
+            },
+            "model_name": {
+                "default": "sentence-transformers/all-MiniLM-L6-v2",
+                "type": "string"
+            }
+        },
+        "required": [
+            "api_key"
+        ],
+        "type": "object"
+    },
+    "connectors": null,
+    "description": "HuggingFace Inference API Embeddings",
+    "display_type": "node",
+    "fields": [
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": "secret",
+            "label": "Api_key",
+            "max": null,
+            "min": null,
+            "name": "api_key",
+            "parent": null,
+            "required": true,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "str"
+        },
+        {
+            "choices": null,
+            "default": "sentence-transformers/all-MiniLM-L6-v2",
+            "description": null,
+            "input_type": null,
+            "label": "Model_name",
+            "max": null,
+            "min": null,
+            "name": "model_name",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "str"
+        }
+    ],
+    "name": "HuggingFace Inference API Embeddings",
+    "type": "embeddings"
+}

--- a/test_data/snapshots/components/langchain.embeddings.huggingface.HuggingFaceInstructEmbeddings.json
+++ b/test_data/snapshots/components/langchain.embeddings.huggingface.HuggingFaceInstructEmbeddings.json
@@ -1,0 +1,118 @@
+{
+    "child_field": null,
+    "class_path": "langchain.embeddings.huggingface.HuggingFaceInstructEmbeddings",
+    "config_schema": {
+        "display_groups": null,
+        "properties": {
+            "cache_folder": {
+                "type": "string"
+            },
+            "embed_instruction": {
+                "default": "Represent the document for retrieval: ",
+                "type": "string"
+            },
+            "encode_kwargs": {
+                "type": "object"
+            },
+            "model_name": {
+                "default": "hkunlp/instructor-large",
+                "type": "string"
+            },
+            "query_instruction": {
+                "default": "Represent the question for retrieving supporting documents: ",
+                "type": "string"
+            }
+        },
+        "required": [
+            "encode_kwargs"
+        ],
+        "type": "object"
+    },
+    "connectors": null,
+    "description": "HuggingFace Instruct Embeddings",
+    "display_type": "node",
+    "fields": [
+        {
+            "choices": null,
+            "default": "hkunlp/instructor-large",
+            "description": null,
+            "input_type": null,
+            "label": "Model_name",
+            "max": null,
+            "min": null,
+            "name": "model_name",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "str"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Cache_folder",
+            "max": null,
+            "min": null,
+            "name": "cache_folder",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "str"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Encode_kwargs",
+            "max": null,
+            "min": null,
+            "name": "encode_kwargs",
+            "parent": null,
+            "required": true,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "Dict"
+        },
+        {
+            "choices": null,
+            "default": "Represent the document for retrieval: ",
+            "description": null,
+            "input_type": null,
+            "label": "Embed_instruction",
+            "max": null,
+            "min": null,
+            "name": "embed_instruction",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "str"
+        },
+        {
+            "choices": null,
+            "default": "Represent the question for retrieving supporting documents: ",
+            "description": null,
+            "input_type": null,
+            "label": "Query_instruction",
+            "max": null,
+            "min": null,
+            "name": "query_instruction",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "str"
+        }
+    ],
+    "name": "HuggingFace Instruct Embeddings",
+    "type": "embeddings"
+}

--- a/test_data/snapshots/components/langchain.embeddings.huggingface_hub.HuggingFaceHubEmbeddings.json
+++ b/test_data/snapshots/components/langchain.embeddings.huggingface_hub.HuggingFaceHubEmbeddings.json
@@ -1,0 +1,97 @@
+{
+    "child_field": null,
+    "class_path": "langchain.embeddings.huggingface_hub.HuggingFaceHubEmbeddings",
+    "config_schema": {
+        "display_groups": null,
+        "properties": {
+            "huggingfacehub_api_token": {
+                "input_type": "secret",
+                "type": "string"
+            },
+            "model_kwargs": {
+                "type": "object"
+            },
+            "repo_id": {
+                "default": "sentence-transformers/all-mpnet-base-v2",
+                "type": "string"
+            },
+            "task": {
+                "default": "feature-extraction",
+                "type": "string"
+            }
+        },
+        "required": [],
+        "type": "object"
+    },
+    "connectors": null,
+    "description": "HuggingFace Hub Embeddings",
+    "display_type": "node",
+    "fields": [
+        {
+            "choices": null,
+            "default": "sentence-transformers/all-mpnet-base-v2",
+            "description": null,
+            "input_type": null,
+            "label": "Repo_id",
+            "max": null,
+            "min": null,
+            "name": "repo_id",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "str"
+        },
+        {
+            "choices": null,
+            "default": "feature-extraction",
+            "description": null,
+            "input_type": null,
+            "label": "Task",
+            "max": null,
+            "min": null,
+            "name": "task",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "str"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": null,
+            "label": "Model_kwargs",
+            "max": null,
+            "min": null,
+            "name": "model_kwargs",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "dict"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "input_type": "secret",
+            "label": "Huggingfacehub_api_token",
+            "max": null,
+            "min": null,
+            "name": "huggingfacehub_api_token",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "str"
+        }
+    ],
+    "name": "HuggingFace Hub Embeddings",
+    "type": "embeddings"
+}


### PR DESCRIPTION

### Description
Adding full suite of hugging face embeddings: normal, instruct, bge, inference api, hub.

Note that these are only available when running locally with libraries manually installed. The embeddings require CUDA, PyTorch and a few other external libs that require >400mb of space. 

![image](https://github.com/kreneskyp/ix/assets/68635/21f30937-57b0-4e51-a7e0-476efe685cce)

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
