### PR TITLE
Chain.is_agent defaults to False

### DIFF
--- a/ix/api/chains/endpoints.py
+++ b/ix/api/chains/endpoints.py
@@ -98,7 +98,7 @@ async def create_chain_chat(chain: Chain) -> Chat:
 async def create_chain_instance(**kwargs) -> Chain:
     """Create a chain. Includes creating a test agent, task, and chat."""
 
-    alias = kwargs.pop("alias", None)
+    alias = kwargs.pop("alias", "")
     chain = Chain(**kwargs)
     await chain.asave()
 

--- a/ix/api/chains/types.py
+++ b/ix/api/chains/types.py
@@ -29,7 +29,7 @@ class Chain(BaseModel):
 class CreateChain(BaseModel):
     name: str
     description: Optional[str]
-    is_agent: bool = True
+    is_agent: bool = False
 
     # agent pass through properties
     alias: Optional[str] = None


### PR DESCRIPTION
### Description
Flipping `Chain.is_agent` to default to `False` for new chains. This change removes the need for some extra validation and case logic for new chains where fields are unset and not sent in the request.

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
