### PR TITLE
Components configs saving without changes

### DIFF
--- a/frontend/chains/editor/PromptMessageInput.js
+++ b/frontend/chains/editor/PromptMessageInput.js
@@ -59,18 +59,27 @@ export const PromptMessageInput = ({ initialValue, onChange, ...props }) => {
     () => withHistory(withReact(createEditor())),
     []
   );
+
   const [value, setValue] = React.useState([
     {
       children: [{ text: initialValue }],
     },
   ]);
 
+  const previousPlainText = React.useRef(extractPlainText(value));
+
   const handleChange = React.useCallback(
     (newValue) => {
-      if (onChange !== undefined) {
-        const plainText = extractPlainText(newValue);
-        onChange(plainText);
+      const newPlainText = extractPlainText(newValue);
+
+      // Only call onChange if the text has actually changed
+      if (newPlainText !== previousPlainText.current) {
+        if (onChange !== undefined) {
+          onChange(newPlainText);
+        }
+        previousPlainText.current = newPlainText;
       }
+
       setValue(newValue);
     },
     [onChange]

--- a/frontend/components/DictForm.js
+++ b/frontend/components/DictForm.js
@@ -32,15 +32,18 @@ export const DictForm = ({ label, dict, key_props, value_props, onChange }) => {
   };
 
   // This effect will update the parent component when entries change
+  const isMounted = React.useRef(false);
   useEffect(() => {
-    if (entries) {
+    if (isMounted.current) {
       const filteredEntries = entries.filter(([key]) => key !== "");
       onChange(Object.fromEntries(filteredEntries));
-    }
 
-    // Check if the last entry is empty before adding a new one
-    if (entries[entries.length - 1].some((entry) => entry !== "")) {
-      setEntries([...entries, ["", ""]]); // Adds a new entry line immediately
+      // Check if the last entry is empty before adding a new one
+      if (entries[entries.length - 1].some((entry) => entry !== "")) {
+        setEntries([...entries, ["", ""]]); // Adds a new entry line immediately
+      }
+    } else {
+      isMounted.current = true;
     }
   }, [entries]);
 


### PR DESCRIPTION
### Description
Prompt editor and DictForms were triggering components to save from user interactions that should not have triggered saves.

Might be related to #392

### Changes
- Prompt editor was saving whenever the editor window received focus
- DictForm was saving on first render, before any edits

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
