### PR TITLE
Generalizing react-select helpers and styling fixes.

### DIFF
--- a/frontend/chains/editor/ComponentTypeMultiSelect.js
+++ b/frontend/chains/editor/ComponentTypeMultiSelect.js
@@ -6,12 +6,10 @@ import { Box, HStack, Text } from "@chakra-ui/react";
 
 import { useEditorColorMode } from "chains/editor/useColorMode";
 import { NODE_STYLES } from "chains/editor/styles";
-import {
-  COMPONENT_TYPE_OPTIONS,
-  MenuList,
-  useSelectStyles,
-} from "chains/editor/ComponentTypeSelect";
+import { COMPONENT_TYPE_OPTIONS } from "chains/editor/ComponentTypeSelect";
 import { getOptionStyle } from "chains/editor/NodeSelector";
+import { useSelectStyles } from "components/select/useSelectStyles";
+import { MenuList } from "components/select/MenuList";
 
 export const ComponentTypeMultiSelect = ({ onChange, value, ...props }) => {
   const { input: styles, highlight } = useEditorColorMode();

--- a/frontend/chains/editor/ComponentTypeSelect.js
+++ b/frontend/chains/editor/ComponentTypeSelect.js
@@ -6,6 +6,8 @@ import { Box, HStack, Text, useTheme } from "@chakra-ui/react";
 
 import { useEditorColorMode } from "chains/editor/useColorMode";
 import { NODE_STYLES } from "chains/editor/styles";
+import { MenuList } from "components/select/MenuList";
+import { useSelectStyles } from "components/select/useSelectStyles";
 
 const AGENT_HELP_TEXT =
   "Agents may be summoned to chat sessions for conversational interactions.";
@@ -109,47 +111,6 @@ export const findOption = (value) => {
   return COMPONENT_TYPE_OPTIONS.find((option) => option.value === value);
 };
 
-export const MenuList = ({ children }) => {
-  const { isLight } = useEditorColorMode();
-  const theme = useTheme();
-  const style = isLight
-    ? {
-        bg: "white",
-        border: "1px solid",
-        borderColor: "gray.200",
-        boxShadow: "0 0 10px rgba(0,0,0,0.5)",
-      }
-    : {
-        bg: "gray.700",
-        border: "1px solid",
-        borderColor: "gray.600",
-        boxShadow: "0 0 10px rgba(0,0,0,0.5)",
-      };
-
-  const scrollbar_css = {
-    "&::-webkit-scrollbar": {
-      width: "5px",
-      padding: "2px",
-    },
-    "&::-webkit-scrollbar-track": {
-      background: "transparent",
-    },
-    "&::-webkit-scrollbar-thumb": {
-      background: theme.colors.gray[300],
-      borderRadius: "2px",
-    },
-    "&::-webkit-scrollbar-thumb:hover": {
-      background: theme.colors.gray[300],
-    },
-  };
-
-  return (
-    <Box height={500} overflowY={"auto"} sx={scrollbar_css} {...style} mx={1}>
-      {children}
-    </Box>
-  );
-};
-
 const ValueContainer = ({ children, ...props }) => {
   const { getValue } = props;
   const value = getValue()[0];
@@ -180,15 +141,6 @@ const ValueContainer = ({ children, ...props }) => {
       </HStack>
     </components.ValueContainer>
   );
-};
-
-export const useSelectStyles = () => {
-  const { input: styles } = useEditorColorMode();
-  return {
-    menuPortal: (base) => ({ ...base, zIndex: 99999 }),
-    valueContainer: (base) => ({ ...base, padding: 0 }),
-    input: (base) => ({ ...base, ...styles }),
-  };
 };
 
 export const ComponentTypeSelect = ({ chain, onChange, value, ...props }) => {

--- a/frontend/components/select/MenuList.js
+++ b/frontend/components/select/MenuList.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { Box } from "@chakra-ui/react";
+import { components } from "react-select";
+
+import { useEditorColorMode } from "chains/editor/useColorMode";
+
+export const MenuList = ({ children, ...props }) => {
+  const { isLight } = useEditorColorMode();
+  const style = isLight
+    ? {
+        bg: "white",
+        border: "0px solid",
+        borderColor: "gray.200",
+        boxShadow: "0 0 10px rgba(0,0,0,0.5)",
+      }
+    : {
+        bg: "gray.800",
+        border: "0px solid",
+        borderColor: "gray.600",
+        boxShadow: "0 0 10px rgba(0,0,0,0.5)",
+      };
+
+  return (
+    <components.MenuList {...props}>
+      <Box {...style} mx={1}>
+        {children}
+      </Box>
+    </components.MenuList>
+  );
+};

--- a/frontend/components/select/useSelectStyles.js
+++ b/frontend/components/select/useSelectStyles.js
@@ -1,0 +1,13 @@
+import { useEditorColorMode } from "chains/editor/useColorMode";
+import { useScrollbarCSS } from "hooks/useScrollbarCSS";
+
+export const useSelectStyles = () => {
+  const { input: styles } = useEditorColorMode();
+
+  return {
+    menuPortal: (base) => ({ ...base, zIndex: 99999 }),
+    valueContainer: (base) => ({ ...base, padding: 0 }),
+    input: (base) => ({ ...base, ...styles }),
+    menuList: (base) => ({ ...base, ...useScrollbarCSS() }),
+  };
+};

--- a/frontend/hooks/useScrollbarCSS.js
+++ b/frontend/hooks/useScrollbarCSS.js
@@ -1,0 +1,21 @@
+import { useTheme } from "@chakra-ui/react";
+
+export const useScrollbarCSS = () => {
+  const theme = useTheme();
+  return {
+    "&::-webkit-scrollbar": {
+      width: "5px",
+      padding: "2px",
+    },
+    "&::-webkit-scrollbar-track": {
+      background: "transparent",
+    },
+    "&::-webkit-scrollbar-thumb": {
+      background: theme.colors.gray[300],
+      borderRadius: "2px",
+    },
+    "&::-webkit-scrollbar-thumb:hover": {
+      background: theme.colors.gray[300],
+    },
+  };
+};


### PR DESCRIPTION

### Description
Some cleanup for `chakra-react-select` to reduce boilerplate needed to use it elsewhere.

- Moving some reusable helpers needed for styling `chakra-react-select`.
- MenuList should be less likely to overflow page now and is a bit simpler markup

![image](https://github.com/kreneskyp/ix/assets/68635/25aef150-3518-4285-ac94-49c455751cd2)


### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
- MenuList placement is a bit farther below the input than is ideal. I couldn't determine which component css needed tweaking. Should try to fix in a future pr.
