### PR TITLE
Styling improvements for RunLog

### DIFF
--- a/frontend/chains/editor/run_log/ExecutionDetail.js
+++ b/frontend/chains/editor/run_log/ExecutionDetail.js
@@ -26,31 +26,43 @@ export const ExecutionDetail = ({ execution }) => {
       ? execution?.outputs
       : JSON.stringify(execution?.outputs, null, 4);
 
+  const syntaxStyle = {
+    fontSize: "12px",
+    maxWidth: "900px",
+    margniRight: "5px",
+  };
+
   return (
     <Box pl={4} pt={1} height={"100%"}>
       <VStack alignItems={"start"} spacing={3}>
-        <Box>
+        <Box width={"100%"}>
           <Heading size={"sm"} mb={1}>
             Input
           </Heading>
-          <Box width={600}>
-            <SyntaxHighlighter style={syntaxTheme} wrapLines={true}>
-              {formattedInputs}
-            </SyntaxHighlighter>
-          </Box>
+          <SyntaxHighlighter
+            customStyle={syntaxStyle}
+            language="json"
+            style={syntaxTheme}
+            wrapLines={true}
+          >
+            {formattedInputs}
+          </SyntaxHighlighter>
         </Box>
-        <Box>
+        <Box width={"100%"}>
           <Heading size={"sm"} mb={1}>
             Output
           </Heading>
-          <Box width={600}>
-            <SyntaxHighlighter style={syntaxTheme} wrapLines={true}>
-              {formattedOutputs}
-            </SyntaxHighlighter>
-          </Box>
+          <SyntaxHighlighter
+            customStyle={syntaxStyle}
+            language="json"
+            style={syntaxTheme}
+            wrapLines={true}
+          >
+            {formattedOutputs}
+          </SyntaxHighlighter>
         </Box>
         {execution?.message && (
-          <Box width={500}>
+          <Box width={"100%"}>
             <Heading size={"sm"} mb={1}>
               Message
             </Heading>


### PR DESCRIPTION
### Description
RunLog styling improvements:
- syntax highlighter is now using "json" language and actually highlighting output correctly
- detail input/output blocks now fill the modal.
- slightly smaller text in input/output blocks

![image](https://github.com/kreneskyp/ix/assets/68635/51e0d768-0070-49f0-a8a1-6d1e74927c68)

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
- code blocks still don't shrink when modal does, preferring to scroll.
