### PR TITLE
JSONSchema form updated to use CodeEditor

### DIFF
--- a/frontend/components/code_editor/CodeEditor.js
+++ b/frontend/components/code_editor/CodeEditor.js
@@ -41,6 +41,7 @@ function extractPlainText(nodes) {
 export const CodeEditor = ({ value, language, onChange }) => {
   const style = useEditorColorMode();
   const [editor] = useState(() => withHistory(withReact(createEditor())));
+  const _value = value || "";
 
   const decorate = useDecorate(editor);
   const onKeyDown = useOnKeydown(editor);
@@ -51,23 +52,23 @@ export const CodeEditor = ({ value, language, onChange }) => {
     borderRadius: 5,
   };
 
-  // Value is encoded to a single code block element. This is to ensure that
-  // There is always exactly one eternal codeblock
+  // Value is encoded to a single code block element to ensure that
+  // there is exactly one eternal CodeBlockType element in the editor.
   const encodedValue = React.useMemo(
     () => [
       {
         type: CodeBlockType,
         language: language,
-        children: toCodeLines(value),
+        children: toCodeLines(_value),
       },
     ],
-    [value]
+    [_value]
   );
 
   const handleChange = React.useCallback(
     (newValue) => {
       const newPlainText = extractPlainText(newValue);
-      if (newPlainText !== value) {
+      if (newPlainText !== _value) {
         if (onChange !== undefined) {
           onChange(newPlainText);
         }

--- a/frontend/components/code_editor/LineNumbers.js
+++ b/frontend/components/code_editor/LineNumbers.js
@@ -9,6 +9,7 @@ export const LineNumbers = () => {
   const lines = element.children || [];
   const { colorMode } = useColorMode();
   const bg = colorMode === "light" ? "blackAlpha.100" : "blackAlpha.300";
+  const color = colorMode === "light" ? "blackAlpha.500" : "whiteAlpha.400";
 
   return (
     <Box
@@ -21,6 +22,7 @@ export const LineNumbers = () => {
       py={2}
       fontSize="xs"
       fontFamily="monospace"
+      color={color}
     >
       {lines.map((_, index) => (
         <Box

--- a/frontend/schemas/json/JSONSchemaFormRightPanel.js
+++ b/frontend/schemas/json/JSONSchemaFormRightPanel.js
@@ -1,34 +1,22 @@
 import React from "react";
 
-import {
-  FormControl,
-  FormErrorMessage,
-  FormLabel,
-  Textarea,
-} from "@chakra-ui/react";
+import { FormControl, FormErrorMessage, FormLabel } from "@chakra-ui/react";
 import { useEditorColorMode } from "chains/editor/useColorMode";
+import CodeEditor from "components/code_editor/CodeEditor";
 
 export const JSONSchemaFormRightPanel = ({ schema, onChange }) => {
   const [state, setState] = React.useState({});
-  const { code, scrollbar, input } = useEditorColorMode();
-
-  const [value, setValue] = React.useState();
-
-  React.useEffect(() => {
-    if (schema?.value) {
-      // convert object to string
-      const str = JSON.stringify(schema.value, null, 2);
-      setValue(str);
-    }
-  }, []);
+  const [value, setValue] = React.useState(
+    JSON.stringify(schema?.value, null, 2)
+  );
 
   const handleChange = React.useCallback(
-    (e) => {
-      setValue(e.target.value);
+    (newValue) => {
+      setValue(newValue);
 
       let as_object;
       try {
-        as_object = JSON.parse(e.target.value);
+        as_object = JSON.parse(newValue);
       } catch (e) {
         setState({ error: e.message });
         return;
@@ -42,21 +30,7 @@ export const JSONSchemaFormRightPanel = ({ schema, onChange }) => {
   return (
     <FormControl name="value" isInvalid={state?.error !== undefined}>
       <FormLabel justify="start">Schema</FormLabel>
-      <Textarea
-        name="parameters"
-        value={value}
-        onChange={handleChange}
-        color={code.color}
-        bg={code.bg}
-        fontFamily="monospace"
-        font="monospace"
-        fontSize="sm"
-        {...input}
-        css={scrollbar}
-        placeholder={"Enter JSON Schema."}
-        height={400}
-        width={"100%"}
-      />
+      <CodeEditor value={value} language="json" onChange={handleChange} />
       <FormErrorMessage>{state?.error}</FormErrorMessage>
     </FormControl>
   );

--- a/frontend/skills/SkillForm.js
+++ b/frontend/skills/SkillForm.js
@@ -1,11 +1,22 @@
 import React from "react";
-import { Box, Button, HStack, Text, useToast } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  HStack,
+  Text,
+  FormControl,
+  FormLabel,
+  FormHelperText,
+  FormErrorMessage,
+  useToast,
+} from "@chakra-ui/react";
 
 import { useCreateUpdateAPI } from "utils/hooks/useCreateUpdateAPI";
 import { ModalClose } from "components/Modal";
 import { SkillDeleteButton } from "skills/SkillDeleteButton";
 import { NameField } from "chains/editor/fields/NameField";
 import CodeEditor from "components/code_editor/CodeEditor";
+import { RequiredAsterisk } from "components/RequiredAsterisk";
 
 // Example python class with typehints and description. docstring should
 const CODE_PLACEHOLDER =
@@ -13,10 +24,7 @@ const CODE_PLACEHOLDER =
   '    """Describe your skill here."""\n' +
   "    return a + 1";
 
-const CODE_HELP =
-  "Python code that will be run when this skill is called. The " +
-  "function must be named 'run'. The return value of the function " +
-  "will be the output of the skill.";
+const CODE_HELP = "Typed python function that implements this skill.";
 
 export const SkillForm = ({ skill, onSuccess }) => {
   const toast = useToast();
@@ -71,21 +79,23 @@ export const SkillForm = ({ skill, onSuccess }) => {
   return (
     <Box>
       <NameField onChange={onDataChange} value={data.name} mb={4} />
-      <CodeEditor
-        label="Function"
-        onChange={handleCodeChange}
-        value={data.code}
-        placeholder={CODE_PLACEHOLDER}
-        help={CODE_HELP}
-        required={true}
-        language={"python"}
-      />
-      <Box color={"red.400"} fontSize={"xs"} mt={4}>
-        {error &&
-          error.data?.detail?.map((err_datum) => {
-            return <Text>{err_datum.msg}</Text>;
-          })}
-      </Box>
+      <FormControl name="code" isInvalid={error !== undefined}>
+        <FormLabel justify="start">
+          Function <RequiredAsterisk />
+        </FormLabel>
+        <CodeEditor
+          value={data.code}
+          language="python"
+          onChange={handleCodeChange}
+          placeholder={CODE_PLACEHOLDER}
+        />
+        {!error && <FormHelperText>{CODE_HELP}</FormHelperText>}
+        <FormErrorMessage>
+          {error?.data?.detail?.map((err_datum) => (
+            <Text>{err_datum.msg}</Text>
+          ))}
+        </FormErrorMessage>
+      </FormControl>
       <HStack display="flex" justifyContent="flex-end" mt={4} mr={7}>
         {skill?.id && <SkillDeleteButton skill={skill} onSuccess={onSuccess} />}
         <Button colorScheme="blue" onClick={onSave} isDisabled={!valid}>


### PR DESCRIPTION
### Description

Updating JSONSchema to use the new CodeEditor (#421) that was added to support SkillForm.

![image](https://github.com/kreneskyp/ix/assets/68635/e32735f9-9055-4f4a-b1a3-020facde62e7)


### Changes
- JSONSchema now uses CodeEditor
- minor tweaks to CodeEditor style
- minor cleanup for SkillForm
### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
