### PR TITLE
Improving artifact components

### DIFF
--- a/ix/chains/fixture_src/artifacts.py
+++ b/ix/chains/fixture_src/artifacts.py
@@ -136,10 +136,38 @@ RUNNABLE_LOAD_ARTIFACTS = {
     ),
 }
 
+LOAD_FILE_CLASS_PATH = "ix.runnable.artifacts.LoadFile"
+LOAD_FILE = {
+    "class_path": LOAD_FILE_CLASS_PATH,
+    "type": "chain",
+    "name": "Load file",
+    "description": "Loads a file from the filesystem",
+}
+
+ENCODE_IMAGE_CLASS_PATH = "ix.runnable.artifacts.EncodeImage"
+ENCODE_IMAGE = {
+    "class_path": ENCODE_IMAGE_CLASS_PATH,
+    "type": "chain",
+    "name": "Encode Image",
+    "description": "Prepare an image for image prompt",
+}
+
+
+LOAD_IMAGE_ARTIFACT_CLASS_PATH = "ix.runnable.artifacts.get_load_image_artifact"
+LOAD_IMAGE_ARTIFACT = {
+    "class_path": LOAD_IMAGE_ARTIFACT_CLASS_PATH,
+    "type": "chain",
+    "name": "Load Image Artifact",
+    "description": "Loads an image from an artifact.",
+}
+
 
 ARTIFACTS = [
     ARTIFACT_MEMORY,
     SAVE_ARTIFACT,
     RUNNABLE_SAVE_ARTIFACT,
     RUNNABLE_LOAD_ARTIFACTS,
+    LOAD_FILE,
+    ENCODE_IMAGE,
+    LOAD_IMAGE_ARTIFACT,
 ]

--- a/ix/commands/filesystem.py
+++ b/ix/commands/filesystem.py
@@ -9,6 +9,11 @@ from asgiref.sync import sync_to_async
 WORKDIR = Path("/var/app/workdir")
 
 
+def get_work_dir() -> Path:
+    """Returns the path to the workdir."""
+    return WORKDIR
+
+
 def create_file_path(file_path):
     """
     Creates the file path if it does not exist.

--- a/ix/runnable/base.py
+++ b/ix/runnable/base.py
@@ -1,0 +1,24 @@
+from typing import Optional, Any, AsyncIterator
+
+from langchain_core.runnables import RunnableConfig
+from langchain_core.runnables.utils import Input, Output
+
+
+class StreamableTransform:
+    """
+    Mixin to make a runnable that proxies streaming to it's transform method.
+    """
+
+    async def astream(
+        self,
+        input: Input,
+        config: Optional[RunnableConfig] = None,
+        **kwargs: Optional[Any],
+    ) -> AsyncIterator[Output]:
+        """proxy to atransform"""
+
+        async def input_aiter() -> AsyncIterator[Input]:
+            yield input
+
+        async for chunk in self.atransform(input_aiter(), config, **kwargs):
+            yield chunk

--- a/ix/runnable/dalle.py
+++ b/ix/runnable/dalle.py
@@ -11,6 +11,10 @@ NO_EXTRA_DETAIL = """I NEED to test how the tool works with extremely simple pro
     DO NOT add any detail, just use it AS-IS:"""
 
 
+DalleSizes = Literal["256x256", "512x512", "1024x1024", "1792x1024", "1024x1792"]
+DefaultDefaultSize = "1024x1024"
+
+
 class DalleImage(RunnableSerializable[Input, List[str]]):
     """
     Generate an image with Dalle API
@@ -21,9 +25,7 @@ class DalleImage(RunnableSerializable[Input, List[str]]):
     model: str = "dall-e-3"
     n: int = 1
     """Number of images to generate"""
-    size: Optional[
-        Literal["256x256", "512x512", "1024x1024", "1792x1024", "1024x1792"]
-    ] = "1024x1024"
+    size: Optional[DalleSizes] = DefaultDefaultSize
     """Size of image to generate"""
     quality: Literal["standard", "hd"] = "standard"
     separator: str = "\n"

--- a/ix/runnable/tests/conftest.py
+++ b/ix/runnable/tests/conftest.py
@@ -1,0 +1,42 @@
+import dataclasses
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+
+@dataclasses.dataclass
+class MockFilesystem:
+    workdir: Path
+    write_file: Callable[[str, str], None]
+    read_file: Callable[[str], str]
+    fake_file: Callable[[str], Path]
+
+
+@pytest.fixture()
+def mock_filesystem(mocker, tmp_path):
+    """Mock filesystem backend"""
+
+    def write_file(path, data):
+        with open(tmp_path / path, "w") as f:
+            f.write(data)
+
+    def read_file(path):
+        with open(tmp_path / path) as f:
+            return f.read()
+
+    def fake_file(path=None):
+        path = path or "test.txt"
+        write_file(path, "this is mock content")
+        return tmp_path / path
+
+    mocker.patch("ix.runnable.artifacts.write_to_file", side_effect=write_file)
+    # mocker.patch("ix.runnable.artifacts.read_file", side_effect=read_file)
+    mocker.patch("ix.runnable.artifacts.get_work_dir", return_value=tmp_path)
+
+    yield MockFilesystem(
+        workdir=tmp_path,
+        write_file=write_file,
+        read_file=read_file,
+        fake_file=fake_file,
+    )

--- a/test_data/snapshots/components/ix.runnable.artifacts.EncodeImage.json
+++ b/test_data/snapshots/components/ix.runnable.artifacts.EncodeImage.json
@@ -1,0 +1,16 @@
+{
+    "child_field": null,
+    "class_path": "ix.runnable.artifacts.EncodeImage",
+    "config_schema": {
+        "display_groups": null,
+        "properties": {},
+        "required": [],
+        "type": "object"
+    },
+    "connectors": null,
+    "description": "Prepare an image for image prompt",
+    "display_type": "node",
+    "fields": null,
+    "name": "Encode Image",
+    "type": "chain"
+}

--- a/test_data/snapshots/components/ix.runnable.artifacts.LoadFile.json
+++ b/test_data/snapshots/components/ix.runnable.artifacts.LoadFile.json
@@ -1,0 +1,16 @@
+{
+    "child_field": null,
+    "class_path": "ix.runnable.artifacts.LoadFile",
+    "config_schema": {
+        "display_groups": null,
+        "properties": {},
+        "required": [],
+        "type": "object"
+    },
+    "connectors": null,
+    "description": "Loads a file from the filesystem",
+    "display_type": "node",
+    "fields": null,
+    "name": "Load file",
+    "type": "chain"
+}

--- a/test_data/snapshots/components/ix.runnable.artifacts.get_load_image_artifact.json
+++ b/test_data/snapshots/components/ix.runnable.artifacts.get_load_image_artifact.json
@@ -1,0 +1,16 @@
+{
+    "child_field": null,
+    "class_path": "ix.runnable.artifacts.get_load_image_artifact",
+    "config_schema": {
+        "display_groups": null,
+        "properties": {},
+        "required": [],
+        "type": "object"
+    },
+    "connectors": null,
+    "description": "Loads an image from an artifact.",
+    "display_type": "node",
+    "fields": null,
+    "name": "Load Image Artifact",
+    "type": "chain"
+}


### PR DESCRIPTION


### Description
Improving artifact components, working towards multi-modal prompts. This 

- adding LoadFile for loading a file from the filesystem working directory,
- adding EncodeImage to resize and base64 encode images to prepare them for usage in a prompt
- LoadArtifacts no longer reads the file, chain with LoadFile to load the file.

##### target multi-modal flow
![image](https://github.com/kreneskyp/ix/assets/68635/d0efe96d-7204-4e29-b277-6c03907c9cdc)

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
