### PR TITLE
Runnable tools

### DIFF
--- a/ix/chains/loaders/core.py
+++ b/ix/chains/loaders/core.py
@@ -856,6 +856,8 @@ def init_flow_node(
 
         if isinstance(instance, Runnable):
             instance = IxNode(
+                name=root.name,
+                description=root.description,
                 node_id=root.id,
                 child=instance,
                 context=context,

--- a/ix/chains/tests/test_config_loader.py
+++ b/ix/chains/tests/test_config_loader.py
@@ -53,6 +53,7 @@ from ix.chains.loaders.core import (
     ImplicitJoin,
 )
 from ix.chains.loaders.memory import get_memory_session
+from ix.chains.loaders.text_splitter import TextSplitterShim
 from ix.chains.loaders.tools import extract_tool_kwargs, get_runnable_tool
 from ix.chains.models import Chain
 from ix.chains.tests.mock_configs import (

--- a/ix/chains/tests/test_config_loader.py
+++ b/ix/chains/tests/test_config_loader.py
@@ -53,8 +53,7 @@ from ix.chains.loaders.core import (
     ImplicitJoin,
 )
 from ix.chains.loaders.memory import get_memory_session
-from ix.chains.loaders.text_splitter import TextSplitterShim
-from ix.chains.loaders.tools import extract_tool_kwargs
+from ix.chains.loaders.tools import extract_tool_kwargs, get_runnable_tool
 from ix.chains.models import Chain
 from ix.chains.tests.mock_configs import (
     CONVERSATIONAL_RETRIEVAL_CHAIN,
@@ -487,6 +486,37 @@ class TestLoadAgents:
         with pytest.raises(ValueError) as excinfo:
             await aload_chain(config)
             assert "Agents require return_messages=True" in str(excinfo.value)
+
+
+@pytest.mark.django_db
+class TestLoadTools:
+    def test_get_runnable_tool(self):
+        runnable = MockRunnable()
+        tool = get_runnable_tool(
+            name="test", description="this is a test", runnable=runnable
+        )
+        assert isinstance(tool, BaseTool)
+        assert tool.name == "test"
+        assert tool.description == "this is a test"
+        assert tool.args_schema.schema() == {
+            "properties": {
+                "value": {"default": "input", "title": "Value", "type": "string"}
+            },
+            "title": "MockRunnableInput",
+            "type": "object",
+        }
+
+        response = tool(dict(value=1))
+        assert response == {"default": "output", "value": "1"}
+
+    async def test_aget_runnable_tool(self):
+        runnable = MockRunnable()
+        tool = get_runnable_tool(
+            name="test", description="this is a test", runnable=runnable
+        )
+        assert isinstance(tool, BaseTool)
+        response = await tool.ainvoke(dict(value=1))
+        assert response == {"default": "output", "value": "1"}
 
 
 @pytest.mark.django_db

--- a/ix/runnable/ix.py
+++ b/ix/runnable/ix.py
@@ -25,6 +25,8 @@ class IxNode(RunnableSerializable[Input, Output]):
 
     # TODO: does this need to be Runnable or RunnableSerializable?
     # Runnable fixes some tests
+    name: Optional[str] = None
+    description: Optional[str] = None
     node_id: UUID
     child: Runnable
     bind_points: List[str]


### PR DESCRIPTION
### Description
Runnable components that provide an `input_type` may now be used as agent tools. 

The runnable will be wrapped in a `StructuredTool`. The input type is used to generate args for the runnable. If there is no type, or a generic `Input` type   (i.e. input type may be just `Input` without defining fields) then the LLM can't generate args for the function call.

This works best with chain references because they use the chain's input as the schema. Chains that are connected directly in-line won't always have a well defined input_type.

##### Ingestion Agent updated to use a ingestion chain instead of `IngestionTool`
![image](https://github.com/kreneskyp/ix/assets/68635/d7b0c50d-ae2a-4a41-8ec2-0b97e0122f82)


### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
