### PR TITLE
create_args_model now creates fields as type Any

### DIFF
--- a/ix/api/tests/test_secrets.py
+++ b/ix/api/tests/test_secrets.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 import pytest_asyncio
 
@@ -177,8 +179,8 @@ class TestSecrets:
     async def test_create_with_new_type(self, auser, asecret_type):
         class DynamicModel(BaseModel):
             # all fields will be inferred as strings
-            one: str
-            second: str
+            one: Any
+            second: Any
 
         data = {
             "type_key": "New Type",

--- a/ix/chains/tests/components/test_ingestion_tool.py
+++ b/ix/chains/tests/components/test_ingestion_tool.py
@@ -64,8 +64,8 @@ class TestIngestionTool:
         # validate args_schema works as expected
         expected = {
             "properties": {
-                "COLLECTION_NAME": {"title": "Collection Name", "type": "string"},
-                "PATH": {"title": "Path", "type": "string"},
+                "COLLECTION_NAME": {"title": "Collection Name"},
+                "PATH": {"title": "Path"},
             },
             "required": ["COLLECTION_NAME", "PATH"],
             "title": "NodeTemplateSchema",

--- a/ix/chains/tests/test_config_loader.py
+++ b/ix/chains/tests/test_config_loader.py
@@ -72,10 +72,10 @@ from ix.chains.tests.mock_configs import (
     PROMPT_CHAT_0,
     PROMPT_CHAT_1,
     PROMPT_CHAT_2,
+    TEXT_SPLITTER,
 )
 from ix.chains.tests.mock_memory import MockMemory
 from ix.chains.tests.mock_runnable import MockRunnable
-from ix.chains.tests.test_templates import TEXT_SPLITTER
 from ix.conftest import aload_fixture
 from ix.memory.artifacts import ArtifactMemory
 from ix.runnable.ix import IxNode

--- a/ix/chains/tests/test_templates.py
+++ b/ix/chains/tests/test_templates.py
@@ -113,10 +113,10 @@ class TestNodeTemplate:
         assert issubclass(model, BaseModel)
         assert "PATH" in model.__fields__
         assert model.schema() == {
+            "properties": {"PATH": {"title": "Path"}},
+            "required": ["PATH"],
             "title": "NodeTemplateSchema",
             "type": "object",
-            "properties": {"PATH": {"title": "Path", "type": "string"}},
-            "required": ["PATH"],
         }
         assert model(PATH=str(TEST_DOCUMENTS)).dict() == {"PATH": str(TEST_DOCUMENTS)}
 

--- a/ix/utils/pydantic.py
+++ b/ix/utils/pydantic.py
@@ -27,5 +27,5 @@ def create_args_model(variables, name="DynamicModel") -> Type[BaseModel]:
     """
     Dynamically create a Pydantic model class with fields for each variable
     """
-    field_definitions = {field: (str, ...) for field in variables}
+    field_definitions = {field: (Any, ...) for field in variables}
     return create_model(name, **field_definitions)


### PR DESCRIPTION
### Description
Dynamic models will now default to fields typed `Any` for wider compatibility. This is an intermediate solution until types can be better configured.

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
