### PR TITLE
Tab fixes

### DIFF
--- a/frontend/chains/ChainEditorView.js
+++ b/frontend/chains/ChainEditorView.js
@@ -148,7 +148,6 @@ const ChainEditorProvider = ({ onError, children }) => {
   );
 };
 
-// TODO: can this be collapsed into ChainEditorView?
 export const ChainEditorControl = () => {
   const { id } = useParams();
   const toast = useToast();

--- a/frontend/chains/flow/ConfigNode.js
+++ b/frontend/chains/flow/ConfigNode.js
@@ -39,7 +39,7 @@ const usePropertyTargets = (node, type) => {
   const edges = useEdges();
 
   return useMemo(() => {
-    const connectors = type.connectors;
+    const connectors = type?.connectors || [];
     return connectors?.map((connector) => {
       const edge = edges?.find(
         (edge) =>
@@ -161,10 +161,10 @@ const DeleteIcon = ({ node }) => {
 
 export const ConfigNode = ({ id, data, selected }) => {
   const { type } = data;
-  const styles = NODE_STYLES[type.type] || DEFAULT_NODE_STYLE;
+  const styles = NODE_STYLES[type?.type] || DEFAULT_NODE_STYLE;
   const { border, color, highlight, highlightColor, bg, selectionShadow } =
     useEditorColorMode();
-  const position = CONNECTOR_CONFIG[type.type]?.source_position || "right";
+  const position = CONNECTOR_CONFIG[type?.type]?.source_position || "right";
   const nodeState = useContext(NodeStateContext);
   const { nodes } = nodeState;
   const node = nodes[data.node.id];
@@ -212,7 +212,7 @@ export const ConfigNode = ({ id, data, selected }) => {
         {...nodeStyle}
       >
         <Handle
-          id={type.type}
+          id={type?.type}
           type="source"
           position={position}
           style={{
@@ -227,7 +227,7 @@ export const ConfigNode = ({ id, data, selected }) => {
           color={highlightColor}
           borderTopLeftRadius={7}
           borderTopRightRadius={7}
-          bg={highlight[type.type] || highlight.default}
+          bg={highlight[type?.type] || highlight.default}
           px={1}
           py={2}
           className="drag-handle"

--- a/frontend/chains/hooks/useGraphForReactFlow.js
+++ b/frontend/chains/hooks/useGraphForReactFlow.js
@@ -30,7 +30,7 @@ export const getEdgeStyle = (colorMode) => {
 export const toReactFlowNode = (node, nodeType) => {
   return {
     id: node.id,
-    type: nodeType.display_type,
+    type: nodeType?.display_type || "node",
     position: node.position,
     data: {
       type: nodeType,

--- a/frontend/chains/hooks/useNodeState.js
+++ b/frontend/chains/hooks/useNodeState.js
@@ -18,7 +18,16 @@ export const useNodeState = (tabState) => {
 
   const setNode = React.useCallback(
     (node) => {
-      setNodes((prev) => ({ ...prev, [node.id]: node }));
+      setNodes((prev) => {
+        // HAX: reject updates from other tabs. This protects against hooks that
+        // aren't updating correctly when switching tabs. This only treats the
+        // symptom, not the cause. But it prevents data corruption of nodes
+        // leaking to other tabs.
+        if (node.chain_id !== tabState.active.chain_id) {
+          return prev;
+        }
+        return { ...prev, [node.id]: node };
+      });
     },
     [setNodes]
   );


### PR DESCRIPTION
### Description
Fixing a bug where selecting a node leaks state to the previous tab. I believe the wrong `setNode` hook is being passed to nodes when switching tabs temporarily. Probably a race condition in the hooks executing. I wasn't able to run that down but found a workaround.

This PR adds some defensive checks to prevent stale hooks as described above. It contains the issue with no apparent side effects. 
 
### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
Address the root cause of the stale hook
