### PR TITLE
Fix edge updates between keys on either the source or target

### DIFF
--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -357,16 +357,22 @@ const ChainGraphEditor = ({ graph }) => {
       } else {
         const isSame =
           oldEdge.source === newConnection.source &&
-          oldEdge.target === newConnection.target;
+          oldEdge.target === newConnection.target &&
+          oldEdge.sourceHandle === newConnection.sourceHandle &&
+          oldEdge.targetHandle === newConnection.targetHandle;
         if (!isSame) {
           toast({ ...NOTIFY_SAVED, description: "Saved Edge" });
           api.updateEdge(oldEdge.data.id, {
             source_id: newConnection.source,
             target_id: newConnection.target,
+            source_key: newConnection.sourceHandle,
+            target_key: newConnection.targetHandle,
           });
           edgeState.updateEdge(oldEdge.data.id, {
             source_id: newConnection.source,
             target_id: newConnection.target,
+            source_key: newConnection.sourceHandle,
+            target_key: newConnection.targetHandle,
           });
         }
       }

--- a/ix/api/editor/types.py
+++ b/ix/api/editor/types.py
@@ -66,6 +66,8 @@ class UpdateNode(BaseModel):
 class UpdateEdge(BaseModel):
     source_id: UUID
     target_id: UUID
+    target_key: str
+    source_key: str
 
 
 class GraphModel(BaseModel):

--- a/ix/api/tests/test_chains.py
+++ b/ix/api/tests/test_chains.py
@@ -762,6 +762,10 @@ class TestChainEdge:
         assert response.status_code == 200, response.json()
         edge_data = response.json()
         assert edge_data["id"] == str(edge.id)
+        assert edge_data["source_id"] == str(node1.id)
+        assert edge_data["target_id"] == str(node2.id)
+        assert edge_data["source_key"] == node1_type.type
+        assert edge_data["target_key"] == "Custom Key"
 
     async def test_delete_chain_edge(self, anode_types):
         # Create a chain edge to delete


### PR DESCRIPTION
### Description
Edge updates weren't saved when the update only switched between keys on the target or source node. The `should save` check didn't include the source or target key.

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
