### PR TITLE
Fixes for Run log input/output formatting:

### DIFF
--- a/ix/utils/json.py
+++ b/ix/utils/json.py
@@ -18,6 +18,8 @@ def to_json_serializable(obj: dict | BaseModel | BaseModelV1) -> dict:
         obj = to_json_serializable(asdict(obj))
     elif isinstance(obj, (dict, list, str, int, float, bool, type(None))):
         pass
+    elif isinstance(obj, bytes):
+        obj = f"[{len(obj)} bytes]"
     else:
         obj = str(obj)
 

--- a/ix/utils/json.py
+++ b/ix/utils/json.py
@@ -15,19 +15,22 @@ def to_json_serializable(obj: dict | BaseModel | BaseModelV1) -> dict:
     elif isinstance(obj, BaseModel):
         obj = obj.model_dump()
     elif is_dataclass(obj):
-        obj = asdict(obj)
+        obj = to_json_serializable(asdict(obj))
     elif isinstance(obj, (dict, list, str, int, float, bool, type(None))):
         pass
     else:
         obj = str(obj)
 
+    # truncate strings that are too long
+    if isinstance(obj, str) and len(obj) > 256:
+        obj = f"{obj[:256]} ... ({len(obj) - 256} chars)"
+
     # now recursively check to make sure there are no nested objects
     # that aren't json serializable
     if isinstance(obj, dict):
-        for key, value in obj.items():
-            obj[key] = to_json_serializable(value)
+        new_obj = {key: to_json_serializable(value) for key, value in obj.items()}
+        obj = new_obj
     elif isinstance(obj, list):
-        for i, value in enumerate(obj):
-            obj[i] = to_json_serializable(value)
+        obj = [to_json_serializable(value) for value in obj]
 
     return obj


### PR DESCRIPTION

### Description
Small collection of fixes for processing input & output sent to the run log. 

Content truncating fixes an issue noticed testing multi-modal prompts (#354) where the Base64 encoded image was 64kb of text. The large content string caused something (probably the syntax parser) to freeze the UI. Truncating the file has fixed the issue.

### Changes
- dataclasses are now recursively processed
- all strings are truncated at 256 chars to be nicer to the database, API, and UI
- Re-applying fix to prevent mutating the original object


### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
