### PR TITLE
import_langchan now accepts NodeType instances

### DIFF
--- a/ix/chains/management/commands/import_langchain.py
+++ b/ix/chains/management/commands/import_langchain.py
@@ -111,13 +111,16 @@ class Command(BaseCommand):
             # validate by converting to pydantic model instance
             # TODO: COMPONENTS should be converted to pydantic models but for now
             #       expect that they are dicts and validated here.
-            node_type_pydantic = NodeTypePydantic(**component)
+            if isinstance(component, dict):
+                node_type_pydantic = NodeTypePydantic(**component)
+            else:
+                node_type_pydantic = component
             config_schema = node_type_pydantic.get_config_schema()
             validated_options = node_type_pydantic.model_dump(
                 exclude={"id", "display_groups", "config_schema"}
             )
 
-            class_path = component.get("class_path")
+            class_path = node_type_pydantic.class_path
             if NodeType.objects.filter(class_path=class_path).exists():
                 # updating existing node type
                 self.to_stdout(f"Updating component: {class_path}")


### PR DESCRIPTION


### Description
small QoL change. `import_langchain` now accepts `NodeType` instance instead of just `dicts`.  Enables component definitions to be defined with the model. 
### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
