### PR TITLE
Clicking back and forth between nodes loses edits.

### DIFF
--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -264,16 +264,20 @@ const ChainGraphEditor = ({ graph }) => {
     [onNodesChange]
   );
 
-  const onNodeDragStop = useCallback((event, node) => {
-    // ignore position updates for root
-    if (node.id === "root") {
-      return;
-    }
+  const onNodeDragStop = useCallback(
+    (event, node) => {
+      // ignore position updates for root
+      if (node.id === "root") {
+        return;
+      }
 
-    // update node with new position
-    api.updateNodePosition(node.id, node.position);
-    nodeState.setNode({ ...node.data.node, position: node.position });
-  }, []);
+      // update node with new position
+      api.updateNodePosition(node.id, node.position);
+      const prevNode = nodeState.nodes[node.id];
+      nodeState.setNode({ ...prevNode, position: node.position });
+    },
+    [nodeState.nodes]
+  );
 
   // new edges
   const onConnect = useCallback(


### PR DESCRIPTION
### Description
Another tab related state issues:  Clicking back and forth between nodes loses edits.

`OnNodeDragStop` handler was updating with stale data. This would result in nodes reverting to the state from when they were initially loaded from the API.  Changes were reflected in the database, but UI was stale.

### Changes
`OnNodeDragStop` now uses updated state

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
