### PR TITLE
TabState.chain_id wasn't set correctly on chain creation

### DIFF
--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -111,7 +111,7 @@ const ChainGraphEditor = ({ graph }) => {
           onSuccess: (response) => {
             tabState.setActive((prev) => ({
               ...prev,
-              chain_id: response.data.chain_id,
+              chain_id: response.data.id,
               chain: response.data,
             }));
             toast({ ...NOTIFY_SAVED, description: "Saved Chain" });


### PR DESCRIPTION
### Description
TabState wasn't initialized properly for new chains. The first node could be dropped, but not the 2nd. 

### Changes
- TabState.chain_id now set correctly on chain creation

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
