### PR TITLE
Adding postgres chat memory backend

### DIFF
--- a/ix/chains/fixture_src/chat_memory_backend.py
+++ b/ix/chains/fixture_src/chat_memory_backend.py
@@ -1,4 +1,4 @@
-from ix.chains.fixture_src.memory import SCOPED_MEMORY_FIELDS
+from ix.chains.fixture_src.memory import SCOPED_MEMORY_FIELDS, SCOPED_MEMORY_FIELD_GROUP
 
 REDIS_MEMORY_BACKEND = {
     "class_path": "langchain.memory.RedisChatMessageHistory",
@@ -36,3 +36,43 @@ FILESYSTEM_MEMORY_BACKEND = {
         },
     ],
 }
+
+
+POSTGRES_CHAT_HISTORY_CLASS_PATH = (
+    "langchain.memory.chat_message_histories.postgres.PostgresChatMessageHistory"
+)
+POSTGRES_CHAT_HISTORY = {
+    "class_path": POSTGRES_CHAT_HISTORY_CLASS_PATH,
+    "type": "memory_backend",
+    "name": "Postgres Chat History",
+    "description": "Stores chat history in a Postgres database",
+    "display_groups": [
+        {
+            "key": "Database",
+            "fields": ["connection_string", "table_name"],
+        },
+        SCOPED_MEMORY_FIELD_GROUP,
+    ],
+    "fields": [
+        {
+            "name": "connection_string",
+            "label": "Connection String",
+            "type": "string",
+            "default": "postgresql://ix:ix@db:5432/ix",
+            "style": {"width": "100%"},
+        },
+        {
+            "name": "table_name",
+            "type": "string",
+            "default": "message_store",
+            "style": {"width": "100%"},
+        },
+    ]
+    + SCOPED_MEMORY_FIELDS,
+}
+
+MEMORY_BACKEND = [
+    REDIS_MEMORY_BACKEND,
+    FILESYSTEM_MEMORY_BACKEND,
+    POSTGRES_CHAT_HISTORY,
+]

--- a/ix/chains/fixture_src/memory.py
+++ b/ix/chains/fixture_src/memory.py
@@ -27,7 +27,6 @@ SCOPED_MEMORY_FIELDS = [
         "name": "session_scope",
         "label": "Session Scope",
         "type": "string",
-
         "input_type": "select",
         "choices": [
             {"label": "chat", "value": "chat"},
@@ -41,7 +40,7 @@ SCOPED_MEMORY_FIELDS = [
         "name": "session_prefix",
         "label": "Session Prefix",
         "description": "prefix applied to the session ID. e.g. 'chat' will result in 'chat:session_id'."
-                      "Chains with the same scope and prefix will share the same session.",
+        "Chains with the same scope and prefix will share the same session.",
         "type": "string",
         "default": "",
         "style": {"width": "100%"},

--- a/ix/chains/fixture_src/memory.py
+++ b/ix/chains/fixture_src/memory.py
@@ -25,7 +25,9 @@ AI_PREFIX = {
 SCOPED_MEMORY_FIELDS = [
     {
         "name": "session_scope",
+        "label": "Session Scope",
         "type": "string",
+
         "input_type": "select",
         "choices": [
             {"label": "chat", "value": "chat"},
@@ -33,18 +35,30 @@ SCOPED_MEMORY_FIELDS = [
             {"label": "task", "value": "task"},
             {"label": "user", "value": "user"},
         ],
+        "style": {"width": "100%"},
     },
     {
         "name": "session_prefix",
+        "label": "Session Prefix",
+        "description": "prefix applied to the session ID. e.g. 'chat' will result in 'chat:session_id'."
+                      "Chains with the same scope and prefix will share the same session.",
         "type": "string",
         "default": "",
+        "style": {"width": "100%"},
     },
     {
         "name": "session_key",
+        "label": "Session Key",
+        "description": "component session will be initialized with this argument.",
         "type": "string",
         "default": "session_id",
+        "style": {"width": "100%"},
     },
 ]
+SCOPED_MEMORY_FIELD_GROUP = {
+    "key": "Session",
+    "fields": ["session_scope", "session_prefix", "session_key"],
+}
 
 
 CHAT_MEMORY_FIELDS = [

--- a/ix/chains/management/commands/import_langchain.py
+++ b/ix/chains/management/commands/import_langchain.py
@@ -6,11 +6,8 @@ from ix.chains.fixture_src.agent_interaction import AGENT_INTERACTION_CHAINS
 from ix.chains.fixture_src.agents import AGENTS
 from ix.chains.fixture_src.artifacts import ARTIFACT_MEMORY, SAVE_ARTIFACT
 from ix.chains.fixture_src.chains import CHAINS
-from ix.chains.fixture_src.chat_memory_backend import (
-    FILESYSTEM_MEMORY_BACKEND,
-    REDIS_MEMORY_BACKEND,
-)
 from ix.chains.fixture_src.dalle import DALLE
+from ix.chains.fixture_src.chat_memory_backend import MEMORY_BACKEND
 from ix.chains.fixture_src.document_loaders import DOCUMENT_LOADERS
 from ix.chains.fixture_src.embeddings import (
     OPENAI_EMBEDDINGS,
@@ -97,14 +94,7 @@ COMPONENTS.extend(
         CONVERSATION_TOKEN_BUFFER_MEMORY,
     ]
 )
-
-# Memory Backends
-COMPONENTS.extend(
-    [
-        REDIS_MEMORY_BACKEND,
-        FILESYSTEM_MEMORY_BACKEND,
-    ]
-)
+COMPONENTS.extend(MEMORY_BACKEND)
 
 # Document retrieval
 COMPONENTS.extend(PARSERS)

--- a/test_data/snapshots/components/langchain.memory.chat_message_histories.postgres.PostgresChatMessageHistory.json
+++ b/test_data/snapshots/components/langchain.memory.chat_message_histories.postgres.PostgresChatMessageHistory.json
@@ -1,9 +1,34 @@
 {
     "child_field": null,
-    "class_path": "langchain.memory.RedisChatMessageHistory",
+    "class_path": "langchain.memory.chat_message_histories.postgres.PostgresChatMessageHistory",
     "config_schema": {
-        "display_groups": null,
+        "display_groups": [
+            {
+                "fields": [
+                    "connection_string",
+                    "table_name"
+                ],
+                "key": "Database",
+                "label": null
+            },
+            {
+                "fields": [
+                    "session_scope",
+                    "session_prefix",
+                    "session_key"
+                ],
+                "key": "Session",
+                "label": null
+            }
+        ],
         "properties": {
+            "connection_string": {
+                "default": "postgresql://ix:ix@db:5432/ix",
+                "style": {
+                    "width": "100%"
+                },
+                "type": "string"
+            },
             "session_key": {
                 "default": "session_id",
                 "description": "component session will be initialized with this argument.",
@@ -33,12 +58,8 @@
                 },
                 "type": "string"
             },
-            "ttl": {
-                "default": 3600,
-                "type": "number"
-            },
-            "url": {
-                "default": "redis://redis:6379/0",
+            "table_name": {
+                "default": "message_store",
                 "style": {
                     "width": "100%"
                 },
@@ -49,18 +70,18 @@
         "type": "object"
     },
     "connectors": null,
-    "description": "Redis Memory Backend",
+    "description": "Stores chat history in a Postgres database",
     "display_type": "node",
     "fields": [
         {
             "choices": null,
-            "default": "redis://redis:6379/0",
+            "default": "postgresql://ix:ix@db:5432/ix",
             "description": null,
             "input_type": null,
-            "label": "",
+            "label": "Connection String",
             "max": null,
             "min": null,
-            "name": "url",
+            "name": "connection_string",
             "parent": null,
             "required": false,
             "secret_key": null,
@@ -72,19 +93,21 @@
         },
         {
             "choices": null,
-            "default": 3600,
+            "default": "message_store",
             "description": null,
             "input_type": null,
             "label": "",
             "max": null,
             "min": null,
-            "name": "ttl",
+            "name": "table_name",
             "parent": null,
             "required": false,
             "secret_key": null,
             "step": null,
-            "style": null,
-            "type": "number"
+            "style": {
+                "width": "100%"
+            },
+            "type": "string"
         },
         {
             "choices": [
@@ -158,6 +181,6 @@
             "type": "string"
         }
     ],
-    "name": "Redis Memory Backend",
+    "name": "Postgres Chat History",
     "type": "memory_backend"
 }


### PR DESCRIPTION
### Description
Adding a postgres chat memory backend.  Use with chain/agent style memory connector or with upcoming `LoadMemories` flow style node.

![image](https://github.com/kreneskyp/ix/assets/68635/dfc740d2-4a60-4e0a-bc95-452193f901f4)
![image](https://github.com/kreneskyp/ix/assets/68635/ae930fa6-5650-4aea-8c90-dc30d777ed0d)
![image](https://github.com/kreneskyp/ix/assets/68635/62eae9c1-771f-4f76-a7a7-3ea60a6df1d4)


### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
