### PR TITLE
Fixing tab state issues with editing edges and deleting nodes

### DIFF
--- a/frontend/chains/ChainEditorView.js
+++ b/frontend/chains/ChainEditorView.js
@@ -18,6 +18,7 @@ import {
   NodeEditorContext,
   ChainState,
   ChainTypes,
+  EdgeState,
 } from "chains/editor/contexts";
 import { EditorRightSidebar } from "chains/editor/EditorRightSidebar";
 import { NodeTypeSearchButton } from "chains/editor/NodeTypeSearchButton";
@@ -33,6 +34,7 @@ import { useTabDataField } from "chains/hooks/useTabDataField";
 import { useChainState } from "chains/hooks/useChainState";
 import { OpenAPISchemaMenuItem } from "schemas/openapi/OpenAPISchemaMenuItem";
 import { JSONSchemaMenuItem } from "schemas/json/JSONSchemaMenuItem";
+import { useEdgeState } from "chains/hooks/useEdgeState";
 export const EditorViewState = React.createContext(null);
 
 /**
@@ -108,6 +110,7 @@ export const useEditorTabs = (initial) => {
     typeState: useTabDataField(tabState.active, tabState.setActive, "types"),
     chainState: useChainState(tabState),
     nodeState: useNodeState(tabState),
+    edgeState: useEdgeState(tabState),
     selection: useSelectedNode(tabState),
     addChain,
     openChain,
@@ -117,7 +120,7 @@ export const useEditorTabs = (initial) => {
 };
 
 const ChainEditorProvider = ({ onError, children }) => {
-  const { chainState, typeState, nodeState, selection } =
+  const { chainState, typeState, nodeState, edgeState, selection } =
     React.useContext(EditorViewState);
 
   const nodeEditor = useNodeEditorState(
@@ -137,15 +140,17 @@ const ChainEditorProvider = ({ onError, children }) => {
     <ChainTypes.Provider value={typeState}>
       <ChainState.Provider value={chainState}>
         <NodeStateContext.Provider value={nodeState}>
-          <NodeEditorContext.Provider value={nodeEditor}>
-            <SelectedNodeContext.Provider value={selection}>
-              <ChainEditorAPIContext.Provider value={api}>
-                <RunLogProvider chain_id={chainState?.[0]?.id}>
-                  {children}
-                </RunLogProvider>
-              </ChainEditorAPIContext.Provider>
-            </SelectedNodeContext.Provider>
-          </NodeEditorContext.Provider>
+          <EdgeState.Provider value={edgeState}>
+            <NodeEditorContext.Provider value={nodeEditor}>
+              <SelectedNodeContext.Provider value={selection}>
+                <ChainEditorAPIContext.Provider value={api}>
+                  <RunLogProvider chain_id={chainState?.[0]?.id}>
+                    {children}
+                  </RunLogProvider>
+                </ChainEditorAPIContext.Provider>
+              </SelectedNodeContext.Provider>
+            </NodeEditorContext.Provider>
+          </EdgeState.Provider>
         </NodeStateContext.Provider>
       </ChainState.Provider>
     </ChainTypes.Provider>

--- a/frontend/chains/editor/contexts.js
+++ b/frontend/chains/editor/contexts.js
@@ -3,6 +3,7 @@ import React, { createContext } from "react";
 export const ChainTypes = createContext(null);
 export const ChainState = createContext(null);
 export const NodeStateContext = createContext(null);
+export const EdgeState = createContext(null);
 export const NodeEditorContext = createContext(null);
 export const SelectedNodeContext = createContext(null);
 export const RunLog = createContext(null);

--- a/frontend/chains/flow/JSONTransformNode.js
+++ b/frontend/chains/flow/JSONTransformNode.js
@@ -173,8 +173,6 @@ export const JSONTransformNode = ({ node, onChange }) => {
     [onChange.field]
   );
 
-  console.log("node: ", node);
-
   const handleBaseChange = (e) => {
     const newBase = parseInt(e.target.value);
     onChange.config({

--- a/frontend/chains/flow/NodeMenu.js
+++ b/frontend/chains/flow/NodeMenu.js
@@ -14,7 +14,7 @@ import {
   faTrash,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { EditorViewState } from "chains/editor/contexts";
+import { EditorViewState, NodeStateContext } from "chains/editor/contexts";
 import { ChainEditorAPIContext } from "chains/editor/ChainEditorAPIContext";
 import { useEditorColorMode } from "chains/editor/useColorMode";
 import { Overlay } from "components/Overlay";
@@ -24,11 +24,13 @@ const CHAIN_REFERENCE = "ix.runnable.flow.load_chain_id";
 
 const DeleteItem = ({ node }) => {
   const api = React.useContext(ChainEditorAPIContext);
+  const nodeState = React.useContext(NodeStateContext);
   const style = useEditorColorMode();
 
   const onClick = React.useCallback(
     (event) => {
       api.deleteNode(node.id);
+      nodeState.deleteNode(node.id);
     },
     [node.id, api]
   );

--- a/frontend/chains/hooks/useEdgeState.js
+++ b/frontend/chains/hooks/useEdgeState.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { useTabDataArray } from "chains/hooks/useTabDataArray";
+
+/**
+ * Hook for managing edge state in a specific tab.
+ * Each edge in the array has an 'id' and 'chain_id'.
+ */
+export const useEdgeState = (tabState) => {
+  const {
+    items: edges,
+    setItems: setEdges,
+    setItem: setEdge,
+    updateItem: updateEdge,
+    deleteItem: deleteEdge,
+  } = useTabDataArray(tabState, "edges");
+
+  return {
+    edges, // Current array of edges
+    setEdges, // Function to set the entire edges array
+    setEdge, // Function to update or add a single edge
+    updateEdge, // Function to update a single edge by id and chain_id
+    deleteEdge, // Function to delete a specific edge by id and chain_id
+  };
+};

--- a/frontend/chains/hooks/useNodeState.js
+++ b/frontend/chains/hooks/useNodeState.js
@@ -1,43 +1,21 @@
-import React from "react";
-import { useTabDataField } from "chains/hooks/useTabDataField";
+import { useTabDataObject } from "chains/hooks/useTabDataObject";
 
 /**
  * Central state for nodes in the editor. All components that need to
  * read or write node state should use this hook.
  */
 export const useNodeState = (tabState) => {
-  const [nodes, setNodes] = useTabDataField(
-    tabState.active,
-    tabState.setActive,
-    "nodes",
-    {
-      node: null,
-      connector: null,
-    }
-  );
+  const {
+    items: nodes,
+    setItems: setNodes,
+    setItem: setNode,
+    deleteItem: deleteNode,
+  } = useTabDataObject(tabState, "nodes");
 
-  const setNode = React.useCallback(
-    (node) => {
-      setNodes((prev) => {
-        // HAX: reject updates from other tabs. This protects against hooks that
-        // aren't updating correctly when switching tabs. This only treats the
-        // symptom, not the cause. But it prevents data corruption of nodes
-        // leaking to other tabs.
-        if (node.chain_id !== tabState.active.chain_id) {
-          return prev;
-        }
-        return { ...prev, [node.id]: node };
-      });
-    },
-    [tabState?.active?.chain_id, setNodes]
-  );
-
-  return React.useMemo(
-    () => ({
-      nodes,
-      setNodes,
-      setNode,
-    }),
-    [nodes, setNodes, setNode]
-  );
+  return {
+    nodes,
+    setNodes,
+    setNode,
+    deleteNode,
+  };
 };

--- a/frontend/chains/hooks/useTabDataArray.js
+++ b/frontend/chains/hooks/useTabDataArray.js
@@ -1,0 +1,71 @@
+import React from "react";
+import { useTabDataField } from "chains/hooks/useTabDataField"; // Assuming this is the correct import path
+
+/**
+ * Generic hook for managing a tab data field that is an array of objects.
+ * Each object in the array has an 'id' and 'chain_id'.
+ */
+export const useTabDataArray = (tabState, fieldName) => {
+  const [items, setItems] = useTabDataField(
+    tabState.active,
+    tabState.setActive,
+    fieldName,
+    []
+  );
+
+  const setItem = React.useCallback(
+    (item) => {
+      setItems((prevItems) => {
+        const index = prevItems.findIndex(
+          (i) => i.id === item.id && i.chain_id === item.chain_id
+        );
+        if (index > -1) {
+          // Update existing item
+          return [
+            ...prevItems.slice(0, index),
+            item,
+            ...prevItems.slice(index + 1),
+          ];
+        } else {
+          // Add new item
+          return [...prevItems, item];
+        }
+      });
+    },
+    [setItems]
+  );
+
+  const updateItem = React.useCallback(
+    (id, updatedFields) => {
+      setItems((prevItems) => {
+        const index = prevItems.findIndex((i) => i.id === id);
+        if (index > -1) {
+          // Update item with the new fields
+          const updatedItem = { ...prevItems[index], ...updatedFields };
+          return [
+            ...prevItems.slice(0, index),
+            updatedItem,
+            ...prevItems.slice(index + 1),
+          ];
+        }
+        return prevItems;
+      });
+    },
+    [setItems]
+  );
+
+  const deleteItem = React.useCallback(
+    (itemId) => {
+      setItems((prevItems) => prevItems.filter((i) => i.id !== itemId));
+    },
+    [setItems]
+  );
+
+  return {
+    items,
+    setItems,
+    setItem,
+    updateItem,
+    deleteItem,
+  };
+};

--- a/frontend/chains/hooks/useTabDataObject.js
+++ b/frontend/chains/hooks/useTabDataObject.js
@@ -1,0 +1,45 @@
+import React from "react";
+import { useTabDataField } from "chains/hooks/useTabDataField";
+
+/**
+ * Generic hook for managing a property that is an object mapping id to item.
+ */
+export const useTabDataObject = (tabState, fieldName, initialValue) => {
+  const [items, setItems] = useTabDataField(
+    tabState.active,
+    tabState.setActive,
+    fieldName,
+    initialValue
+  );
+
+  const setItem = React.useCallback(
+    (item) => {
+      setItems((prevItems) => {
+        // Reject updates from other tabs to prevent data corruption
+        if (item.chain_id !== tabState.active.chain_id) {
+          return prevItems;
+        }
+        return { ...prevItems, [item.id]: item };
+      });
+    },
+    [tabState?.active?.chain_id, setItems]
+  );
+
+  const deleteItem = React.useCallback(
+    (itemId) => {
+      setItems((prevItems) => {
+        const newItems = { ...prevItems };
+        delete newItems[itemId];
+        return newItems;
+      });
+    },
+    [setItems]
+  );
+
+  return {
+    items,
+    setItems,
+    setItem,
+    deleteItem,
+  };
+};

--- a/frontend/schemas/openapi/SchemaPathsList.js
+++ b/frontend/schemas/openapi/SchemaPathsList.js
@@ -70,8 +70,6 @@ export const SchemaPathsList = ({ schema, schema_id }) => {
     return byTag;
   }, [schema]);
 
-  console.log("::Schema: ", schema);
-
   return (
     <Box>
       {Object.keys(pathsByTag).map((tag) => (


### PR DESCRIPTION
### Description
Rooted out another nest of gremlins in the tab state code. Edges updates and node deletes weren't syncing. Used this opportunity to further refine tab state utils to simplify this for future fields.

### Changes
- added hooks to simplify state and callback for maps and arrays of objects in a tab state field.
- edge create, update, delete should now all sync to tab state.
- node delete should now sync to tab state.

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
