### PR TITLE
Drag n Drop schemas

### DIFF
--- a/frontend/chains/editor/DraggableNode.js
+++ b/frontend/chains/editor/DraggableNode.js
@@ -1,0 +1,45 @@
+import React from "react";
+import { Box } from "@chakra-ui/react";
+
+/**
+ * Generic wrapper component that make a react component drag-n-droppable into the graph.
+ * can be configured with a class_path, name, description, and config for the node that
+ * will be created.
+ *
+ * This is used to create draggable nodes in the sidebar for objects like schmeas, agents,
+ * and chains. The dropped nodes may be initialized with a config that references the
+ * object that was dragged in.
+ */
+export const DraggableNode = ({
+  children,
+  name,
+  description,
+  class_path,
+  config,
+  onDrag,
+  ...props
+}) => {
+  const handleStart = (event) => {
+    const payload = {
+      name,
+      description,
+      class_path,
+      config,
+    };
+    event.dataTransfer.setData(
+      "application/reactflow",
+      JSON.stringify(payload)
+    );
+    event.dataTransfer.effectAllowed = "move";
+
+    if (onDrag) {
+      onDrag(payload);
+    }
+  };
+
+  return (
+    <Box cursor={"grab"} draggable onDragStart={handleStart} {...props}>
+      {children}
+    </Box>
+  );
+};

--- a/frontend/chains/editor/NodeSelector.js
+++ b/frontend/chains/editor/NodeSelector.js
@@ -52,7 +52,10 @@ export const NodeSelector = ({ type }) => {
   const style = getOptionStyle(isLight);
 
   const handleStart = (event, data) => {
-    event.dataTransfer.setData("application/reactflow", JSON.stringify(type));
+    event.dataTransfer.setData(
+      "application/reactflow",
+      JSON.stringify({ type })
+    );
     event.dataTransfer.effectAllowed = "move";
   };
 

--- a/frontend/components/ListItemNode.js
+++ b/frontend/components/ListItemNode.js
@@ -1,0 +1,53 @@
+import React from "react";
+import { Box } from "@chakra-ui/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faChain } from "@fortawesome/free-solid-svg-icons";
+import { useEditorColorMode } from "chains/editor/useColorMode";
+
+/**
+ * An expanding node for use in menu popover lists. When hovered, the node
+ * expands to show the full label.
+ *
+ * This is normally combined with DraggableNode to create a node
+ * that can be dragged into the graph.
+ */
+export const ListItemNode = ({ label, icon }) => {
+  const style = useEditorColorMode();
+
+  return (
+    <Box
+      h={"100%"}
+      w={10}
+      bg={"blackAlpha.300"}
+      p={3}
+      color={"gray.400"}
+      display={"flex"}
+      alignItems={"center"}
+      justifyContent={"center"}
+      _hover={{
+        bg: style.highlight.chain,
+        color: "white",
+        width: "130px",
+        ".hover-text": { visibility: "visible", maxWidth: "120px" },
+      }}
+      transition="background-color 0.2s ease-in, color 0.2s ease-in, width 0.2s ease-in"
+      borderRadius={5}
+      fontSize={"xs"}
+      cursor={"grab"}
+    >
+      <FontAwesomeIcon icon={icon || faChain} />
+      <Box
+        as="span"
+        className="hover-text"
+        visibility="hidden"
+        maxWidth="0"
+        overflow="hidden"
+        whiteSpace="nowrap"
+        ml={2}
+        transition="visibility 0.2s ease-in, max-width 0.2s ease-in"
+      >
+        {label}
+      </Box>
+    </Box>
+  );
+};

--- a/frontend/schemas/SchemaTable.js
+++ b/frontend/schemas/SchemaTable.js
@@ -4,7 +4,7 @@ import { ModalTrigger } from "components/Modal";
 import { SchemaFormModalButton } from "schemas/SchemaFormModalButton";
 import { useEditorColorMode } from "chains/editor/useColorMode";
 
-export const SchemaTable = ({ type, title, page, load }) => {
+export const SchemaTable = ({ type, page, Draggable, load }) => {
   const style = useEditorColorMode();
 
   return (
@@ -29,6 +29,7 @@ export const SchemaTable = ({ type, title, page, load }) => {
               </ModalTrigger.Button>
             </SchemaFormModalButton>
           </Box>
+          {Draggable && <Draggable schema={schema} />}
         </HStack>
       ))}
     </VStack>

--- a/frontend/schemas/json/JSONSchemaDraggable.js
+++ b/frontend/schemas/json/JSONSchemaDraggable.js
@@ -1,0 +1,22 @@
+import React from "react";
+import { DraggableNode } from "chains/editor/DraggableNode";
+import { ListItemNode } from "components/ListItemNode";
+
+const DRAGGABLE_CONFIG = {
+  class_path: "ix.runnable.schemas.LoadSchema",
+  label: "Load Schema",
+};
+
+export const JSONSchemaDraggable = ({ schema }) => {
+  return (
+    <DraggableNode
+      {...DRAGGABLE_CONFIG}
+      name={`Load: ${schema.name}`}
+      description={schema.description}
+      config={{ schema_id: schema.id }}
+      height={"100%"}
+    >
+      <ListItemNode label={"Load Schema"} />
+    </DraggableNode>
+  );
+};

--- a/frontend/schemas/json/JSONSchemaMenuItem.js
+++ b/frontend/schemas/json/JSONSchemaMenuItem.js
@@ -13,6 +13,7 @@ import { SchemaFormModalButton } from "schemas/SchemaFormModalButton";
 import { MenuItem } from "site/MenuItem";
 import { JSONSchemaIcon } from "icons/JSONSchemaIcon";
 import { useEditorColorMode } from "chains/editor/useColorMode";
+import { JSONSchemaDraggable } from "schemas/json/JSONSchemaDraggable";
 
 export const JSONSchemaMenuItem = ({ editor }) => {
   const style = useEditorColorMode();
@@ -56,7 +57,12 @@ export const JSONSchemaMenuItem = ({ editor }) => {
           </Box>
         ) : (
           <Box width={500}>
-            <SchemaTable page={page} load={load} type={"json"} />
+            <SchemaTable
+              page={page}
+              load={load}
+              type={"json"}
+              Draggable={JSONSchemaDraggable}
+            />
           </Box>
         )}
       </LeftSidebarPopupContent>

--- a/frontend/schemas/openapi/OpenAPIDraggable.js
+++ b/frontend/schemas/openapi/OpenAPIDraggable.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { DraggableNode } from "chains/editor/DraggableNode";
+import { ListItemNode } from "components/ListItemNode";
+
+export const DRAGGABLE_CONFIG = {
+  class_path: "ix.runnable.openapi.RunOpenAPIRequest",
+  label: "Run OpenAPI Request",
+};
+
+export const OpenAPIDraggable = ({ schema }) => {
+  // name and description for RunOpenAPIRequest should be taken from the action (path+method)
+  // which aren't known here. Set the schema_id only.
+  return (
+    <DraggableNode
+      {...DRAGGABLE_CONFIG}
+      name=""
+      description=""
+      config={{ schema_id: schema.id }}
+      height={"100%"}
+    >
+      <ListItemNode label={"OpenAPI Request"} />
+    </DraggableNode>
+  );
+};

--- a/frontend/schemas/openapi/OpenAPISchemaMenuItem.js
+++ b/frontend/schemas/openapi/OpenAPISchemaMenuItem.js
@@ -13,6 +13,7 @@ import { SchemaFormModalButton } from "schemas/SchemaFormModalButton";
 import { MenuItem } from "site/MenuItem";
 import { OpenAPIIcon } from "icons/OpenAPIIcon";
 import { useEditorColorMode } from "chains/editor/useColorMode";
+import { OpenAPIDraggable } from "schemas/openapi/OpenAPIDraggable";
 
 export const OpenAPISchemaMenuItem = ({ editor }) => {
   const { page, isLoading, load } = usePaginatedAPI("/api/schemas/", {
@@ -56,7 +57,12 @@ export const OpenAPISchemaMenuItem = ({ editor }) => {
           </Box>
         ) : (
           <Box width={500}>
-            <SchemaTable page={page} load={load} type={"openapi"} />
+            <SchemaTable
+              page={page}
+              load={load}
+              type={"openapi"}
+              Draggable={OpenAPIDraggable}
+            />
           </Box>
         )}
       </LeftSidebarPopupContent>

--- a/ix/api/components/endpoints.py
+++ b/ix/api/components/endpoints.py
@@ -19,6 +19,7 @@ router = APIRouter()
 @router.get("/node_types/", response_model=NodeTypePage, tags=["Components"])
 async def get_node_types(
     search: Optional[str] = None,
+    class_path: Optional[str] = None,
     types: Optional[List[str]] = Query(None, alias="types"),
     limit: int = 50,
     offset: int = 0,
@@ -33,6 +34,8 @@ async def get_node_types(
             | Q(type__icontains=search)
             | Q(class_path__icontains=search)
         )
+    if class_path:
+        query = query.filter(class_path=class_path)
 
     if types:
         query = query.filter(type__in=types)


### PR DESCRIPTION
### Description
JSONSchema and OpenAPI Spec can now be drag-n-dropped into the graph from the menu popover. This adds a generic `DraggableNode` wrapper to extend drag-n-drop functionality to other objects.


https://github.com/kreneskyp/ix/assets/68635/a3aefe0c-f522-49fa-b869-9c0d69aec21c



### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
- attempted to integrate `DraggableNode` with Chains, Agents, and API Actions. All three are in a modal, which appears to block drag-n-drop into the graph. I think the issue is the overlay it creates. Will search for a work around in a separate PR.
