### PR TITLE
Adding static operation_id to all endpoints

### DIFF
--- a/ix/api/agents/endpoints.py
+++ b/ix/api/agents/endpoints.py
@@ -25,7 +25,12 @@ class AgentCreateUpdate(BaseModel):
     config: dict = {}
 
 
-@router.post("/agents/", response_model=AgentPydantic, tags=["Agents"])
+@router.post(
+    "/agents/",
+    operation_id="create_agent",
+    response_model=AgentPydantic,
+    tags=["Agents"],
+)
 async def create_agent(
     agent: AgentCreateUpdate, user: AbstractUser = Depends(get_request_user)
 ):
@@ -34,7 +39,12 @@ async def create_agent(
     return AgentPydantic.model_validate(agent_obj)
 
 
-@router.get("/agents/{agent_id}", response_model=AgentPydantic, tags=["Agents"])
+@router.get(
+    "/agents/{agent_id}",
+    operation_id="get_agent",
+    response_model=AgentPydantic,
+    tags=["Agents"],
+)
 async def get_agent(agent_id: str, user: AbstractUser = Depends(get_request_user)):
     try:
         query = Agent.objects.filter(pk=agent_id)
@@ -44,7 +54,9 @@ async def get_agent(agent_id: str, user: AbstractUser = Depends(get_request_user
     return AgentPydantic.model_validate(agent)
 
 
-@router.get("/agents/", response_model=AgentPage, tags=["Agents"])
+@router.get(
+    "/agents/", operation_id="get_agents", response_model=AgentPage, tags=["Agents"]
+)
 async def get_agents(
     search: Optional[str] = None,
     chat_id: Optional[UUID] = None,
@@ -65,7 +77,12 @@ async def get_agents(
     )
 
 
-@router.put("/agents/{agent_id}", response_model=AgentPydantic, tags=["Agents"])
+@router.put(
+    "/agents/{agent_id}",
+    operation_id="update_agent",
+    response_model=AgentPydantic,
+    tags=["Agents"],
+)
 async def update_agent(
     agent_id: str,
     agent: AgentCreateUpdate,
@@ -82,7 +99,12 @@ async def update_agent(
     return agent_obj
 
 
-@router.delete("/agents/{agent_id}", response_model=DeletedItem, tags=["Agents"])
+@router.delete(
+    "/agents/{agent_id}",
+    operation_id="delete_agent",
+    response_model=DeletedItem,
+    tags=["Agents"],
+)
 async def delete_agent(agent_id: str, user: AbstractUser = Depends(get_request_user)):
     try:
         query = Agent.objects.filter(pk=agent_id)

--- a/ix/api/artifacts/endpoints.py
+++ b/ix/api/artifacts/endpoints.py
@@ -19,7 +19,12 @@ router = APIRouter()
 __all__ = ["router"]
 
 
-@router.post("/artifacts/", response_model=ArtifactPydantic, tags=["Artifacts"])
+@router.post(
+    "/artifacts/",
+    operation_id="create_artifact",
+    response_model=ArtifactPydantic,
+    tags=["Artifacts"],
+)
 async def create_artifact(data: ArtifactCreate, user=Depends(get_request_user)):
     instance = Artifact(user=user, **data.model_dump())
     await instance.asave()
@@ -27,7 +32,10 @@ async def create_artifact(data: ArtifactCreate, user=Depends(get_request_user)):
 
 
 @router.get(
-    "/artifacts/{artifact_id}", response_model=ArtifactPydantic, tags=["Artifacts"]
+    "/artifacts/{artifact_id}",
+    operation_id="get_artifact",
+    response_model=ArtifactPydantic,
+    tags=["Artifacts"],
 )
 async def get_artifact(artifact_id: str, user=Depends(get_request_user)):
     try:
@@ -38,7 +46,12 @@ async def get_artifact(artifact_id: str, user=Depends(get_request_user)):
     return ArtifactPydantic.model_validate(artifact)
 
 
-@router.get("/artifacts/", response_model=ArtifactPage, tags=["Artifacts"])
+@router.get(
+    "/artifacts/",
+    operation_id="get_artifacts",
+    response_model=ArtifactPage,
+    tags=["Artifacts"],
+)
 async def get_artifacts(
     chat_id: Optional[UUID] = None,
     search: Optional[str] = None,
@@ -62,7 +75,10 @@ async def get_artifacts(
 
 
 @router.put(
-    "/artifacts/{artifact_id}", response_model=ArtifactPydantic, tags=["Artifacts"]
+    "/artifacts/{artifact_id}",
+    operation_id="update_artifact",
+    response_model=ArtifactPydantic,
+    tags=["Artifacts"],
 )
 async def update_artifact(
     artifact_id: str, data: ArtifactUpdate, user=Depends(get_request_user)
@@ -80,6 +96,7 @@ async def update_artifact(
 
 @router.get(
     "/artifacts/{artifact_id}/download",
+    operation_id="download_artifact",
     tags=["Artifacts"],
     responses={
         200: {

--- a/ix/api/chains/endpoints.py
+++ b/ix/api/chains/endpoints.py
@@ -30,7 +30,12 @@ class DeletedItem(BaseModel):
     id: UUID
 
 
-@router.get("/chains/", response_model=ChainQueryPage, tags=["Chains"])
+@router.get(
+    "/chains/",
+    operation_id="get_chains",
+    response_model=ChainQueryPage,
+    tags=["Chains"],
+)
 async def get_chains(
     search: Optional[str] = None,
     limit: int = 10,
@@ -112,7 +117,12 @@ async def create_chain_instance(**kwargs) -> Chain:
     return chain
 
 
-@router.post("/chains/", response_model=ChainPydantic, tags=["Chains"])
+@router.post(
+    "/chains/",
+    operation_id="create_chain",
+    response_model=ChainPydantic,
+    tags=["Chains"],
+)
 async def create_chain(
     chain: CreateChain, user: AbstractUser = Depends(get_request_user)
 ):
@@ -120,7 +130,12 @@ async def create_chain(
     return ChainPydantic.model_validate(new_chain)
 
 
-@router.get("/chains/{chain_id}", response_model=ChainPydantic, tags=["Chains"])
+@router.get(
+    "/chains/{chain_id}",
+    operation_id="get_chain",
+    response_model=ChainPydantic,
+    tags=["Chains"],
+)
 async def get_chain_detail(
     chain_id: UUID, user: AbstractUser = Depends(get_request_user)
 ):
@@ -161,7 +176,12 @@ async def sync_chain_agent(chain: Chain, alias: str) -> None:
             await Agent.objects.filter(chain=chain, is_test=False).adelete()
 
 
-@router.put("/chains/{chain_id}", response_model=ChainPydantic, tags=["Chains"])
+@router.put(
+    "/chains/{chain_id}",
+    operation_id="update_chain",
+    response_model=ChainPydantic,
+    tags=["Chains"],
+)
 async def update_chain(
     chain_id: UUID, chain: UpdateChain, user: AbstractUser = Depends(get_request_user)
 ):
@@ -189,7 +209,12 @@ async def update_chain(
     return response
 
 
-@router.delete("/chains/{chain_id}", response_model=DeletedItem, tags=["Chains"])
+@router.delete(
+    "/chains/{chain_id}",
+    operation_id="delete_chain",
+    response_model=DeletedItem,
+    tags=["Chains"],
+)
 async def delete_chain(chain_id: UUID, user: AbstractUser = Depends(get_request_user)):
     query = Chain.filtered_owners(user)
     try:

--- a/ix/api/chats/endpoints.py
+++ b/ix/api/chats/endpoints.py
@@ -41,7 +41,9 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.post("/chats/", response_model=ChatPydantic, tags=["Chats"])
+@router.post(
+    "/chats/", operation_id="create_chat", response_model=ChatPydantic, tags=["Chats"]
+)
 async def create_chat(chat: ChatNew, user: AbstractUser = Depends(get_request_user)):
     # Check if user is authenticated
     if user.is_anonymous:
@@ -82,7 +84,12 @@ async def create_chat(chat: ChatNew, user: AbstractUser = Depends(get_request_us
     return ChatPydantic.model_validate(chat_obj)
 
 
-@router.get("/chats/{chat_id}", response_model=ChatPydantic, tags=["Chats"])
+@router.get(
+    "/chats/{chat_id}",
+    operation_id="get_chat",
+    response_model=ChatPydantic,
+    tags=["Chats"],
+)
 async def get_chat(chat_id: UUID, user: AbstractUser = Depends(get_request_user)):
     query = Chat.filtered_owners(user)
     try:
@@ -92,7 +99,9 @@ async def get_chat(chat_id: UUID, user: AbstractUser = Depends(get_request_user)
     return ChatPydantic.model_validate(chat)
 
 
-@router.get("/chats/", response_model=ChatQueryPage, tags=["Chats"])
+@router.get(
+    "/chats/", operation_id="get_chats", response_model=ChatQueryPage, tags=["Chats"]
+)
 async def get_chats(
     user: AbstractUser = Depends(get_request_user),
     search: Optional[str] = None,
@@ -110,7 +119,12 @@ async def get_chats(
     )
 
 
-@router.put("/chats/{chat_id}", response_model=ChatPydantic, tags=["Chats"])
+@router.put(
+    "/chats/{chat_id}",
+    operation_id="update_chat",
+    response_model=ChatPydantic,
+    tags=["Chats"],
+)
 async def update_chat(
     chat_id: UUID, chat: ChatUpdate, user: AbstractUser = Depends(get_request_user)
 ):
@@ -127,7 +141,12 @@ async def update_chat(
     return ChatPydantic.model_validate(chat_obj)
 
 
-@router.delete("/chats/{chat_id}", response_model=DeletedItem, tags=["Chats"])
+@router.delete(
+    "/chats/{chat_id}",
+    operation_id="delete_chat",
+    response_model=DeletedItem,
+    tags=["Chats"],
+)
 async def delete_chat(chat_id: UUID, user: AbstractUser = Depends(get_request_user)):
     query = Chat.filtered_owners(user)
     try:
@@ -139,7 +158,10 @@ async def delete_chat(chat_id: UUID, user: AbstractUser = Depends(get_request_us
 
 
 @router.delete(
-    "/chats/{chat_id}/agents/{agent_id}", response_model=ChatAgentAction, tags=["Chats"]
+    "/chats/{chat_id}/agents/{agent_id}",
+    operation_id="remove_agent",
+    response_model=ChatAgentAction,
+    tags=["Chats"],
 )
 async def remove_agent(
     chat_id: UUID, agent_id: UUID, user: AbstractUser = Depends(get_request_user)
@@ -156,7 +178,10 @@ async def remove_agent(
 
 
 @router.put(
-    "/chats/{chat_id}/agents/{agent_id}", response_model=ChatAgentAction, tags=["Chats"]
+    "/chats/{chat_id}/agents/{agent_id}",
+    operation_id="add_agent",
+    response_model=ChatAgentAction,
+    tags=["Chats"],
 )
 async def add_agent(
     chat_id: UUID, agent_id: UUID, user: AbstractUser = Depends(get_request_user)
@@ -178,7 +203,12 @@ async def add_agent(
         raise HTTPException(status_code=404, detail="Agent does not exist.")
 
 
-@router.get("/chats/{chat_id}/graph", response_model=ChatGraph, tags=["Chats"])
+@router.get(
+    "/chats/{chat_id}/graph",
+    operation_id="get_chat_graph",
+    response_model=ChatGraph,
+    tags=["Chats"],
+)
 async def get_chat_graph(chat_id: str, user: AbstractUser = Depends(get_request_user)):
     """Chat and related objects
 
@@ -225,7 +255,10 @@ def get_artifacts(user_input):
 
 
 @router.get(
-    "/chats/{chat_id}/messages", response_model=ChatMessageQueryPage, tags=["Chats"]
+    "/chats/{chat_id}/messages",
+    operation_id="get_messages",
+    response_model=ChatMessageQueryPage,
+    tags=["Chats"],
 )
 async def get_messages(
     chat_id,
@@ -248,7 +281,12 @@ async def get_messages(
     )
 
 
-@router.post("/chats/{chat_id}/messages", response_model=ChatMessage, tags=["Chats"])
+@router.post(
+    "/chats/{chat_id}/messages",
+    operation_id="send_message",
+    response_model=ChatMessage,
+    tags=["Chats"],
+)
 async def send_message(
     chat_id: str, chat_input: ChatInput, user: AbstractUser = Depends(get_request_user)
 ):
@@ -314,7 +352,9 @@ async def send_message(
     return ChatMessage.model_validate(message)
 
 
-@router.post("/chats/{chat_id}/messages/clear", tags=["Chats"])
+@router.post(
+    "/chats/{chat_id}/messages/clear", operation_id="clear_messages", tags=["Chats"]
+)
 async def clear_messages(chat_id: str, user: AbstractUser = Depends(get_request_user)):
     try:
         chat = await Chat.filtered_owners(user).aget(pk=chat_id)

--- a/ix/api/components/endpoints.py
+++ b/ix/api/components/endpoints.py
@@ -16,7 +16,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.get("/node_types/", response_model=NodeTypePage, tags=["Components"])
+@router.get(
+    "/node_types/",
+    operation_id="get_node_types",
+    response_model=NodeTypePage,
+    tags=["Components"],
+)
 async def get_node_types(
     search: Optional[str] = None,
     class_path: Optional[str] = None,
@@ -51,7 +56,10 @@ class NodeTypeDetail(NodeTypePydantic):
 
 
 @router.get(
-    "/node_types/{node_type_id}", response_model=NodeTypeDetail, tags=["Components"]
+    "/node_types/{node_type_id}",
+    operation_id="get_node_type",
+    response_model=NodeTypeDetail,
+    tags=["Components"],
 )
 async def get_node_type_detail(
     node_type_id: UUID, user: AbstractUser = Depends(get_request_user)
@@ -65,7 +73,12 @@ async def get_node_type_detail(
     return NodeTypeDetail.from_orm(node_type)
 
 
-@router.post("/node_types/", response_model=NodeTypePydantic, tags=["Components"])
+@router.post(
+    "/node_types/",
+    operation_id="create_node_type",
+    response_model=NodeTypePydantic,
+    tags=["Components"],
+)
 async def create_node_type(
     node_type: NodeTypePydantic, user: AbstractUser = Depends(get_request_user)
 ):
@@ -77,7 +90,10 @@ async def create_node_type(
 
 
 @router.put(
-    "/node_types/{node_type_id}", response_model=NodeTypePydantic, tags=["Components"]
+    "/node_types/{node_type_id}",
+    operation_id="update_node_type",
+    response_model=NodeTypePydantic,
+    tags=["Components"],
 )
 async def update_node_type(
     node_type_id: UUID,
@@ -98,7 +114,10 @@ async def update_node_type(
 
 
 @router.delete(
-    "/node_types/{node_type_id}", response_model=DeletedItem, tags=["Components"]
+    "/node_types/{node_type_id}",
+    operation_id="delete_node_type",
+    response_model=DeletedItem,
+    tags=["Components"],
 )
 async def delete_node_type(
     node_type_id: UUID, user: AbstractUser = Depends(get_request_user)

--- a/ix/api/datasources/endpoints.py
+++ b/ix/api/datasources/endpoints.py
@@ -22,7 +22,12 @@ class DataSourceCreateUpdate(BaseModel):
     retrieval_chain: UUID
 
 
-@router.post("/datasources/", response_model=DataSourcePydantic, tags=["DataSources"])
+@router.post(
+    "/datasources/",
+    operation_id="create_datasource",
+    response_model=DataSourcePydantic,
+    tags=["DataSources"],
+)
 async def create_datasource(
     datasource: DataSourceCreateUpdate,
     current_user: AbstractUser = Depends(get_request_user),
@@ -38,6 +43,7 @@ async def create_datasource(
 
 @router.get(
     "/datasources/{datasource_id}",
+    operation_id="get_datasource",
     response_model=DataSourcePydantic,
     tags=["DataSources"],
 )
@@ -54,7 +60,12 @@ async def get_datasource(
     return DataSourcePydantic.from_orm(datasource)
 
 
-@router.get("/datasources/", response_model=DataSourcePage, tags=["DataSources"])
+@router.get(
+    "/datasources/",
+    operation_id="get_datasources",
+    response_model=DataSourcePage,
+    tags=["DataSources"],
+)
 async def get_datasources(
     search: Optional[str] = None,
     limit: int = 10,
@@ -75,6 +86,7 @@ async def get_datasources(
 
 @router.put(
     "/datasources/{datasource_id}",
+    operation_id="update_datasource",
     response_model=DataSourcePydantic,
     tags=["DataSources"],
 )
@@ -98,7 +110,10 @@ async def update_datasource(
 
 
 @router.delete(
-    "/datasources/{datasource_id}", response_model=DeletedItem, tags=["DataSources"]
+    "/datasources/{datasource_id}",
+    operation_id="delete_datasource",
+    response_model=DeletedItem,
+    tags=["DataSources"],
 )
 async def delete_datasource(
     datasource_id: UUID,

--- a/ix/api/editor/endpoints.py
+++ b/ix/api/editor/endpoints.py
@@ -38,7 +38,10 @@ router = APIRouter()
 
 
 @router.post(
-    "/chains/{chain_id}/set_root", response_model=UpdatedRoot, tags=["Chain Editor"]
+    "/chains/{chain_id}/set_root",
+    operation_id="set_root",
+    response_model=UpdatedRoot,
+    tags=["Chain Editor"],
 )
 async def set_chain_root(chain_id: UUID, update_root: UpdateRoot):
     # update old roots:
@@ -56,7 +59,12 @@ async def set_chain_root(chain_id: UUID, update_root: UpdateRoot):
     return UpdatedRoot(old_roots=old_root_ids, roots=update_root.node_ids)
 
 
-@router.post("/chains/nodes", response_model=NodePydantic, tags=["Chain Editor"])
+@router.post(
+    "/chains/nodes",
+    operation_id="add_node",
+    response_model=NodePydantic,
+    tags=["Chain Editor"],
+)
 async def add_chain_node(node: AddNode):
     if not node.chain_id:
         chain = await create_chain_instance(
@@ -95,7 +103,10 @@ async def add_chain_node(node: AddNode):
 
 
 @router.put(
-    "/chains/nodes/{node_id}", response_model=NodePydantic, tags=["Chain Editor"]
+    "/chains/nodes/{node_id}",
+    operation_id="update_node",
+    response_model=NodePydantic,
+    tags=["Chain Editor"],
 )
 async def update_chain_node(node_id: UUID, data: UpdateNode):
     try:
@@ -111,6 +122,7 @@ async def update_chain_node(node_id: UUID, data: UpdateNode):
 
 @router.post(
     "/chains/nodes/{node_id}/position",
+    operation_id="move_node",
     response_model=NodePydantic,
     tags=["Chain Editor"],
 )
@@ -122,7 +134,10 @@ async def update_chain_node_position(node_id: UUID, data: PositionUpdate):
 
 
 @router.delete(
-    "/chains/nodes/{node_id}", response_model=DeletedItem, tags=["Chain Editor"]
+    "/chains/nodes/{node_id}",
+    operation_id="delete_node",
+    response_model=DeletedItem,
+    tags=["Chain Editor"],
 )
 async def delete_chain_node(node_id: UUID):
     node = await ChainNode.objects.aget(id=node_id)
@@ -133,7 +148,12 @@ async def delete_chain_node(node_id: UUID):
     return DeletedItem(id=node_id)
 
 
-@router.post("/chains/edges", response_model=EdgePydantic, tags=["Chain Editor"])
+@router.post(
+    "/chains/edges",
+    operation_id="add_edge",
+    response_model=EdgePydantic,
+    tags=["Chain Editor"],
+)
 async def add_chain_edge(data: EdgePydantic):
     new_edge = ChainEdge(**data.dict())
     await new_edge.asave()
@@ -141,7 +161,10 @@ async def add_chain_edge(data: EdgePydantic):
 
 
 @router.put(
-    "/chains/edges/{edge_id}", response_model=EdgePydantic, tags=["Chain Editor"]
+    "/chains/edges/{edge_id}",
+    operation_id="update_edge",
+    response_model=EdgePydantic,
+    tags=["Chain Editor"],
 )
 async def update_chain_edge(edge_id, data: UpdateEdge):
     try:
@@ -156,7 +179,10 @@ async def update_chain_edge(edge_id, data: UpdateEdge):
 
 
 @router.delete(
-    "/chains/edges/{edge_id}", response_model=DeletedItem, tags=["Chain Editor"]
+    "/chains/edges/{edge_id}",
+    operation_id="delete_edge",
+    response_model=DeletedItem,
+    tags=["Chain Editor"],
 )
 async def delete_chain_edge(edge_id: UUID):
     edge = await ChainEdge.objects.aget(id=edge_id)
@@ -166,7 +192,10 @@ async def delete_chain_edge(edge_id: UUID):
 
 
 @router.get(
-    "/chains/{chain_id}/graph", response_model=GraphModel, tags=["Chain Editor"]
+    "/chains/{chain_id}/graph",
+    operation_id="get_chain_graph",
+    response_model=GraphModel,
+    tags=["Chain Editor"],
 )
 async def get_chain_graph(chain_id: UUID):
     """Return chain and all it's nodes and edges."""
@@ -211,7 +240,10 @@ async def _get_test_chat(chain_id: UUID, user: AbstractUser) -> Chat:
 
 
 @router.get(
-    "/chains/{chain_id}/chat", response_model=ChatPydantic, tags=["Chain Editor"]
+    "/chains/{chain_id}/chat",
+    operation_id="get_test_chat",
+    response_model=ChatPydantic,
+    tags=["Chain Editor"],
 )
 async def get_chain_chat(
     chain_id: UUID, user: AbstractUser = Depends(get_request_user)

--- a/ix/api/secrets/endpoints.py
+++ b/ix/api/secrets/endpoints.py
@@ -25,7 +25,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.post("/secret_types/", response_model=SecretTypePydantic, tags=["Secrets"])
+@router.post(
+    "/secret_types/",
+    operation_id="create_secret_type",
+    response_model=SecretTypePydantic,
+    tags=["Secrets"],
+)
 async def create_secret_type(
     secret_type: SecretTypeEdit,
     user: User = Depends(get_request_user),
@@ -40,6 +45,7 @@ async def create_secret_type(
 
 @router.get(
     "/secret_types/{secret_type_id}",
+    operation_id="get_secret_type",
     response_model=SecretTypePydantic,
     tags=["Secrets"],
 )
@@ -51,7 +57,12 @@ async def get_secret_type(secret_type_id: UUID, user: User = Depends(get_request
     return SecretTypePydantic.model_validate(secret_type)
 
 
-@router.get("/secret_types/", response_model=SecretTypePage, tags=["Secrets"])
+@router.get(
+    "/secret_types/",
+    operation_id="get_secret_types",
+    response_model=SecretTypePage,
+    tags=["Secrets"],
+)
 async def get_secret_types(
     limit: int = 10,
     offset: int = 0,
@@ -79,6 +90,7 @@ async def get_secret_types(
 
 @router.put(
     "/secret_types/{secret_type_id}",
+    operation_id="update_secret_type",
     response_model=SecretTypePydantic,
     tags=["Secrets"],
 )
@@ -100,7 +112,11 @@ async def update_secret_type(
     return SecretTypePydantic.model_validate(secret_type_obj)
 
 
-@router.delete("/secret_types/{secret_type_id}", tags=["Secrets"])
+@router.delete(
+    "/secret_types/{secret_type_id}",
+    operation_id="delete_secret_type",
+    tags=["Secrets"],
+)
 async def delete_secret_type(
     secret_type_id: UUID,
     user: User = Depends(get_request_user),
@@ -148,7 +164,12 @@ async def validate_secret_type(secret: CreateSecret, user: AbstractUser) -> Secr
             raise HTTPException(status_code=422, detail="Invalid secret type")
 
 
-@router.post("/secrets/", response_model=SecretPydantic, tags=["Secrets"])
+@router.post(
+    "/secrets/",
+    operation_id="create_secret",
+    response_model=SecretPydantic,
+    tags=["Secrets"],
+)
 async def create_secret(secret: CreateSecret, user: User = Depends(get_request_user)):
     secret_type = await validate_secret_type(secret, user)
 
@@ -175,6 +196,7 @@ async def create_secret(secret: CreateSecret, user: User = Depends(get_request_u
 
 @router.get(
     "/secrets/{secret_id}",
+    operation_id="get_secret",
     response_model=SecretPydantic,
     tags=["Secrets"],
 )
@@ -192,6 +214,7 @@ async def get_secret(secret_id: UUID, user: User = Depends(get_request_user)):
 
 @router.put(
     "/secrets/{secret_id}",
+    operation_id="update_secret",
     response_model=SecretPydantic,
     tags=["Secrets"],
 )
@@ -246,7 +269,9 @@ async def update_secret(
     return SecretPydantic.model_validate(secret_obj)
 
 
-@router.get("/secrets/", response_model=SecretPage, tags=["Secrets"])
+@router.get(
+    "/secrets/", operation_id="get_secrets", response_model=SecretPage, tags=["Secrets"]
+)
 async def get_secrets(
     secret_type: Optional[str] = None,
     limit: int = 10,
@@ -273,7 +298,12 @@ async def get_secrets(
     )
 
 
-@router.delete("/secrets/{secret_id}", response_model=DeletedItem, tags=["Secrets"])
+@router.delete(
+    "/secrets/{secret_id}",
+    operation_id="delete_secret",
+    response_model=DeletedItem,
+    tags=["Secrets"],
+)
 async def delete_secret(secret_id: UUID, user: User = Depends(get_request_user)):
     try:
         secret = await Secret.filtered_owners(user).aget(pk=secret_id)

--- a/ix/api/workspace/endpoints.py
+++ b/ix/api/workspace/endpoints.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.post("/upload/", response_model=ArtifactPydantic)
+@router.post("/upload/", operation_id="upload_file", response_model=ArtifactPydantic)
 async def upload_file(file: UploadFile = File(...), task_id: str = Form(None)):
     file_location = Path(settings.WORKSPACE_DIR) / file.filename
     with file_location.open("wb+") as buffer:

--- a/ix/data/endpoints.py
+++ b/ix/data/endpoints.py
@@ -23,13 +23,23 @@ router = APIRouter()
 
 
 # Schema Endpoints
-@router.post("/schemas/", response_model=SchemaPydantic, tags=["Schemas"])
+@router.post(
+    "/schemas/",
+    operation_id="create_schema",
+    response_model=SchemaPydantic,
+    tags=["Schemas"],
+)
 async def create_schema(schema: NewSchema, user: User = Depends(get_request_user)):
     schema_obj = await Schema.objects.acreate(user_id=user.id, **schema.model_dump())
     return SchemaPydantic.model_validate(schema_obj)
 
 
-@router.get("/schemas/{schema_id}", response_model=SchemaPydantic, tags=["Schemas"])
+@router.get(
+    "/schemas/{schema_id}",
+    operation_id="get_schema",
+    response_model=SchemaPydantic,
+    tags=["Schemas"],
+)
 async def get_schema(schema_id: UUID, user: User = Depends(get_request_user)):
     try:
         schema = await Schema.filtered_owners(user).aget(pk=schema_id)
@@ -38,7 +48,9 @@ async def get_schema(schema_id: UUID, user: User = Depends(get_request_user)):
     return SchemaPydantic.model_validate(schema)
 
 
-@router.get("/schemas/", response_model=SchemaPage, tags=["Schemas"])
+@router.get(
+    "/schemas/", operation_id="get_schemas", response_model=SchemaPage, tags=["Schemas"]
+)
 async def get_schemas(
     limit: int = 10,
     offset: int = 0,
@@ -55,7 +67,12 @@ async def get_schemas(
     )
 
 
-@router.put("/schemas/{schema_id}", response_model=SchemaPydantic, tags=["Schemas"])
+@router.put(
+    "/schemas/{schema_id}",
+    operation_id="update_schema",
+    response_model=SchemaPydantic,
+    tags=["Schemas"],
+)
 async def update_schema(
     schema_id: UUID, schema_data: SchemaPydantic, user: User = Depends(get_request_user)
 ):
@@ -70,7 +87,7 @@ async def update_schema(
     return SchemaPydantic.model_validate(schema_obj)
 
 
-@router.delete("/schemas/{schema_id}", tags=["Schemas"])
+@router.delete("/schemas/{schema_id}", operation_id="delete_schema", tags=["Schemas"])
 async def delete_schema(schema_id: UUID, user: User = Depends(get_request_user)):
     try:
         schema = await Schema.filtered_owners(user).aget(pk=schema_id)
@@ -81,7 +98,9 @@ async def delete_schema(schema_id: UUID, user: User = Depends(get_request_user))
     return DeletedItem(id=str(schema_id))
 
 
-@router.get("/schemas/{schema_id}/action", tags=["Schemas"])
+@router.get(
+    "/schemas/{schema_id}/action", operation_id="get_schema_action", tags=["Schemas"]
+)
 async def get_schema_action(
     schema_id: UUID, path: str, method: str, user: User = Depends(get_request_user)
 ):
@@ -94,13 +113,15 @@ async def get_schema_action(
 
 
 # Data Endpoints
-@router.post("/data/", response_model=DataPydantic, tags=["Data"])
+@router.post(
+    "/data/", response_model=DataPydantic, operation_id="create_data", tags=["Data"]
+)
 async def create_data(data: DataPydantic, user: User = Depends(get_request_user)):
     data_obj = await Data.objects.acreate(user_id=user.id, **data.model_dump())
     return DataPydantic.model_validate(data_obj)
 
 
-@router.get("/data/", response_model=DataPage, tags=["Data"])
+@router.get("/data/", response_model=DataPage, operation_id="get_datas", tags=["Data"])
 async def get_datas(
     limit: int = 10,
     offset: int = 0,
@@ -114,7 +135,12 @@ async def get_datas(
     )
 
 
-@router.get("/data/{data_id}", response_model=DataPydantic, tags=["Data"])
+@router.get(
+    "/data/{data_id}",
+    operation_id="get_data",
+    response_model=DataPydantic,
+    tags=["Data"],
+)
 async def get_data(data_id: UUID, user: User = Depends(get_request_user)):
     try:
         data = await Data.filtered_owners(user).aget(pk=data_id)
@@ -123,7 +149,12 @@ async def get_data(data_id: UUID, user: User = Depends(get_request_user)):
     return DataPydantic.model_validate(data)
 
 
-@router.put("/data/{data_id}", response_model=DataPydantic, tags=["Data"])
+@router.put(
+    "/data/{data_id}",
+    operation_id="update_data",
+    response_model=DataPydantic,
+    tags=["Data"],
+)
 async def update_data(
     data_id: UUID, data_data: DataPydantic, user: User = Depends(get_request_user)
 ):
@@ -138,7 +169,7 @@ async def update_data(
     return DataPydantic.model_validate(data_obj)
 
 
-@router.delete("/data/{data_id}", tags=["Data"])
+@router.delete("/data/{data_id}", operation_id="delete_data", tags=["Data"])
 async def delete_data(data_id: UUID, user: User = Depends(get_request_user)):
     try:
         data = await Data.filtered_owners(user).aget(pk=data_id)


### PR DESCRIPTION


### Description
Adding static `operation_id` to all endpoints. FastAPIs auto-generated ids were poorly suited to LLM integration. They were needlessly long and repetitive. 

##### Before
`create_agent_agents__post`

##### After
`create_agent`


### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
