### PR TITLE
Initial nodes were added to graph with null chain_id.

### DIFF
--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -111,11 +111,23 @@ const ChainGraphEditor = ({ graph }) => {
       if (chain?.id === undefined) {
         loadChain(`/api/chains/${response.data.chain_id}`, {
           onSuccess: (response) => {
-            tabState.setActive((prev) => ({
-              ...prev,
-              chain_id: response.data.id,
-              chain: response.data,
-            }));
+            tabState.setActive((prev) => {
+              // update any initial nodes that are missing chain_id
+              const nodes = { ...prev.nodes };
+              for (const id in nodes) {
+                const node = nodes[id];
+                if (node.chain_id === null) {
+                  nodes[id] = { ...node, chain_id: response.data.id };
+                }
+              }
+
+              return {
+                ...prev,
+                chain_id: response.data.id,
+                chain: response.data,
+                nodes,
+              };
+            });
             toast({ ...NOTIFY_SAVED, description: "Saved Chain" });
           },
         });


### PR DESCRIPTION
### Description
The first node added to a new flow is created without a `chain_id` because it isn't known at the time the node is created. This manifested in the node config form being unable to update any fields.

The `onSuccess` callback for `onDrop` now updates `chain_id` 

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
