### PR TITLE
Chat messages now include artifact_ids

### DIFF
--- a/frontend/chat/hooks/useSendInput.js
+++ b/frontend/chat/hooks/useSendInput.js
@@ -7,10 +7,11 @@ export const useSendInput = (chat_id) => {
   const url = `/api/chats/${chat_id}/messages`;
 
   const sendInput = useCallback(
-    async (text) => {
+    async (text, artifact_ids) => {
       const data = {
         chat_id: chat_id,
         text: text,
+        artifact_ids: artifact_ids || []
       };
 
       setIsLoading(true);

--- a/frontend/chat/input/ChatInput.js
+++ b/frontend/chat/input/ChatInput.js
@@ -187,6 +187,7 @@ const insertHighlight = (type, editor, object) => {
     type,
     display: type === "mention" ? object.alias : object.key,
     children: [{ text: "" }],
+    object
   };
   Transforms.insertNodes(editor, highlight);
   Transforms.move(editor);

--- a/ix/api/chats/endpoints.py
+++ b/ix/api/chats/endpoints.py
@@ -266,6 +266,7 @@ async def send_message(
         content=UserFeedback(
             type="FEEDBACK",
             feedback=text,
+            artifact_ids=artifact_ids,
         ),
     )
 

--- a/ix/api/chats/endpoints.py
+++ b/ix/api/chats/endpoints.py
@@ -257,6 +257,7 @@ async def send_message(
     except Chat.DoesNotExist:
         raise HTTPException(status_code=404, detail="Chat does not exist.")
     text = chat_input.text
+    artifact_ids = [str(pk) for pk in chat_input.artifact_ids or []]
 
     # save to persistent storage
     message = await TaskLogMessage.objects.acreate(
@@ -302,7 +303,7 @@ async def send_message(
     inputs = {
         "user_input": text,
         "chat_id": str(chat.id),
-        "artifact_keys": get_artifacts(user_input) or [],
+        "artifact_ids": artifact_ids,
     }
 
     # Start agent loop. This does NOT check if the loop is already running

--- a/ix/api/chats/types.py
+++ b/ix/api/chats/types.py
@@ -104,6 +104,7 @@ class ChatInput(BaseModel):
     """An input to a chat."""
 
     text: str
+    artifact_ids: Optional[List[UUID]] = None
 
 
 class ChatMessage(BaseModel):

--- a/ix/api/tests/test_chat.py
+++ b/ix/api/tests/test_chat.py
@@ -556,6 +556,7 @@ class TestChatMessage:
         assert message.agent_id is None
         assert message.content["type"] == "FEEDBACK"
         assert message.content["feedback"] == text
+        assert message.content["artifact_ids"] == [str(artifact.id)]
 
         mock_start_agent_loop.delay.assert_called_once_with(
             str(chat.task_id),

--- a/ix/api/tests/test_chat.py
+++ b/ix/api/tests/test_chat.py
@@ -530,7 +530,7 @@ class TestChatMessage:
             str(chat.task_id),
             chain_id=str(lead.chain_id),
             user_id=str(user.id),
-            inputs={"user_input": text, "chat_id": str(chat.id), "artifact_keys": []},
+            inputs={"user_input": text, "chat_id": str(chat.id), "artifact_ids": []},
         )
 
     async def test_send_message_with_artifact(self, anode_types, mock_start_agent_loop):
@@ -538,9 +538,13 @@ class TestChatMessage:
         user = await aget_default_user()
         lead = await Agent.objects.aget(id=chat.lead_id)
         text = "Test message with {test_artifact}"
+        artifact = await afake_artifact(task_id=chat.task_id, key="test_artifact")
 
         async with AsyncClient(app=app, base_url="http://test") as ac:
-            response = await ac.post(f"/chats/{chat.id}/messages", json={"text": text})
+            response = await ac.post(
+                f"/chats/{chat.id}/messages",
+                json={"text": text, "artifact_ids": [str(artifact.id)]},
+            )
 
         assert response.status_code == 200, response.content
         result = response.json()
@@ -560,7 +564,7 @@ class TestChatMessage:
             inputs={
                 "user_input": text,
                 "chat_id": str(chat.id),
-                "artifact_keys": ["test_artifact"],
+                "artifact_ids": [str(artifact.id)],
             },
         )
 
@@ -591,7 +595,7 @@ class TestChatMessage:
             str(subtask.id),
             chain_id=str(agent.chain_id),
             user_id=str(user.id),
-            inputs={"user_input": text, "chat_id": str(chat.id), "artifact_keys": []},
+            inputs={"user_input": text, "chat_id": str(chat.id), "artifact_ids": []},
         )
 
 

--- a/ix/memory/tests/test_artifact_memory.py
+++ b/ix/memory/tests/test_artifact_memory.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
 
@@ -63,9 +64,7 @@ class TestArtifactMemory:
 
         # run
         artifact1 = await afake_artifact(task=atask, key="test_artifact_1")
-        await chain.ainvoke(
-            input=dict(name="tester", artifact_keys=["test_artifact_1"])
-        )
+        await chain.ainvoke(input=dict(name="tester", artifact_ids=[str(artifact1.id)]))
 
         # assert artifact was used in prompt
         mock_openai.acompletion_with_retry.assert_called_once()
@@ -88,24 +87,26 @@ class TestArtifactMemory:
         instance = await aload_chain(ARTIFACT_MEMORY)
         artifact1 = await afake_artifact(task=atask, key="test_artifact_1")
         artifact2 = await afake_artifact(task=atask, key="test_artifact_2")
+        id_1 = str(artifact1.id)
+        id_2 = str(artifact2.id)
 
         # test no artifact_keys
         result1 = instance.load_memory_variables(dict())
         assert result1 == {"related_artifacts": ""}
 
         # test empty artifact_keys
-        result1 = instance.load_memory_variables(dict(artifact_keys=[]))
+        result1 = instance.load_memory_variables(dict(artifact_ids=[]))
         assert result1 == {"related_artifacts": ""}
 
         # test one artifact_key
-        inputs = dict(artifact_keys=["test_artifact_1"])
+        inputs = dict(artifact_ids=[id_1])
         result2 = instance.load_memory_variables(inputs=inputs)
         assert "REFERENCED ARTIFACTS:" in result2["related_artifacts"]
         assert artifact1.as_memory_text() in result2["related_artifacts"]
         assert artifact2.as_memory_text() not in result2["related_artifacts"]
 
         # test one artifact_key
-        inputs = dict(artifact_keys=["test_artifact_1", "test_artifact_2"])
+        inputs = dict(artifact_ids=[id_1, id_2])
         result3 = instance.load_memory_variables(inputs=inputs)
         assert "REFERENCED ARTIFACTS:" in result3["related_artifacts"]
         assert artifact1.as_memory_text() in result3["related_artifacts"]
@@ -114,7 +115,7 @@ class TestArtifactMemory:
         # test unknown artifact_key
         # hax: this won't raise an error of any kind now, but it's worth considering
         #      how to handle this better in the future.
-        inputs = dict(artifact_keys=["test_artifact_does_not_exist"])
+        inputs = dict(artifact_ids=[str(uuid4())])
         result4 = instance.load_memory_variables(inputs=inputs)
         assert result4 == {"related_artifacts": ""}
 
@@ -125,10 +126,10 @@ class TestArtifactMemory:
     async def test_scope(self, aclean_artifacts, atask, aload_chain):
         # artifact from another chat
         unrelated_task = await afake_task()
-        await afake_artifact(task=unrelated_task, key="test_artifact_3")
+        artifact = await afake_artifact(task=unrelated_task, key="test_artifact_3")
 
         # none of the excluded artifacts should be included in the memory
         instance = await aload_chain(ARTIFACT_MEMORY)
-        inputs = dict(artifact_keys=["test_artifact_3"])
+        inputs = dict(artifact_ids=[str(artifact.id)])
         result1 = instance.load_memory_variables(inputs=inputs)
         assert result1 == {"related_artifacts": ""}

--- a/ix/task_log/models.py
+++ b/ix/task_log/models.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from typing import TypedDict, Optional
+from typing import TypedDict, Optional, List
 
 from django.contrib.auth import get_user_model
 from django.db import models
@@ -73,6 +73,7 @@ class Task(models.Model):
 class UserFeedback(TypedDict):
     type: str
     feedback: Optional[str]
+    artifact_ids: List[str | uuid.UUID]
     message_id: Optional[str]
 
 


### PR DESCRIPTION
### Description
Updating chat message input and endpoint to pass `artifact_ids` instead of `artifact_keys`.  Helps enable vision agent for testing multi-modal prompts (#354 )

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
