### PR TITLE
Get fields kwargs

### DIFF
--- a/ix/api/components/types.py
+++ b/ix/api/components/types.py
@@ -602,14 +602,15 @@ class NodeType(BaseModel):
 
     def get_config_schema(self) -> dict:
         """JSON schema for the config"""
-        schema = self.generate_config_schema(self.fields or [])
+        title = self.class_path.split(".")[-1]
+        schema = self.generate_config_schema(title=title, fields=self.fields or [])
         schema.update(**self.model_dump(include="display_groups"))
         return schema
 
     @staticmethod
-    def generate_config_schema(fields: List[NodeTypeField]) -> dict:
+    def generate_config_schema(title: str, fields: List[NodeTypeField]) -> dict:
         """Generates a JSON schema from a list of NodeTypeField objects."""
-        schema = {"type": "object", "properties": {}, "required": []}
+        schema = {"title": title, "type": "object", "properties": {}, "required": []}
         for field in fields:
             # Determine the type of the field for the JSON schema
             if field.type in {"str", "string"}:

--- a/ix/api/components/types.py
+++ b/ix/api/components/types.py
@@ -342,13 +342,21 @@ class NodeTypeField(BaseModel):
         exclude: Optional[List[str]] = None,
         field_options: Optional[Dict[str, Dict[str, Any]]] = None,
         parent: Optional[str] = None,
+        **kwargs,
     ) -> List[Dict[str, Any]]:
+        # Setup field kwargs from legacy field_options and kwargs
+        field_kwargs = field_options or {}
+        field_kwargs.update(kwargs)
+
+        if field_kwargs:
+            include = set(include or []) | set(field_kwargs.keys())
+
         if isinstance(obj, type) and issubclass(obj, BaseModel | ABC):
             fields = cls.get_fields_from_model(
                 obj,
                 include=include,
                 exclude=exclude,
-                field_options=field_options,
+                field_options=field_kwargs,
                 parent=parent,
             )
         elif isinstance(obj, Callable):
@@ -356,7 +364,7 @@ class NodeTypeField(BaseModel):
                 obj,
                 include=include,
                 exclude=exclude,
-                field_options=field_options,
+                field_options=field_kwargs,
                 parent=parent,
             )
         else:

--- a/ix/chains/tests/test_config.py
+++ b/ix/chains/tests/test_config.py
@@ -108,6 +108,15 @@ class GetFieldsBase:
 
     field_source = None
 
+    def test_field_kwargs(self, field_overrides):
+        """field options may be passed as kwargs."""
+        fields = NodeTypeField.get_fields(
+            self.field_source,
+            **field_overrides,
+        )
+        field = fields[0]
+        assert field["name"] == "field1"
+
     def test_field_with_default(self, field_overrides):
         fields = NodeTypeField.get_fields(
             self.field_source,
@@ -115,7 +124,8 @@ class GetFieldsBase:
             field_options=field_overrides,
         )
 
-        assert fields[0]["default"] == "default"
+        field = fields[0] if fields[0]["name"] == "field_with_default" else fields[1]
+        assert field["default"] == "default"
 
     def test_get_literal_field(self, field_overrides):
         fields = NodeTypeField.get_fields(
@@ -124,7 +134,8 @@ class GetFieldsBase:
             field_options=field_overrides,
         )
 
-        assert fields[0]["choices"] == [
+        field = fields[0] if fields[0]["name"] == "literal" else fields[1]
+        assert field["choices"] == [
             {"value": "foo", "label": "Foo"},
             {"value": "bar", "label": "Bar"},
         ]

--- a/test_data/snapshots/components/__ROOT__.json
+++ b/test_data/snapshots/components/__ROOT__.json
@@ -24,6 +24,7 @@
             }
         },
         "required": [],
+        "title": "__ROOT__",
         "type": "object"
     },
     "connectors": [],

--- a/test_data/snapshots/components/ix.chains.agent_interaction.DelegateToAgentChain.json
+++ b/test_data/snapshots/components/ix.chains.agent_interaction.DelegateToAgentChain.json
@@ -40,6 +40,7 @@
             "target_alias",
             "delegate_inputs"
         ],
+        "title": "DelegateToAgentChain",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.artifacts.SaveArtifact.json
+++ b/test_data/snapshots/components/ix.chains.artifacts.SaveArtifact.json
@@ -56,6 +56,7 @@
             "content_key",
             "output_key"
         ],
+        "title": "SaveArtifact",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.chains.components.document_loaders.StringLoader.json
+++ b/test_data/snapshots/components/ix.chains.components.document_loaders.StringLoader.json
@@ -16,6 +16,7 @@
         "required": [
             "text"
         ],
+        "title": "StringLoader",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.chains.components.json.JSONData.json
+++ b/test_data/snapshots/components/ix.chains.components.json.JSONData.json
@@ -20,6 +20,7 @@
         "required": [
             "data"
         ],
+        "title": "JSONData",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.chains.components.json.JSONPath.json
+++ b/test_data/snapshots/components/ix.chains.components.json.JSONPath.json
@@ -17,6 +17,7 @@
         "required": [
             "path"
         ],
+        "title": "JSONPath",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.chains.components.lcel.init_branch.json
+++ b/test_data/snapshots/components/ix.chains.components.lcel.init_branch.json
@@ -27,6 +27,7 @@
             "branches",
             "branches_hash"
         ],
+        "title": "init_branch",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.chains.components.lcel.init_each.json
+++ b/test_data/snapshots/components/ix.chains.components.lcel.init_each.json
@@ -5,6 +5,7 @@
         "display_groups": null,
         "properties": {},
         "required": [],
+        "title": "init_each",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.components.lcel.init_parallel.json
+++ b/test_data/snapshots/components/ix.chains.components.lcel.init_parallel.json
@@ -27,6 +27,7 @@
             "steps",
             "steps_hash"
         ],
+        "title": "init_parallel",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.chains.components.lcel.init_pass_through.json
+++ b/test_data/snapshots/components/ix.chains.components.lcel.init_pass_through.json
@@ -5,6 +5,7 @@
         "display_groups": null,
         "properties": {},
         "required": [],
+        "title": "init_pass_through",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.chains.components.lcel.init_sequence.json
+++ b/test_data/snapshots/components/ix.chains.components.lcel.init_sequence.json
@@ -5,6 +5,7 @@
         "display_groups": null,
         "properties": {},
         "required": [],
+        "title": "init_sequence",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.components.memory.LoadMemory.json
+++ b/test_data/snapshots/components/ix.chains.components.memory.LoadMemory.json
@@ -20,6 +20,7 @@
         "required": [
             "memory_inputs"
         ],
+        "title": "LoadMemory",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.components.memory.SaveMemory.json
+++ b/test_data/snapshots/components/ix.chains.components.memory.SaveMemory.json
@@ -20,6 +20,7 @@
             }
         },
         "required": [],
+        "title": "SaveMemory",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.components.tools.IngestionTool.json
+++ b/test_data/snapshots/components/ix.chains.components.tools.IngestionTool.json
@@ -16,6 +16,7 @@
             }
         },
         "required": [],
+        "title": "IngestionTool",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.components.vectorstores.AsyncChromaVectorstore.json
+++ b/test_data/snapshots/components/ix.chains.components.vectorstores.AsyncChromaVectorstore.json
@@ -70,6 +70,7 @@
             "allowed_search_types",
             "search_kwargs"
         ],
+        "title": "AsyncChromaVectorstore",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.components.vectorstores.AsyncRedisVectorstore.json
+++ b/test_data/snapshots/components/ix.chains.components.vectorstores.AsyncRedisVectorstore.json
@@ -57,6 +57,7 @@
             "allowed_search_types",
             "search_kwargs"
         ],
+        "title": "AsyncRedisVectorstore",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.functions.FunctionSchema.json
+++ b/test_data/snapshots/components/ix.chains.functions.FunctionSchema.json
@@ -21,6 +21,7 @@
             }
         },
         "required": [],
+        "title": "FunctionSchema",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.chains.functions.OpenAIFunctionParser.json
+++ b/test_data/snapshots/components/ix.chains.functions.OpenAIFunctionParser.json
@@ -11,6 +11,7 @@
             }
         },
         "required": [],
+        "title": "OpenAIFunctionParser",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.chains.llm_chain.LLMChain.json
+++ b/test_data/snapshots/components/ix.chains.llm_chain.LLMChain.json
@@ -20,6 +20,7 @@
             }
         },
         "required": [],
+        "title": "LLMChain",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.llm_chain.LLMReply.json
+++ b/test_data/snapshots/components/ix.chains.llm_chain.LLMReply.json
@@ -11,6 +11,7 @@
             }
         },
         "required": [],
+        "title": "LLMReply",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.loaders.agents.initialize_chat_conversational_react_description.json
+++ b/test_data/snapshots/components/ix.chains.loaders.agents.initialize_chat_conversational_react_description.json
@@ -25,6 +25,7 @@
             }
         },
         "required": [],
+        "title": "initialize_chat_conversational_react_description",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.loaders.agents.initialize_chat_zero_shot_react_description.json
+++ b/test_data/snapshots/components/ix.chains.loaders.agents.initialize_chat_zero_shot_react_description.json
@@ -25,6 +25,7 @@
             }
         },
         "required": [],
+        "title": "initialize_chat_zero_shot_react_description",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.loaders.agents.initialize_conversational_react_description.json
+++ b/test_data/snapshots/components/ix.chains.loaders.agents.initialize_conversational_react_description.json
@@ -25,6 +25,7 @@
             }
         },
         "required": [],
+        "title": "initialize_conversational_react_description",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.loaders.agents.initialize_openai_functions.json
+++ b/test_data/snapshots/components/ix.chains.loaders.agents.initialize_openai_functions.json
@@ -25,6 +25,7 @@
             }
         },
         "required": [],
+        "title": "initialize_openai_functions",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.loaders.agents.initialize_openai_multi_functions.json
+++ b/test_data/snapshots/components/ix.chains.loaders.agents.initialize_openai_multi_functions.json
@@ -25,6 +25,7 @@
             }
         },
         "required": [],
+        "title": "initialize_openai_multi_functions",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.loaders.agents.initialize_react_docstore.json
+++ b/test_data/snapshots/components/ix.chains.loaders.agents.initialize_react_docstore.json
@@ -25,6 +25,7 @@
             }
         },
         "required": [],
+        "title": "initialize_react_docstore",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.loaders.agents.initialize_self_ask_with_search.json
+++ b/test_data/snapshots/components/ix.chains.loaders.agents.initialize_self_ask_with_search.json
@@ -25,6 +25,7 @@
             }
         },
         "required": [],
+        "title": "initialize_self_ask_with_search",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.loaders.agents.initialize_structured_chat_zero_shot_react_description.json
+++ b/test_data/snapshots/components/ix.chains.loaders.agents.initialize_structured_chat_zero_shot_react_description.json
@@ -25,6 +25,7 @@
             }
         },
         "required": [],
+        "title": "initialize_structured_chat_zero_shot_react_description",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.loaders.agents.initialize_zero_shot_react_description.json
+++ b/test_data/snapshots/components/ix.chains.loaders.agents.initialize_zero_shot_react_description.json
@@ -25,6 +25,7 @@
             }
         },
         "required": [],
+        "title": "initialize_zero_shot_react_description",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.moderator.ChatModerator.json
+++ b/test_data/snapshots/components/ix.chains.moderator.ChatModerator.json
@@ -5,6 +5,7 @@
         "display_groups": null,
         "properties": {},
         "required": [],
+        "title": "ChatModerator",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.openapi.get_openapi_chain_async.json
+++ b/test_data/snapshots/components/ix.chains.openapi.get_openapi_chain_async.json
@@ -18,6 +18,7 @@
             }
         },
         "required": [],
+        "title": "get_openapi_chain_async",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.routing.MapSubchain.json
+++ b/test_data/snapshots/components/ix.chains.routing.MapSubchain.json
@@ -25,6 +25,7 @@
             }
         },
         "required": [],
+        "title": "MapSubchain",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.chains.tests.mock_chain.MockChain.json
+++ b/test_data/snapshots/components/ix.chains.tests.mock_chain.MockChain.json
@@ -5,6 +5,7 @@
         "display_groups": null,
         "properties": {},
         "required": [],
+        "title": "MockChain",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.chains.tests.mock_memory.MockMemory.json
+++ b/test_data/snapshots/components/ix.chains.tests.mock_memory.MockMemory.json
@@ -5,6 +5,7 @@
         "display_groups": null,
         "properties": {},
         "required": [],
+        "title": "MockMemory",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.chains.tests.mock_runnable.MockRunnable.json
+++ b/test_data/snapshots/components/ix.chains.tests.mock_runnable.MockRunnable.json
@@ -5,6 +5,7 @@
         "display_groups": null,
         "properties": {},
         "required": [],
+        "title": "MockRunnable",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.chains.tools.chain_as_tool.json
+++ b/test_data/snapshots/components/ix.chains.tools.chain_as_tool.json
@@ -33,6 +33,7 @@
             }
         },
         "required": [],
+        "title": "chain_as_tool",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.memory.artifacts.ArtifactMemory.json
+++ b/test_data/snapshots/components/ix.memory.artifacts.ArtifactMemory.json
@@ -26,6 +26,7 @@
             }
         },
         "required": [],
+        "title": "ArtifactMemory",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.runnable.artifacts.EncodeImage.json
+++ b/test_data/snapshots/components/ix.runnable.artifacts.EncodeImage.json
@@ -5,6 +5,7 @@
         "display_groups": null,
         "properties": {},
         "required": [],
+        "title": "EncodeImage",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.runnable.artifacts.LoadArtifacts.json
+++ b/test_data/snapshots/components/ix.runnable.artifacts.LoadArtifacts.json
@@ -5,6 +5,7 @@
         "display_groups": null,
         "properties": {},
         "required": [],
+        "title": "LoadArtifacts",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.runnable.artifacts.LoadFile.json
+++ b/test_data/snapshots/components/ix.runnable.artifacts.LoadFile.json
@@ -5,6 +5,7 @@
         "display_groups": null,
         "properties": {},
         "required": [],
+        "title": "LoadFile",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.runnable.artifacts.SaveArtifact.json
+++ b/test_data/snapshots/components/ix.runnable.artifacts.SaveArtifact.json
@@ -30,6 +30,7 @@
             }
         },
         "required": [],
+        "title": "SaveArtifact",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.runnable.artifacts.get_load_image_artifact.json
+++ b/test_data/snapshots/components/ix.runnable.artifacts.get_load_image_artifact.json
@@ -5,6 +5,7 @@
         "display_groups": null,
         "properties": {},
         "required": [],
+        "title": "get_load_image_artifact",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.runnable.dalle.DalleImage.json
+++ b/test_data/snapshots/components/ix.runnable.dalle.DalleImage.json
@@ -63,6 +63,7 @@
             }
         },
         "required": [],
+        "title": "DalleImage",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.runnable.flow.load_chain_id.json
+++ b/test_data/snapshots/components/ix.runnable.flow.load_chain_id.json
@@ -14,6 +14,7 @@
         "required": [
             "chain_id"
         ],
+        "title": "load_chain_id",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.runnable.llm.IXChatOpenAI.json
+++ b/test_data/snapshots/components/ix.runnable.llm.IXChatOpenAI.json
@@ -173,6 +173,7 @@
             "tags",
             "metadata"
         ],
+        "title": "IXChatOpenAI",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.runnable.output_parser.ParseFunctionCall.json
+++ b/test_data/snapshots/components/ix.runnable.output_parser.ParseFunctionCall.json
@@ -5,6 +5,7 @@
         "display_groups": null,
         "properties": {},
         "required": [],
+        "title": "ParseFunctionCall",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.runnable.prompt.MultiModalChatPrompt.json
+++ b/test_data/snapshots/components/ix.runnable.prompt.MultiModalChatPrompt.json
@@ -20,6 +20,7 @@
             }
         },
         "required": [],
+        "title": "MultiModalChatPrompt",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.runnable.schema.Schema.json
+++ b/test_data/snapshots/components/ix.runnable.schema.Schema.json
@@ -22,6 +22,7 @@
             "description",
             "parameters"
         ],
+        "title": "Schema",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/ix.tools.arxiv.get_arxiv.json
+++ b/test_data/snapshots/components/ix.tools.arxiv.get_arxiv.json
@@ -41,6 +41,7 @@
             }
         },
         "required": [],
+        "title": "get_arxiv",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.tools.bing.get_bing_search.json
+++ b/test_data/snapshots/components/ix.tools.bing.get_bing_search.json
@@ -37,6 +37,7 @@
             "bing_subscription_key",
             "bing_search_url"
         ],
+        "title": "get_bing_search",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.tools.duckduckgo.get_ddg_search.json
+++ b/test_data/snapshots/components/ix.tools.duckduckgo.get_ddg_search.json
@@ -36,6 +36,7 @@
             }
         },
         "required": [],
+        "title": "get_ddg_search",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.tools.google.get_google_search.json
+++ b/test_data/snapshots/components/ix.tools.google.get_google_search.json
@@ -38,6 +38,7 @@
             }
         },
         "required": [],
+        "title": "get_google_search",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.tools.google.get_google_serper.json
+++ b/test_data/snapshots/components/ix.tools.google.get_google_serper.json
@@ -53,6 +53,7 @@
             }
         },
         "required": [],
+        "title": "get_google_serper",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.tools.graphql.get_graphql_tool.json
+++ b/test_data/snapshots/components/ix.tools.graphql.get_graphql_tool.json
@@ -22,6 +22,7 @@
         "required": [
             "graphql_endpoint"
         ],
+        "title": "get_graphql_tool",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.tools.lambda_api.get_lambda_api.json
+++ b/test_data/snapshots/components/ix.tools.lambda_api.get_lambda_api.json
@@ -28,6 +28,7 @@
             }
         },
         "required": [],
+        "title": "get_lambda_api",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.tools.metaphor.get_metaphor_contents.json
+++ b/test_data/snapshots/components/ix.tools.metaphor.get_metaphor_contents.json
@@ -24,6 +24,7 @@
         "required": [
             "metaphor_api_key"
         ],
+        "title": "get_metaphor_contents",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.tools.metaphor.get_metaphor_find_similar.json
+++ b/test_data/snapshots/components/ix.tools.metaphor.get_metaphor_find_similar.json
@@ -24,6 +24,7 @@
         "required": [
             "metaphor_api_key"
         ],
+        "title": "get_metaphor_find_similar",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.tools.metaphor.get_metaphor_search.json
+++ b/test_data/snapshots/components/ix.tools.metaphor.get_metaphor_search.json
@@ -24,6 +24,7 @@
         "required": [
             "metaphor_api_key"
         ],
+        "title": "get_metaphor_search",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.tools.pubmed.get_pubmed.json
+++ b/test_data/snapshots/components/ix.tools.pubmed.get_pubmed.json
@@ -36,6 +36,7 @@
             }
         },
         "required": [],
+        "title": "get_pubmed",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.tools.wikipedia.get_wikipedia.json
+++ b/test_data/snapshots/components/ix.tools.wikipedia.get_wikipedia.json
@@ -36,6 +36,7 @@
             }
         },
         "required": [],
+        "title": "get_wikipedia",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.tools.wolfram_alpha.get_wolfram_alpha.json
+++ b/test_data/snapshots/components/ix.tools.wolfram_alpha.get_wolfram_alpha.json
@@ -22,6 +22,7 @@
             }
         },
         "required": [],
+        "title": "get_wolfram_alpha",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/ix.tools.zapier.zapier_toolkit.json
+++ b/test_data/snapshots/components/ix.tools.zapier.zapier_toolkit.json
@@ -29,6 +29,7 @@
             "zapier_nla_api_key",
             "zapier_nla_oauth_access_token"
         ],
+        "title": "zapier_toolkit",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.agents.agent_toolkits.file_management.toolkit.FileManagementToolkit.json
+++ b/test_data/snapshots/components/langchain.agents.agent_toolkits.file_management.toolkit.FileManagementToolkit.json
@@ -13,6 +13,7 @@
         "required": [
             "root_dir"
         ],
+        "title": "FileManagementToolkit",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.chains.SequentialChain.json
+++ b/test_data/snapshots/components/langchain.chains.SequentialChain.json
@@ -21,6 +21,7 @@
             }
         },
         "required": [],
+        "title": "SequentialChain",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/langchain.chains.conversational_retrieval.base.ConversationalRetrievalChain.from_llm.json
+++ b/test_data/snapshots/components/langchain.chains.conversational_retrieval.base.ConversationalRetrievalChain.from_llm.json
@@ -37,6 +37,7 @@
         "required": [
             "max_tokens_limit"
         ],
+        "title": "from_llm",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/langchain.chat_models.anthropic.ChatAnthropic.json
+++ b/test_data/snapshots/components/langchain.chat_models.anthropic.ChatAnthropic.json
@@ -58,6 +58,7 @@
             "tags",
             "metadata"
         ],
+        "title": "ChatAnthropic",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.chat_models.fireworks.ChatFireworks.json
+++ b/test_data/snapshots/components/langchain.chat_models.fireworks.ChatFireworks.json
@@ -56,6 +56,7 @@
             "tags",
             "metadata"
         ],
+        "title": "ChatFireworks",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.chat_models.google_palm.ChatGooglePalm.json
+++ b/test_data/snapshots/components/langchain.chat_models.google_palm.ChatGooglePalm.json
@@ -87,6 +87,7 @@
             "tags",
             "metadata"
         ],
+        "title": "ChatGooglePalm",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.chat_models.openai.ChatOpenAI.json
+++ b/test_data/snapshots/components/langchain.chat_models.openai.ChatOpenAI.json
@@ -168,6 +168,7 @@
             "tags",
             "metadata"
         ],
+        "title": "ChatOpenAI",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/langchain.document_loaders.BSHTMLLoader.json
+++ b/test_data/snapshots/components/langchain.document_loaders.BSHTMLLoader.json
@@ -21,6 +21,7 @@
         "required": [
             "file_path"
         ],
+        "title": "BSHTMLLoader",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.document_loaders.JSONLoader.json
+++ b/test_data/snapshots/components/langchain.document_loaders.JSONLoader.json
@@ -32,6 +32,7 @@
             "file_path",
             "jq_schema"
         ],
+        "title": "JSONLoader",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.document_loaders.PyPDFLoader.json
+++ b/test_data/snapshots/components/langchain.document_loaders.PyPDFLoader.json
@@ -16,6 +16,7 @@
         "required": [
             "file_path"
         ],
+        "title": "PyPDFLoader",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.document_loaders.UnstructuredHTMLLoader.json
+++ b/test_data/snapshots/components/langchain.document_loaders.UnstructuredHTMLLoader.json
@@ -5,6 +5,7 @@
         "display_groups": null,
         "properties": {},
         "required": [],
+        "title": "UnstructuredHTMLLoader",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.document_loaders.UnstructuredMarkdownLoader.json
+++ b/test_data/snapshots/components/langchain.document_loaders.UnstructuredMarkdownLoader.json
@@ -5,6 +5,7 @@
         "display_groups": null,
         "properties": {},
         "required": [],
+        "title": "UnstructuredMarkdownLoader",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.document_loaders.csv_loader.CSVLoader.json
+++ b/test_data/snapshots/components/langchain.document_loaders.csv_loader.CSVLoader.json
@@ -20,6 +20,7 @@
         "required": [
             "file_path"
         ],
+        "title": "CSVLoader",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.document_loaders.generic.GenericLoader.from_filesystem.json
+++ b/test_data/snapshots/components/langchain.document_loaders.generic.GenericLoader.from_filesystem.json
@@ -27,6 +27,7 @@
         "required": [
             "path"
         ],
+        "title": "from_filesystem",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/langchain.document_loaders.parsers.language.language_parser.LanguageParser.json
+++ b/test_data/snapshots/components/langchain.document_loaders.parsers.language.language_parser.LanguageParser.json
@@ -39,6 +39,7 @@
             }
         },
         "required": [],
+        "title": "LanguageParser",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.document_loaders.web_base.WebBaseLoader.json
+++ b/test_data/snapshots/components/langchain.document_loaders.web_base.WebBaseLoader.json
@@ -27,6 +27,7 @@
             }
         },
         "required": [],
+        "title": "WebBaseLoader",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/langchain.embeddings.google_palm.GooglePalmEmbeddings.json
+++ b/test_data/snapshots/components/langchain.embeddings.google_palm.GooglePalmEmbeddings.json
@@ -20,6 +20,7 @@
             }
         },
         "required": [],
+        "title": "GooglePalmEmbeddings",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.embeddings.huggingface.HuggingFaceBgeEmbeddings.json
+++ b/test_data/snapshots/components/langchain.embeddings.huggingface.HuggingFaceBgeEmbeddings.json
@@ -31,6 +31,7 @@
             "model_kwargs",
             "encode_kwargs"
         ],
+        "title": "HuggingFaceBgeEmbeddings",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.embeddings.huggingface.HuggingFaceEmbeddings.json
+++ b/test_data/snapshots/components/langchain.embeddings.huggingface.HuggingFaceEmbeddings.json
@@ -31,6 +31,7 @@
             "model_kwargs",
             "encode_kwargs"
         ],
+        "title": "HuggingFaceEmbeddings",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.embeddings.huggingface.HuggingFaceInferenceAPIEmbeddings.json
+++ b/test_data/snapshots/components/langchain.embeddings.huggingface.HuggingFaceInferenceAPIEmbeddings.json
@@ -18,6 +18,7 @@
         "required": [
             "api_key"
         ],
+        "title": "HuggingFaceInferenceAPIEmbeddings",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.embeddings.huggingface.HuggingFaceInstructEmbeddings.json
+++ b/test_data/snapshots/components/langchain.embeddings.huggingface.HuggingFaceInstructEmbeddings.json
@@ -31,6 +31,7 @@
         "required": [
             "encode_kwargs"
         ],
+        "title": "HuggingFaceInstructEmbeddings",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.embeddings.huggingface_hub.HuggingFaceHubEmbeddings.json
+++ b/test_data/snapshots/components/langchain.embeddings.huggingface_hub.HuggingFaceHubEmbeddings.json
@@ -24,6 +24,7 @@
             }
         },
         "required": [],
+        "title": "HuggingFaceHubEmbeddings",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.embeddings.llama_cpp.LlamaCppEmbeddings.json
+++ b/test_data/snapshots/components/langchain.embeddings.llama_cpp.LlamaCppEmbeddings.json
@@ -72,6 +72,7 @@
             }
         },
         "required": [],
+        "title": "LlamaCppEmbeddings",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.embeddings.mosaicml.MosaicMLInstructorEmbeddings.json
+++ b/test_data/snapshots/components/langchain.embeddings.mosaicml.MosaicMLInstructorEmbeddings.json
@@ -42,6 +42,7 @@
             }
         },
         "required": [],
+        "title": "MosaicMLInstructorEmbeddings",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.embeddings.openai.OpenAIEmbeddings.json
+++ b/test_data/snapshots/components/langchain.embeddings.openai.OpenAIEmbeddings.json
@@ -43,6 +43,7 @@
             }
         },
         "required": [],
+        "title": "OpenAIEmbeddings",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.embeddings.vertexai.VertexAIEmbeddings.json
+++ b/test_data/snapshots/components/langchain.embeddings.vertexai.VertexAIEmbeddings.json
@@ -16,6 +16,7 @@
             }
         },
         "required": [],
+        "title": "VertexAIEmbeddings",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.llms.fireworks.Fireworks.json
+++ b/test_data/snapshots/components/langchain.llms.fireworks.Fireworks.json
@@ -56,6 +56,7 @@
             "tags",
             "metadata"
         ],
+        "title": "Fireworks",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.llms.llamacpp.LlamaCpp.json
+++ b/test_data/snapshots/components/langchain.llms.llamacpp.LlamaCpp.json
@@ -157,6 +157,7 @@
             "tags",
             "metadata"
         ],
+        "title": "LlamaCpp",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.llms.ollama.Ollama.json
+++ b/test_data/snapshots/components/langchain.llms.ollama.Ollama.json
@@ -116,6 +116,7 @@
             "tags",
             "metadata"
         ],
+        "title": "Ollama",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.llms.ollama.Ollama.json
+++ b/test_data/snapshots/components/langchain.llms.ollama.Ollama.json
@@ -86,6 +86,16 @@
                 "label": "Tfs_z",
                 "type": "number"
             },
+            "top_k": {
+                "default": 40,
+                "description": "Top K",
+                "input_type": "slider",
+                "label": "Top_k",
+                "maximum": 100.0,
+                "minimum": 1.0,
+                "multipleOf": 1.0,
+                "type": "number"
+            },
             "top_p": {
                 "default": 0.9,
                 "input_type": "slider",
@@ -351,6 +361,23 @@
             "step": null,
             "style": null,
             "type": "float"
+        },
+        {
+            "choices": null,
+            "default": 40,
+            "description": "Top K",
+            "init_type": "init",
+            "input_type": "slider",
+            "label": "Top_k",
+            "max": 100.0,
+            "min": 1.0,
+            "name": "top_k",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": 1.0,
+            "style": null,
+            "type": "int"
         },
         {
             "choices": null,

--- a/test_data/snapshots/components/langchain.memory.ConversationBufferMemory.json
+++ b/test_data/snapshots/components/langchain.memory.ConversationBufferMemory.json
@@ -36,6 +36,7 @@
             }
         },
         "required": [],
+        "title": "ConversationBufferMemory",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/langchain.memory.RedisChatMessageHistory.json
+++ b/test_data/snapshots/components/langchain.memory.RedisChatMessageHistory.json
@@ -51,6 +51,7 @@
             }
         },
         "required": [],
+        "title": "RedisChatMessageHistory",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.memory.buffer_window.ConversationBufferWindowMemory.json
+++ b/test_data/snapshots/components/langchain.memory.buffer_window.ConversationBufferWindowMemory.json
@@ -41,6 +41,7 @@
             }
         },
         "required": [],
+        "title": "ConversationBufferWindowMemory",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/langchain.memory.chat_message_histories.file.FileChatMessageHistory.json
+++ b/test_data/snapshots/components/langchain.memory.chat_message_histories.file.FileChatMessageHistory.json
@@ -14,6 +14,7 @@
             }
         },
         "required": [],
+        "title": "FileChatMessageHistory",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.memory.chat_message_histories.postgres.PostgresChatMessageHistory.json
+++ b/test_data/snapshots/components/langchain.memory.chat_message_histories.postgres.PostgresChatMessageHistory.json
@@ -72,6 +72,7 @@
             }
         },
         "required": [],
+        "title": "PostgresChatMessageHistory",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain.memory.summary_buffer.ConversationSummaryBufferMemory.json
+++ b/test_data/snapshots/components/langchain.memory.summary_buffer.ConversationSummaryBufferMemory.json
@@ -41,6 +41,7 @@
             }
         },
         "required": [],
+        "title": "ConversationSummaryBufferMemory",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/langchain.memory.token_buffer.ConversationTokenBufferMemory.json
+++ b/test_data/snapshots/components/langchain.memory.token_buffer.ConversationTokenBufferMemory.json
@@ -41,6 +41,7 @@
             }
         },
         "required": [],
+        "title": "ConversationTokenBufferMemory",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/langchain.prompts.chat.ChatPromptTemplate.json
+++ b/test_data/snapshots/components/langchain.prompts.chat.ChatPromptTemplate.json
@@ -13,6 +13,7 @@
             }
         },
         "required": [],
+        "title": "ChatPromptTemplate",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/langchain.retrievers.multi_query.MultiQueryRetriever.from_llm.json
+++ b/test_data/snapshots/components/langchain.retrievers.multi_query.MultiQueryRetriever.from_llm.json
@@ -5,6 +5,7 @@
         "display_groups": null,
         "properties": {},
         "required": [],
+        "title": "from_llm",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/langchain.schema.vectorstore.VectorStoreRetriever.json
+++ b/test_data/snapshots/components/langchain.schema.vectorstore.VectorStoreRetriever.json
@@ -25,6 +25,7 @@
             "allowed_search_types",
             "search_kwargs"
         ],
+        "title": "VectorStoreRetriever",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/langchain.text_splitter.RecursiveCharacterTextSplitter.from_language.json
+++ b/test_data/snapshots/components/langchain.text_splitter.RecursiveCharacterTextSplitter.from_language.json
@@ -54,6 +54,7 @@
             }
         },
         "required": [],
+        "title": "from_language",
         "type": "object"
     },
     "connectors": [

--- a/test_data/snapshots/components/langchain_google_genai.ChatGoogleGenerativeAI.json
+++ b/test_data/snapshots/components/langchain_google_genai.ChatGoogleGenerativeAI.json
@@ -111,6 +111,7 @@
             "tags",
             "metadata"
         ],
+        "title": "ChatGoogleGenerativeAI",
         "type": "object"
     },
     "connectors": null,

--- a/test_data/snapshots/components/langchain_google_genai.GoogleGenerativeAIEmbeddings.json
+++ b/test_data/snapshots/components/langchain_google_genai.GoogleGenerativeAIEmbeddings.json
@@ -17,6 +17,7 @@
             }
         },
         "required": [],
+        "title": "GoogleGenerativeAIEmbeddings",
         "type": "object"
     },
     "connectors": null,


### PR DESCRIPTION
### Description

`NodeTypeField.get_fields()` now accepts `kwargs` to reduce complexity of adding `field_options`.  

Fields added via `kwargs` are automatically added to `include`. `kwargs` override the default values parsed from the target.

##### New syntax
```
NodeTypeField.get_fields(Component, foo={"type": "list"})
```

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
