### PR TITLE
Create secrets in config form

### DIFF
--- a/frontend/components/Modal.js
+++ b/frontend/components/Modal.js
@@ -21,6 +21,7 @@ export const GenericModal = ({
   showClose,
   children,
   size,
+  closeOnBlur,
 }) => {
   const modalRef = React.useRef();
 
@@ -31,12 +32,14 @@ export const GenericModal = ({
   };
 
   React.useEffect(() => {
-    if (isOpen) {
-      document.addEventListener("focus", handleFocus, true);
+    if (closeOnBlur) {
+      if (isOpen) {
+        document.addEventListener("focus", handleFocus, true);
+      }
+      return () => {
+        document.removeEventListener("focus", handleFocus, true);
+      };
     }
-    return () => {
-      document.removeEventListener("focus", handleFocus, true);
-    };
   }, [isOpen, onClose]);
 
   return (
@@ -66,6 +69,7 @@ export const GenericModal = ({
 GenericModal.defaultProps = {
   showClose: true,
   size: "6xl",
+  closeOnBlur: true,
 };
 
 export const ModalTriggerContent = ({ children }) => {

--- a/frontend/secrets/SecretSelect.js
+++ b/frontend/secrets/SecretSelect.js
@@ -1,7 +1,11 @@
 import React from "react";
-import { Select } from "@chakra-ui/react";
+import { Box, HStack, Select, Tooltip } from "@chakra-ui/react";
 import { usePaginatedAPI } from "utils/hooks/usePaginatedAPI";
 import { useEditorColorMode } from "chains/editor/useColorMode";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPlusCircle } from "@fortawesome/free-solid-svg-icons";
+import SecretsFormModalButton from "secrets/SecretsFormModalButton";
+import { ModalTriggerButton } from "components/Modal";
 
 export const SecretSelect = ({ secretKey, value, onChange }) => {
   const style = useEditorColorMode();
@@ -11,21 +15,50 @@ export const SecretSelect = ({ secretKey, value, onChange }) => {
   });
 
   React.useEffect(() => {
-    load({ secret_type: secretKey });
+    load({ secret_type: secretKey }).catch((err) => {
+      console.error("failed to load secrets", err);
+    });
   }, [secretKey]);
 
+  // New Secret callback: refresh secrets and select the new secret
+  const loadAndSelect = (response) => {
+    load({ secret_type: secretKey }).then(() => {
+      onChange({
+        target: {
+          value: response.id,
+        },
+      });
+    });
+  };
+
   return (
-    <Select
-      value={value || ""}
-      onChange={onChange}
-      placeholder={"Select a secret"}
-      {...style.input}
-    >
-      {page?.objects?.map((secret) => (
-        <option key={secret.id} value={secret.id}>
-          {secret.name}
-        </option>
-      ))}
-    </Select>
+    <HStack>
+      <SecretsFormModalButton forType={secretKey} onSuccess={loadAndSelect}>
+        <ModalTriggerButton>
+          <Tooltip label="Add Secret">
+            <Box
+              color={"gray.500"}
+              _hover={{ color: "green.400", bg: "transparent" }}
+              mx={0}
+            >
+              <FontAwesomeIcon icon={faPlusCircle} />
+            </Box>
+          </Tooltip>
+        </ModalTriggerButton>
+      </SecretsFormModalButton>
+      <Select
+        value={value || ""}
+        onChange={onChange}
+        placeholder={"Select a secret"}
+        {...style.input}
+        ml={0}
+      >
+        {page?.objects?.map((secret) => (
+          <option key={secret.id} value={secret.id}>
+            {secret.name}
+          </option>
+        ))}
+      </Select>
+    </HStack>
   );
 };

--- a/frontend/secrets/SecretsForm.js
+++ b/frontend/secrets/SecretsForm.js
@@ -75,8 +75,8 @@ export const SecretsForm = ({ forType, secret, onSuccess }) => {
       Object.entries(data.value || {}).filter(([key, value]) => value !== "")
     );
 
-    save({ ...data, value }).then(() => {
-      onSuccess();
+    save({ ...data, value }).then((response) => {
+      onSuccess(response);
       onClose();
     });
   }, [data, save]);

--- a/frontend/secrets/SecretsFormModalButton.js
+++ b/frontend/secrets/SecretsFormModalButton.js
@@ -4,6 +4,7 @@ import { ModalTrigger, ModalTriggerContent } from "components/Modal";
 import { Box } from "@chakra-ui/react";
 
 export const SecretsFormModalButton = ({
+  forType,
   secret,
   onOpen,
   onSuccess,
@@ -19,7 +20,11 @@ export const SecretsFormModalButton = ({
       {children}
       <ModalTriggerContent>
         <Box p={4}>
-          <SecretsForm secret={secret} onSuccess={onSuccess} />
+          <SecretsForm
+            forType={forType}
+            secret={secret}
+            onSuccess={onSuccess}
+          />
         </Box>
       </ModalTriggerContent>
     </ModalTrigger>

--- a/frontend/secrets/SecretsFormModalButton.js
+++ b/frontend/secrets/SecretsFormModalButton.js
@@ -16,6 +16,7 @@ export const SecretsFormModalButton = ({
       showClose={false}
       size="xl"
       title="Edit Secret"
+      closeOnBlur={false}
     >
       {children}
       <ModalTriggerContent>

--- a/ix/api/secrets/endpoints.py
+++ b/ix/api/secrets/endpoints.py
@@ -57,6 +57,7 @@ async def get_secret_types(
     offset: int = 0,
     user: User = Depends(get_request_user),
     search: Optional[str] = None,
+    key: Optional[str] = None,
 ):
     """
     List SecretTypes available to the user.
@@ -64,6 +65,8 @@ async def get_secret_types(
     query = SecretType.filtered_owners(user).all()
     if search:
         query = query.filter(name__icontains=search)
+    if key:
+        query = query.filter(name=key)
 
     # Handling pagination manually for this example
     query = query[offset : offset + limit]


### PR DESCRIPTION
### Description
New secrets can now be created directly from the config form.  `SecretSelect` now has a `+` button next to it that opens a `SecretsForm` with the type pre-selected.

This simplifies the flow for creating a new key. 

https://github.com/kreneskyp/ix/assets/68635/a49994f6-7b3e-48b7-b0ae-acb84f277d55

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
