### PR TITLE
Chain input_type now matches root node's inputs.

### DIFF
--- a/ix/chains/loaders/core.py
+++ b/ix/chains/loaders/core.py
@@ -3,7 +3,7 @@ import itertools
 import logging
 import time
 from collections import defaultdict
-from typing import Callable, Any, List, Tuple, Dict, Set, Union
+from typing import Callable, Any, List, Tuple, Dict, Set, Union, Type
 from uuid import UUID
 
 from asgiref.sync import sync_to_async
@@ -13,6 +13,8 @@ from langchain.schema.runnable import (
     Runnable,
 )
 from langchain.schema.runnable.utils import Input, Output
+from langchain_core.runnables import RunnablePassthrough
+from pydantic import BaseModel
 
 from ix.api.components.types import NodeType as NodeTypePydantic
 from ix.api.chains.types import Node as NodePydantic, InputConfig
@@ -28,6 +30,7 @@ from ix.runnable.ix import IxNode
 from ix.secrets.models import Secret
 from ix.utils.config import format_config
 from ix.utils.importlib import import_class
+from ix.utils.pydantic import create_args_model_v1
 from jsonschema_pydantic import jsonschema_to_pydantic
 
 import_node_class = import_class
@@ -467,9 +470,16 @@ def init_chain_flow(
     """
     Initialize a flow from a chain.
     """
-    flow_root = load_chain_flow(chain=chain)
+    input_type, flow_root = load_chain_flow(chain=chain)
     logger.debug(f"init_chain_flow chain={chain.id} flow_root={flow_root}")
-    return init_flow_node(flow_root, context=context, variables=variables)
+    flow = init_flow_node(flow_root, context=context, variables=variables)
+
+    # Add the root's schema as the outward facing input_type using a passthrough.
+    if isinstance(flow, Runnable):
+        type_mask = RunnablePassthrough(input_type=input_type)
+        flow = type_mask | flow
+
+    return flow
 
 
 async def ainit_chain_flow(
@@ -506,21 +516,27 @@ async def ainit_flow(
     return await sync_to_async(init_flow)(nodes, context, variables, seen)
 
 
-def load_chain_flow(chain: Chain) -> FlowPlaceholder:
+def load_chain_flow(chain: Chain) -> Tuple[Type[BaseModel], FlowPlaceholder]:
     try:
         root = chain.nodes.get(root=True, class_path=ROOT_CLASS_PATH)
         nodes = chain.nodes.filter(incoming_edges__source=root)
         logger.debug(f"Loading chain flow with roots: {root}")
+        input_type = create_args_model_v1(
+            root.config.get("outputs", []), name="ChainInput"
+        )
     except ChainNode.DoesNotExist:
         # fallback to old style roots:
         # TODO: remove this fallback after all chains have been migrated
         nodes = chain.nodes.filter(root=True)
         logger.debug(f"Loading chain flow with roots: {nodes}")
+        input_type = create_args_model_v1(
+            ["user_input", "artifact_ids"], name="ChainInput"
+        )
 
-    return load_flow_node(nodes)
+    return input_type, load_flow_node(nodes)
 
 
-async def aload_chain_flow(chain: Chain) -> FlowPlaceholder:
+async def aload_chain_flow(chain: Chain) -> Tuple[Type[BaseModel], FlowPlaceholder]:
     return await sync_to_async(load_chain_flow)(chain)
 
 

--- a/ix/chains/tests/components/test_ingestion_tool.py
+++ b/ix/chains/tests/components/test_ingestion_tool.py
@@ -8,7 +8,11 @@ from ix.chains.fixture_src.text_splitter import RECURSIVE_CHARACTER_SPLITTER_CLA
 from ix.chains.fixture_src.tools import INGESTION_TOOL_CLASS_PATH
 from ix.chains.fixture_src.vectorstores import CHROMA_CLASS_PATH
 from ix.chains.loaders.templates import NodeTemplate
-from ix.chains.tests.test_config_loader import TEST_DOCUMENTS, EMBEDDINGS
+from ix.chains.tests.test_config_loader import (
+    TEST_DOCUMENTS,
+    EMBEDDINGS,
+    unpack_chain_flow,
+)
 from ix.chains.tests.test_templates import LOADER_TEMPLATE
 
 CHROMA_TEMPLATE = {
@@ -45,8 +49,8 @@ class What(BaseModel):
 @pytest.mark.django_db
 class TestIngestionTool:
     async def test_load(self, aload_chain):
-        ix_node = await aload_chain(INGESTION_TOOL)
-        component = ix_node.child
+        flow = await aload_chain(INGESTION_TOOL)
+        component = unpack_chain_flow(flow)
         assert isinstance(component, IngestionTool)
         assert component.name == "ingest"
         assert component.description == "Ingest data into a vectorstore"
@@ -83,15 +87,15 @@ class TestIngestionTool:
         }
 
     async def test_load_override_name_and_description(self, aload_chain):
-        ix_node = await aload_chain(NAMED_INGESTION_TOOL)
-        component = ix_node.child
+        flow = await aload_chain(NAMED_INGESTION_TOOL)
+        component = unpack_chain_flow(flow)
         assert isinstance(component, IngestionTool)
         assert component.name == "custom_ingest"
         assert component.description == "custom description"
 
     async def test_ainvoke(self, aload_chain, mock_openai_embeddings):
-        ix_node = await aload_chain(INGESTION_TOOL)
-        component = ix_node.child
+        flow = await aload_chain(INGESTION_TOOL)
+        component = unpack_chain_flow(flow)
         args = dict(PATH=str(TEST_DOCUMENTS), COLLECTION_NAME="test_collection")
         try:
             result = await component.ainvoke(input=args)

--- a/ix/chains/tests/fake.py
+++ b/ix/chains/tests/fake.py
@@ -71,7 +71,7 @@ def fake_root(**kwargs) -> ChainNode:
     """
     Create a fake root chain node.
     """
-    config = kwargs.get(
+    config = kwargs.pop(
         "config",
         {
             "class_path": "__ROOT__",

--- a/ix/chains/tests/mock_runnable.py
+++ b/ix/chains/tests/mock_runnable.py
@@ -3,8 +3,8 @@ from copy import deepcopy
 from typing import Optional, Any
 
 from langchain.schema.runnable import Runnable, RunnableConfig
-from langchain.schema.runnable.utils import Output, Input
-from pydantic import BaseModel
+from langchain.schema.runnable.utils import Output
+from pydantic.v1 import BaseModel as BaseModelV1
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +19,11 @@ MOCK_RUNNABLE_CONFIG = {
 }
 
 
-class MockRunnable(Runnable[Input, Output], BaseModel):
+class MockRunnableInput(BaseModelV1):
+    value: str = "input"
+
+
+class MockRunnable(Runnable[MockRunnableInput, Output], BaseModelV1):
     """Mock runnable that returns a default value"""
 
     name: str = "default"
@@ -27,7 +31,7 @@ class MockRunnable(Runnable[Input, Output], BaseModel):
 
     def invoke(
         self,
-        input: Input,
+        input: MockRunnableInput,
         config: Optional[RunnableConfig] = None,
     ) -> dict:
         if isinstance(input, dict):

--- a/ix/chains/tests/test_config_loader.py
+++ b/ix/chains/tests/test_config_loader.py
@@ -777,7 +777,7 @@ class TestLoadFlow:
     async def test_sequence(self, lcel_sequence, aix_context):
         fixture = lcel_sequence
         chain = fixture["chain"]
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
 
         assert flow == [
             fixture["nodes"][0],
@@ -797,7 +797,7 @@ class TestLoadFlow:
             "b": fixture["node2"],
         }
         # assert flow
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == fixture["map"]
 
     async def test_map_with_one_branch(self, lcel_map_with_one_branch, aix_context):
@@ -810,14 +810,14 @@ class TestLoadFlow:
             "a": fixture["node1"],
         }
         # assert flow
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == fixture["map"]
 
     async def test_sequence_in_map_start(self, lcel_sequence_in_map_start, aix_context):
         """Test a map with a nested sequence. First node in chain is the map."""
         fixture = lcel_sequence_in_map_start
         chain = fixture["chain"]
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == fixture["map"]
 
     async def test_sequence_in_map_in_sequence(
@@ -829,7 +829,7 @@ class TestLoadFlow:
         """
         fixture = lcel_sequence_in_map_in_sequence
         chain = fixture["chain"]
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == [
             fixture["node1"],
             fixture["map"],
@@ -845,7 +845,7 @@ class TestLoadFlow:
         """
         fixture = lcel_sequence_in_map_in_sequence_n2
         chain = fixture["chain"]
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == [
             fixture["node1"],
             fixture["map"],
@@ -857,7 +857,7 @@ class TestLoadFlow:
         """Test a sequence starting with a map. First node in chain is a map"""
         fixture = lcel_map_in_sequence_start
         chain = fixture["chain"]
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == [
             fixture["map"],
             fixture["node2"],
@@ -869,7 +869,7 @@ class TestLoadFlow:
         """Test a sequence starting with a map. First node in chain is a map"""
         fixture = lcel_map_in_sequence_start_n2
         chain = fixture["chain"]
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == [
             fixture["map"],
             fixture["node2"],
@@ -880,7 +880,7 @@ class TestLoadFlow:
         """Test a sequence with a nested map. First node in chain is the first node of sequence."""
         fixture = lcel_map_in_sequence
         chain = lcel_map_in_sequence["chain"]
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == [
             fixture["node1"],
             fixture["map"],
@@ -891,7 +891,7 @@ class TestLoadFlow:
         """Test a sequence with a nested map. First node in chain is the first node of sequence."""
         fixture = lcel_map_in_sequence_n2
         chain = fixture["chain"]
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == [
             fixture["node1"],
             fixture["map"],
@@ -903,7 +903,7 @@ class TestLoadFlow:
         """Test a map with a nested map"""
         fixture = lcel_map_in_map
         chain = fixture["chain"]
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == fixture["map"]
 
     async def test_map_in_map_in_sequence_start(
@@ -912,7 +912,7 @@ class TestLoadFlow:
         """Test a map with a nested map"""
         fixture = lcel_map_in_map_in_sequence_start
         chain = fixture["chain"]
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == [
             fixture["map"],
             fixture["node3"],
@@ -924,7 +924,7 @@ class TestLoadFlow:
         """Test a map with a nested map"""
         fixture = lcel_map_in_map_in_sequence_start_n2
         chain = fixture["chain"]
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == [
             fixture["map"],
             fixture["node3"],
@@ -937,7 +937,7 @@ class TestLoadFlow:
         """Test a map with a nested map"""
         fixture = lcel_map_in_map_in_sequence
         chain = fixture["chain"]
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == [
             fixture["node1"],
             fixture["map"],
@@ -949,7 +949,7 @@ class TestLoadFlow:
         """Test a map with a nested map"""
         fixture = lcel_map_in_map_in_sequence_n2
         chain = fixture["chain"]
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == [
             fixture["node1"],
             fixture["map"],
@@ -970,7 +970,7 @@ class TestLoadFlow:
         ]
 
         # test loaded flow
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == fixture["branch"]
 
     async def test_branch_in_branch(self, lcel_branch_in_branch, aix_context):
@@ -987,7 +987,7 @@ class TestLoadFlow:
         ]
 
         # test loaded flow
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == fixture["branch"]
 
     async def test_branch_in_default_branch(
@@ -1002,7 +1002,7 @@ class TestLoadFlow:
         assert fixture["branch"].default == fixture["inner_branch"]
 
         # test loaded flow
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == fixture["branch"]
 
     async def test_sequence_in_branch(self, lcel_sequence_in_branch, aix_context):
@@ -1018,7 +1018,7 @@ class TestLoadFlow:
         ]
 
         # test loaded flow
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == fixture["branch"]
 
     async def test_sequence_in_default_branch(
@@ -1033,7 +1033,7 @@ class TestLoadFlow:
         assert fixture["branch"].default == fixture["inner_sequence"]
 
         # test loaded flow
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == fixture["branch"]
 
     async def test_map_in_branch(self, lcel_map_in_branch, aix_context):
@@ -1042,7 +1042,7 @@ class TestLoadFlow:
         chain = fixture["chain"]
 
         # test loaded flow
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == fixture["branch"]
 
     async def test_map_in_default_branch(self, lcel_map_in_default_branch, aix_context):
@@ -1051,7 +1051,7 @@ class TestLoadFlow:
         chain = fixture["chain"]
 
         # test loaded flow
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == fixture["branch"]
 
     async def test_branch_in_sequence(self, lcel_branch_in_sequence, aix_context):
@@ -1064,7 +1064,7 @@ class TestLoadFlow:
         chain = fixture["chain"]
 
         # test loaded flow
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
 
         # Verify the class of the flow using isinstance
         assert isinstance(flow, SequencePlaceholder)
@@ -1124,7 +1124,7 @@ class TestLoadFlow:
         chain = fixture["chain"]
 
         # test loaded flow
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == fixture["sequence"]
 
     @pytest.mark.skip(reason="not supported yet")
@@ -1133,7 +1133,7 @@ class TestLoadFlow:
         chain = fixture["chain"]
 
         # test loaded flow
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == fixture["map"]
 
     async def test_join_after_branch(self, lcel_join_after_branch, aix_context):
@@ -1162,7 +1162,7 @@ class TestLoadFlow:
         chain = fixture["chain"]
 
         # test loaded flow
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
 
         # root is a branch
         assert isinstance(flow, BranchPlaceholder)
@@ -1226,7 +1226,7 @@ class TestLoadFlow:
         chain = fixture["chain"]
 
         # test loaded flow
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == fixture["each"]
 
     async def test_sequence_in_each(self, lcel_flow_each_sequence):
@@ -1234,7 +1234,7 @@ class TestLoadFlow:
         chain = fixture["chain"]
 
         # test loaded flow
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         assert flow == fixture["each"]
 
 
@@ -1656,7 +1656,7 @@ class TestFlow:
         chain = fixture["chain"]
 
         # test loaded flow
-        flow = await aload_chain_flow(chain)
+        _, flow = await aload_chain_flow(chain)
         output = await flow.ainvoke(input={"input": "test"})
         assert output == {}
 

--- a/ix/runnable/tests/test_flow.py
+++ b/ix/runnable/tests/test_flow.py
@@ -43,12 +43,8 @@ class TestIxNode:
         }
 
         mapped = RunnableParallel(steps={"foo": ix_node})
-        assert mapped.input_schema().schema() == {
-            "title": "RunnableParallelInput",
-            "type": "object",
-            "properties": {
-                "value": {"title": "Value", "default": "input", "type": "string"}
-            },
+        assert mapped.input_schema().schema()["properties"] == {
+            "value": {"title": "Value", "default": "input", "type": "string"}
         }
 
 

--- a/ix/utils/pydantic.py
+++ b/ix/utils/pydantic.py
@@ -2,6 +2,8 @@ from typing import Any, Type
 
 import pydantic
 from pydantic import BaseModel, create_model
+from pydantic.v1 import create_model as create_model_v1
+
 
 PYDANTIC_VERSION = pydantic.__version__.split(".")
 PYDANTIC_MAJOR_VERSION = int(PYDANTIC_VERSION[0])
@@ -29,3 +31,11 @@ def create_args_model(variables, name="DynamicModel") -> Type[BaseModel]:
     """
     field_definitions = {field: (Any, ...) for field in variables}
     return create_model(name, **field_definitions)
+
+
+def create_args_model_v1(variables, name="DynamicModel") -> Type[BaseModel]:
+    """
+    Dynamically create a Pydantic model class with fields for each variable
+    """
+    field_definitions = {field: (Any, ...) for field in variables}
+    return create_model_v1(name, **field_definitions)


### PR DESCRIPTION
### Description
Chain `input_type` is now generated dynamically to match the inputs (outputs) described by the root node. This provides an input type usable as a pydantic model and json schema.  Will be used by downstream consumers of the chain to display or invoke it.

The type is applied by setting it on a `RunnablePassthrough` and joining it to the head of the chain's nodes.

##### ChatInput node and config
![image](https://github.com/kreneskyp/ix/assets/68635/d5e614fd-71da-4878-abb2-c743f4db3a0c)

### Changes
- added auto input "type mask" to all loaded runnables.
- some other helper and test cleanup.
- relies on unpacking helper (#377)

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
