### PR TITLE
OpenAPI nodes

### DIFF
--- a/ix/chains/fixture_src/openapi.py
+++ b/ix/chains/fixture_src/openapi.py
@@ -1,0 +1,37 @@
+from ix.api.components.types import NodeType, NodeTypeField, DisplayGroup
+from ix.runnable.openapi import RunOpenAPIRequest
+
+RUN_OPEN_API_REQUEST_CLASS_PATH = "ix.runnable.openapi.RunOpenAPIRequest"
+RUN_OPEN_API_REQUEST = NodeType(
+    class_path=RUN_OPEN_API_REQUEST_CLASS_PATH,
+    type="chain",
+    name="OpenAPI Request",
+    description="Send a request to an OpenAPI server",
+    fields=NodeTypeField.get_fields(
+        RunOpenAPIRequest,
+        include=[
+            "schema_id",
+            "server",
+            "path",
+            "method",
+            "headers",
+        ],
+        field_options={
+            "schema_id": {"label": "Schema", "input_type": "IX:openapi_schema"},
+            "server": {"input_type": "IX:openapi_server"},
+            "path": {"label": "Action", "input_type": "IX:openapi_action"},
+            "method": {"input_type": "hidden"},
+        },
+    ),
+    display_groups=[
+        DisplayGroup(
+            key="Config",
+            label="Config",
+            fields=["schema_id", "server", "path", "method"],
+        ),
+        DisplayGroup(key="Auth", label="Authentication", fields=["headers"]),
+    ],
+)
+
+
+OPEN_API = [RUN_OPEN_API_REQUEST]

--- a/ix/chains/management/commands/import_langchain.py
+++ b/ix/chains/management/commands/import_langchain.py
@@ -18,6 +18,7 @@ from ix.chains.fixture_src.lcel import LANGCHAIN_RUNNABLES
 from ix.chains.fixture_src.llm import LLMS
 from ix.chains.fixture_src.memory import MEMORY
 from ix.chains.fixture_src.openai_functions import OPENAI_FUNCTIONS
+from ix.chains.fixture_src.openapi import OPEN_API
 from ix.chains.fixture_src.parsers import PARSERS
 from ix.chains.fixture_src.prompts import PROMPTS
 from ix.chains.fixture_src.retriever import RETRIEVERS
@@ -65,6 +66,9 @@ COMPONENTS.extend(DOCUMENT_LOADERS)
 COMPONENTS.extend(UNSTRUCTURED_IO)
 COMPONENTS.extend(VECTORSTORES)
 COMPONENTS.extend(RETRIEVERS)
+
+# Misc components
+COMPONENTS.extend(OPEN_API)
 
 # IX integrations & flow
 COMPONENTS.extend(LANGCHAIN_RUNNABLES)

--- a/ix/runnable/openapi.py
+++ b/ix/runnable/openapi.py
@@ -1,0 +1,98 @@
+import uuid
+import httpx
+from typing import Optional, Type, Dict, Any
+
+from langchain_core.runnables import RunnableSerializable, RunnableConfig
+from langchain_core.runnables.utils import Input, Output
+from pydantic import BaseModel
+
+from ix.data.models import Schema
+from ix.utils.openapi import get_input_schema, HTTP_METHODS, get_action_schema
+from jsonschema_pydantic import jsonschema_to_pydantic
+
+
+def build_httpx_kwargs(path: str, input: Input, **kwargs) -> dict[str, Any]:
+    """Build kwargs for OpenAPI request with httpx"""
+    formatted_path = path.format(**input.get("path", {}))
+    headers = kwargs.get("headers", {})
+    headers.update(input.get("headers", {}))
+    request_kwargs = {
+        "url": formatted_path,
+        "params": input.get("query"),
+        "headers": headers,
+    }
+
+    body = input.get("body", None)
+    if body:
+        request_kwargs["json"] = body
+
+    return request_kwargs
+
+
+class RunOpenAPIRequest(RunnableSerializable[Input, Output]):
+    """Make a request to an OpenAPI server and return the response."""
+
+    schema_id: uuid.UUID = None
+    server: str
+    path: str
+    method: HTTP_METHODS
+    headers: Optional[dict] = None
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    def get_schema(self) -> Schema:
+        return Schema.objects.get(pk=self.schema_id)
+
+    def _get_input_schema(self, schema: Schema) -> Dict[str, Any]:
+        """Get JSON schema from OpenAPI schema for the specified path and method.
+
+        The schema includes params for path, query, and body.
+        """
+        if schema.type != "openapi":
+            raise ValueError("Schema must be of type openapi")
+
+        action_schema = get_action_schema(schema.value, self.path, self.method)
+        input_schema = get_input_schema(action_schema, self.path, self.method)
+        return input_schema
+
+    def get_input_schema(
+        self, config: Optional[RunnableConfig] = None
+    ) -> Type[BaseModel]:
+        """return input schema for the path and method."""
+        schema = self.get_schema()
+        input_schema_dict = self._get_input_schema(schema)
+        input_schema = jsonschema_to_pydantic(input_schema_dict, version=2)
+        return input_schema
+
+    def get_output_schema(
+        self, config: Optional[RunnableConfig] = None
+    ) -> Type[BaseModel]:
+        # TODO: extract from openapi spec
+        return super().get_output_schema(config)
+
+    def invoke(
+        self, input: Input, config: Optional[RunnableConfig] = None, **kwargs
+    ) -> Output:
+        with httpx.Client() as client:
+            request_kwargs = build_httpx_kwargs(self.server, self.path, input)
+            client_method = getattr(client, self.method)
+            response = client_method(**request_kwargs)
+
+        if response.status_code != 200:
+            raise Exception(f"Failed to get schema: {response.content}")
+
+        return response.json()
+
+    async def ainvoke(
+        self, input: Input, config: Optional[RunnableConfig] = None, **kwargs
+    ) -> Output:
+        async with httpx.AsyncClient(base_url=self.server) as client:
+            request_kwargs = build_httpx_kwargs(self.path, input)
+            client_method = getattr(client, self.method)
+            response = await client_method(**request_kwargs)
+
+        if response.status_code != 200:
+            raise Exception(f"Failed to get schema: {response.content}")
+
+        return response.json()

--- a/ix/runnable/tests/test_openapi.py
+++ b/ix/runnable/tests/test_openapi.py
@@ -1,0 +1,195 @@
+import httpx
+import pytest
+import pytest_asyncio
+from pydantic import BaseModel
+from pydantic.v1 import BaseModel as BaseModelV1
+
+from ix.api.chains.types import ChainQueryPage, Chain as ChainPydantic, CreateChain
+from ix.chains.tests.fake import afake_chain
+from ix.data.models import Schema
+from ix.runnable.openapi import RunOpenAPIRequest
+from ix.server.fast_api import app
+from ix.utils.tests.mock_schema import LIST_PATH, SERVER, DETAIL_PATH, SCHEMA
+
+
+@pytest.fixture
+def mock_httpx(mocker):
+    """Mock httpx.AsyncClient to use FastAPI app as transport."""
+    original_async_client = httpx.AsyncClient
+
+    def async_client_wrapper(*args, **kwargs):
+        kwargs["app"] = app
+        return original_async_client(*args, **kwargs)
+
+    mocker.patch("httpx.AsyncClient", side_effect=async_client_wrapper)
+
+
+@pytest.fixture
+def schema():
+    return Schema.objects.create(
+        name="IX Test Schema",
+        type="openapi",
+        description="Subset of IX schema for testing",
+        value=SCHEMA,
+    )
+
+
+@pytest_asyncio.fixture
+async def aschema():
+    return await Schema.objects.acreate(
+        name="IX Test Schema",
+        type="openapi",
+        description="Subset of IX schema for testing",
+        value=SCHEMA,
+    )
+
+
+@pytest.mark.django_db
+class TestRunOpenAPIRequest:
+    def test_input_query_args(self, schema):
+        """Test that component can be initialized"""
+        runnable = RunOpenAPIRequest(
+            schema_id=schema.id, path=LIST_PATH, method="get", server=SERVER
+        )
+        assert issubclass(runnable.get_input_schema(), (BaseModel, BaseModelV1))
+        assert runnable.get_input_schema().model_json_schema() == {
+            "$defs": {
+                "DynamicModel": {
+                    "properties": {
+                        "is_agent": {
+                            "anyOf": [{"type": "boolean"}, {"type": "null"}],
+                            "default": None,
+                            "title": "Is Agent",
+                        },
+                        "limit": {
+                            "anyOf": [{"type": "integer"}, {"type": "null"}],
+                            "default": 10,
+                            "title": "Limit",
+                        },
+                        "offset": {
+                            "anyOf": [{"type": "integer"}, {"type": "null"}],
+                            "default": 0,
+                            "title": "Offset",
+                        },
+                        "search": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "default": None,
+                            "title": "Search",
+                        },
+                    },
+                    "title": "DynamicModel",
+                    "type": "object",
+                }
+            },
+            "properties": {
+                "query": {
+                    "anyOf": [{"$ref": "#/$defs/DynamicModel"}, {"type": "null"}],
+                    "default": None,
+                }
+            },
+            "title": "DynamicModel",
+            "type": "object",
+        }
+
+    def test_input_with_path_args(self, schema):
+        """Test that component can be initialized"""
+        runnable = RunOpenAPIRequest(
+            schema_id=schema.id, path=DETAIL_PATH, method="get", server=SERVER
+        )
+        input_schema = runnable.get_input_schema()
+        assert issubclass(input_schema, (BaseModel, BaseModelV1))
+        assert input_schema.model_json_schema() == {
+            "$defs": {
+                "DynamicModel": {
+                    "properties": {"chain_id": {"title": "Chain Id", "type": "string"}},
+                    "required": ["chain_id"],
+                    "title": "DynamicModel",
+                    "type": "object",
+                }
+            },
+            "properties": {
+                "args": {
+                    "anyOf": [{"$ref": "#/$defs/DynamicModel"}, {"type": "null"}],
+                    "default": None,
+                }
+            },
+            "title": "DynamicModel",
+            "type": "object",
+        }
+
+    def test_input_with_body_args(self, schema):
+        """Test that component can be initialized"""
+        runnable = RunOpenAPIRequest(
+            schema_id=schema.id, path=LIST_PATH, method="post", server=SERVER
+        )
+
+        input_schema = runnable.get_input_schema()
+        assert issubclass(input_schema, (BaseModel, BaseModelV1))
+        assert input_schema.model_json_schema() == {
+            "$defs": {
+                "CreateChain": {
+                    "properties": {
+                        "alias": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "default": None,
+                            "title": "Alias",
+                        },
+                        "description": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "title": "Description",
+                        },
+                        "is_agent": {
+                            "anyOf": [{"type": "boolean"}, {"type": "null"}],
+                            "default": False,
+                            "title": "Is Agent",
+                        },
+                        "name": {"title": "Name", "type": "string"},
+                    },
+                    "required": ["name", "description"],
+                    "title": "CreateChain",
+                    "type": "object",
+                }
+            },
+            "properties": {"body": {"$ref": "#/$defs/CreateChain"}},
+            "required": ["body"],
+            "title": "DynamicModel",
+            "type": "object",
+        }
+
+    async def test_ainvoke_get_list(self, auser, aschema, mock_httpx):
+        await afake_chain()
+        runnable = RunOpenAPIRequest(
+            schema_id=aschema.id,
+            path=LIST_PATH,
+            method="get",
+            server=SERVER,
+            headers={},
+        )
+        output = await runnable.ainvoke(input={})
+        page = ChainQueryPage.model_validate(output)
+        assert page.count >= 1
+
+    async def test_ainvoke_get_detail(self, aschema, auser, mock_httpx):
+        chain = await afake_chain(is_agent=False)
+        runnable = RunOpenAPIRequest(
+            schema_id=aschema.id, path=DETAIL_PATH, method="get", server=SERVER
+        )
+        output = await runnable.ainvoke(input={"path": {"chain_id": str(chain.id)}})
+        assert ChainPydantic.model_validate(output).id == chain.id
+
+    async def test_ainvoke_post_list(self, aschema, auser, mock_httpx):
+        runnable = RunOpenAPIRequest(
+            schema_id=aschema.id, path=LIST_PATH, method="post", server=SERVER
+        )
+
+        data = CreateChain(
+            name="Test Chain",
+            description="Test Chain Description",
+            is_agent=False,
+        )
+        output = await runnable.ainvoke(input={"body": data.model_dump()})
+        chain = ChainPydantic.model_validate(output)
+
+        assert chain.name == data.name
+        assert chain.description == data.description
+        assert chain.is_agent == data.is_agent

--- a/ix/utils/tests/mock_schema.py
+++ b/ix/utils/tests/mock_schema.py
@@ -1,0 +1,445 @@
+LIST_PATH = "/chains/"
+DETAIL_PATH = "/chains/{chain_id}"
+SERVER = "http://test"
+
+SCHEMA = {
+    "openapi": "3.1.0",
+    "info": {
+        "title": "IX agent editor API",
+        "description": "API for editing Agents, Chains, and node_type components",
+        "version": "0.1.0",
+    },
+    "paths": {
+        "/chains/": {
+            "get": {
+                "tags": ["Chains"],
+                "summary": "Get Chains",
+                "operationId": "get_chains_chains__get",
+                "parameters": [
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "required": False,
+                        "schema": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "title": "Search",
+                        },
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": False,
+                        "schema": {"type": "integer", "default": 10, "title": "Limit"},
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "required": False,
+                        "schema": {"type": "integer", "default": 0, "title": "Offset"},
+                    },
+                    {
+                        "name": "is_agent",
+                        "in": "query",
+                        "required": False,
+                        "schema": {
+                            "anyOf": [{"type": "boolean"}, {"type": "null"}],
+                            "title": "Is Agent",
+                        },
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ChainQueryPage"
+                                }
+                            }
+                        },
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+            },
+            "post": {
+                "tags": ["Chains"],
+                "summary": "Create Chain",
+                "operationId": "create_chain_chains__post",
+                "requestBody": {
+                    "required": True,
+                    "content": {
+                        "application/json": {
+                            "schema": {"$ref": "#/components/schemas/CreateChain"}
+                        }
+                    },
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Chain"}
+                            }
+                        },
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+            },
+        },
+        "/chains/{chain_id}": {
+            "get": {
+                "tags": ["Chains"],
+                "summary": "Get Chain Detail",
+                "operationId": "get_chain_detail_chains__chain_id__get",
+                "parameters": [
+                    {
+                        "name": "chain_id",
+                        "in": "path",
+                        "required": True,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Chain Id",
+                        },
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Chain"}
+                            }
+                        },
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+            },
+            "put": {
+                "tags": ["Chains"],
+                "summary": "Update Chain",
+                "operationId": "update_chain_chains__chain_id__put",
+                "parameters": [
+                    {
+                        "name": "chain_id",
+                        "in": "path",
+                        "required": True,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Chain Id",
+                        },
+                    }
+                ],
+                "requestBody": {
+                    "required": True,
+                    "content": {
+                        "application/json": {
+                            "schema": {"$ref": "#/components/schemas/UpdateChain"}
+                        }
+                    },
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Chain"}
+                            }
+                        },
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+            },
+            "delete": {
+                "tags": ["Chains"],
+                "summary": "Delete Chain",
+                "operationId": "delete_chain_chains__chain_id__delete",
+                "parameters": [
+                    {
+                        "name": "chain_id",
+                        "in": "path",
+                        "required": True,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Chain Id",
+                        },
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/DeletedItem"}
+                            }
+                        },
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+            },
+        },
+    },
+    "components": {
+        "schemas": {
+            "Chain": {
+                "properties": {
+                    "id": {
+                        "anyOf": [
+                            {"type": "string", "format": "uuid"},
+                            {"type": "null"},
+                        ],
+                        "title": "Id",
+                    },
+                    "name": {"type": "string", "title": "Name"},
+                    "description": {"type": "string", "title": "Description"},
+                    "created_at": {
+                        "anyOf": [
+                            {"type": "string", "format": "date-time"},
+                            {"type": "null"},
+                        ],
+                        "title": "Created At",
+                    },
+                    "is_agent": {
+                        "type": "boolean",
+                        "title": "Is Agent",
+                        "default": True,
+                    },
+                    "alias": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "title": "Alias",
+                    },
+                },
+                "type": "object",
+                "required": ["id", "name", "description", "created_at"],
+                "title": "Chain",
+            },
+            "ChainQueryPage": {
+                "properties": {
+                    "page_number": {"type": "integer", "title": "Page Number"},
+                    "pages": {"type": "integer", "title": "Pages"},
+                    "count": {"type": "integer", "title": "Count"},
+                    "has_next": {"type": "boolean", "title": "Has Next"},
+                    "has_previous": {"type": "boolean", "title": "Has Previous"},
+                    "objects": {
+                        "items": {"$ref": "#/components/schemas/Chain"},
+                        "type": "array",
+                        "title": "Objects",
+                    },
+                },
+                "type": "object",
+                "required": [
+                    "page_number",
+                    "pages",
+                    "count",
+                    "has_next",
+                    "has_previous",
+                    "objects",
+                ],
+                "title": "ChainQueryPage",
+            },
+            "CreateChain": {
+                "properties": {
+                    "name": {"type": "string", "title": "Name"},
+                    "description": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "title": "Description",
+                    },
+                    "is_agent": {
+                        "type": "boolean",
+                        "title": "Is Agent",
+                        "default": False,
+                    },
+                    "alias": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "title": "Alias",
+                    },
+                },
+                "type": "object",
+                "required": ["name", "description"],
+                "title": "CreateChain",
+            },
+            "HTTPValidationError": {
+                "properties": {
+                    "detail": {
+                        "items": {"$ref": "#/components/schemas/ValidationError"},
+                        "type": "array",
+                        "title": "Detail",
+                    }
+                },
+                "type": "object",
+                "title": "HTTPValidationError",
+            },
+            "UpdateChain": {
+                "properties": {
+                    "name": {"type": "string", "title": "Name"},
+                    "description": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "title": "Description",
+                    },
+                    "is_agent": {
+                        "type": "boolean",
+                        "title": "Is Agent",
+                        "default": False,
+                    },
+                    "alias": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "title": "Alias",
+                    },
+                },
+                "type": "object",
+                "required": ["name", "description"],
+                "title": "UpdateChain",
+            },
+            "UpdateEdge": {
+                "properties": {
+                    "source_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Source Id",
+                    },
+                    "target_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Target Id",
+                    },
+                },
+                "type": "object",
+                "required": ["source_id", "target_id"],
+                "title": "UpdateEdge",
+            },
+            "ValidationError": {
+                "properties": {
+                    "loc": {
+                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+                        "type": "array",
+                        "title": "Location",
+                    },
+                    "msg": {"type": "string", "title": "Message"},
+                    "type": {"type": "string", "title": "Error Type"},
+                },
+                "type": "object",
+                "required": ["loc", "msg", "type"],
+                "title": "ValidationError",
+            },
+        }
+    },
+    "servers": [
+        {"url": "http://172.17.0.1:8000/api", "description": "Development server"}
+    ],
+}
+
+GET_LIST_SCHEMA = {
+    "definitions": {
+        "Query": {
+            "properties": {
+                "is_agent": {
+                    "anyOf": [{"type": "boolean"}, {"type": "null"}],
+                    "title": "Is Agent",
+                },
+                "limit": {"default": 10, "title": "Limit", "type": "integer"},
+                "offset": {"default": 0, "title": "Offset", "type": "integer"},
+                "search": {
+                    "anyOf": [{"type": "string"}, {"type": "null"}],
+                    "title": "Search",
+                },
+            },
+            "required": [],
+            "type": "object",
+        }
+    },
+    "properties": {"query": {"$ref": "#/definitions/Query"}},
+    "required": [],
+    "type": "object",
+}
+
+POST_LIST_SCHEMA = {
+    "definitions": {
+        "CreateChain": {
+            "properties": {
+                "alias": {
+                    "anyOf": [{"type": "string"}, {"type": "null"}],
+                    "title": "Alias",
+                },
+                "description": {
+                    "anyOf": [{"type": "string"}, {"type": "null"}],
+                    "title": "Description",
+                },
+                "is_agent": {
+                    "default": False,
+                    "title": "Is " "Agent",
+                    "type": "boolean",
+                },
+                "name": {"title": "Name", "type": "string"},
+            },
+            "required": ["name", "description"],
+            "title": "CreateChain",
+            "type": "object",
+        }
+    },
+    "properties": {"body": {"$ref": "#/definitions/CreateChain"}},
+    "required": ["body"],
+    "type": "object",
+}
+
+
+GET_DETAIL_SCHEMA = {
+    "definitions": {
+        "Args": {
+            "properties": {
+                "chain_id": {"format": "uuid", "title": "Chain Id", "type": "string"}
+            },
+            "required": ["chain_id"],
+            "type": "object",
+        }
+    },
+    "properties": {"args": {"$ref": "#/definitions/Args"}},
+    "required": ["path"],
+    "type": "object",
+}

--- a/ix/utils/tests/test_openapi.py
+++ b/ix/utils/tests/test_openapi.py
@@ -1,0 +1,27 @@
+from ix.utils.openapi import get_input_schema
+from ix.utils.tests.mock_schema import (
+    SCHEMA,
+    DETAIL_PATH,
+    LIST_PATH,
+    GET_DETAIL_SCHEMA,
+    GET_LIST_SCHEMA,
+    POST_LIST_SCHEMA,
+)
+
+
+class TestGetInputSchema:
+    """
+    Test using get_input_schema to extract the input schema from an OpenAPI schema.
+    """
+
+    def test_path_args(self):
+        input_schema = get_input_schema(SCHEMA, DETAIL_PATH, "get")
+        assert input_schema == GET_DETAIL_SCHEMA
+
+    def test_query_args(self):
+        input_schema = get_input_schema(SCHEMA, LIST_PATH, "get")
+        assert input_schema == GET_LIST_SCHEMA
+
+    def test_body_args(self):
+        input_schema = get_input_schema(SCHEMA, LIST_PATH, "post")
+        assert input_schema == POST_LIST_SCHEMA

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ isort==5.12.0
 jq==1.4.1
 jsonpath-ng==1.6.0
 jsonschema==4.19.1
-jsonschema-pydantic==0.3.0
+jsonschema-pydantic==0.5.0
 langchain==0.1.0
 langchain-community==0.0.12
 langchain-google-genai[images]==0.0.6

--- a/test_data/snapshots/components/ix.runnable.openapi.RunOpenAPIRequest.json
+++ b/test_data/snapshots/components/ix.runnable.openapi.RunOpenAPIRequest.json
@@ -1,0 +1,189 @@
+{
+    "child_field": null,
+    "class_path": "ix.runnable.openapi.RunOpenAPIRequest",
+    "config_schema": {
+        "display_groups": [
+            {
+                "fields": [
+                    "schema_id",
+                    "server",
+                    "path",
+                    "method"
+                ],
+                "key": "Config",
+                "label": "Config"
+            },
+            {
+                "fields": [
+                    "headers"
+                ],
+                "key": "Auth",
+                "label": "Authentication"
+            }
+        ],
+        "properties": {
+            "headers": {
+                "label": "Headers",
+                "type": "object"
+            },
+            "method": {
+                "enum": [
+                    "get",
+                    "post",
+                    "put",
+                    "patch",
+                    "delete",
+                    "options",
+                    "head"
+                ],
+                "input_type": "hidden",
+                "label": "Method",
+                "type": "string"
+            },
+            "path": {
+                "input_type": "IX:openapi_action",
+                "label": "Action",
+                "type": "string"
+            },
+            "schema_id": {
+                "input_type": "IX:openapi_schema",
+                "label": "Schema",
+                "type": "object"
+            },
+            "server": {
+                "input_type": "IX:openapi_server",
+                "label": "Server",
+                "type": "string"
+            }
+        },
+        "required": [
+            "schema_id",
+            "server",
+            "path",
+            "method"
+        ],
+        "title": "RunOpenAPIRequest",
+        "type": "object"
+    },
+    "connectors": null,
+    "description": "Send a request to an OpenAPI server",
+    "display_type": "node",
+    "fields": [
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "init_type": "init",
+            "input_type": "IX:openapi_schema",
+            "label": "Schema",
+            "max": null,
+            "min": null,
+            "name": "schema_id",
+            "parent": null,
+            "required": true,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "UUID"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "init_type": "init",
+            "input_type": "IX:openapi_server",
+            "label": "Server",
+            "max": null,
+            "min": null,
+            "name": "server",
+            "parent": null,
+            "required": true,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "str"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "init_type": "init",
+            "input_type": "IX:openapi_action",
+            "label": "Action",
+            "max": null,
+            "min": null,
+            "name": "path",
+            "parent": null,
+            "required": true,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "str"
+        },
+        {
+            "choices": [
+                {
+                    "label": "Get",
+                    "value": "get"
+                },
+                {
+                    "label": "Post",
+                    "value": "post"
+                },
+                {
+                    "label": "Put",
+                    "value": "put"
+                },
+                {
+                    "label": "Patch",
+                    "value": "patch"
+                },
+                {
+                    "label": "Delete",
+                    "value": "delete"
+                },
+                {
+                    "label": "Options",
+                    "value": "options"
+                },
+                {
+                    "label": "Head",
+                    "value": "head"
+                }
+            ],
+            "default": null,
+            "description": null,
+            "init_type": "init",
+            "input_type": "hidden",
+            "label": "Method",
+            "max": null,
+            "min": null,
+            "name": "method",
+            "parent": null,
+            "required": true,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "str"
+        },
+        {
+            "choices": null,
+            "default": null,
+            "description": null,
+            "init_type": "init",
+            "input_type": null,
+            "label": "Headers",
+            "max": null,
+            "min": null,
+            "name": "headers",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "dict"
+        }
+    ],
+    "name": "OpenAPI Request",
+    "type": "chain"
+}


### PR DESCRIPTION
### Description
Adding `RunOpenAPIRequest` a runnable that sends a request to an OpenAPI server using a schema stored in the registry. The component allows you to select a schema, server, and action. `RunOpenAPIRequest` returns an input schema for the action and is usable as a tool.

Create schemas via the new UI accessible via the menu or the component's config #391 

##### RunOpenAPIRequest config
![image](https://github.com/kreneskyp/ix/assets/68635/023ecd74-cd0d-4f96-8740-797db946b3ab)


### Changes
- adds `RunOpenAPIRequest `
- adds a workaround to build `StructuredTool` for Pydantic v2 models, which are output by `jsonschema-pydantic`.
- updated to the latest `jsonschema-pydantic`.  Needed at least `0.4.0`

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
