### PR TITLE
JSONSchema should use schema description when used for function call

### DIFF
--- a/ix/chains/tests/mock_runnable.py
+++ b/ix/chains/tests/mock_runnable.py
@@ -4,7 +4,7 @@ from typing import Optional, Any
 
 from langchain.schema.runnable import Runnable, RunnableConfig
 from langchain.schema.runnable.utils import Output
-from pydantic.v1 import BaseModel as BaseModelV1
+from pydantic.v1 import BaseModel as BaseModelV1, Field
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +20,9 @@ MOCK_RUNNABLE_CONFIG = {
 
 
 class MockRunnableInput(BaseModelV1):
-    value: str = "input"
+    """Mock input for the mock runnable"""
+
+    value: str = Field(description="this is a mock value", default="input")
 
 
 class MockRunnable(Runnable[MockRunnableInput, Output], BaseModelV1):

--- a/ix/runnable/llm.py
+++ b/ix/runnable/llm.py
@@ -9,9 +9,13 @@ from ix.data.types import Schema
 
 def to_openai_fn(obj: Any) -> dict:
     if isinstance(obj, Schema):
+        # HAX: include the schema description in the function description to ensure
+        # it's available to the LLM to use the function.
+        schema_description = obj.value.get("description", "")
+
         return {
             "name": obj.name,
-            "description": obj.description,
+            "description": f"{obj.description}\n\n{schema_description}",
             "parameters": obj.value,
         }
     else:

--- a/ix/runnable/tests/test_flow.py
+++ b/ix/runnable/tests/test_flow.py
@@ -36,9 +36,15 @@ class TestIxNode:
 
         assert ix_node.input_schema().schema() == {
             "properties": {
-                "value": {"default": "input", "title": "Value", "type": "string"}
+                "value": {
+                    "default": "input",
+                    "title": "Value",
+                    "type": "string",
+                    "description": "this is a mock value",
+                }
             },
             "title": "MockRunnableInput",
+            "description": "Mock input for the mock runnable",
             "type": "object",
         }
 


### PR DESCRIPTION
### Description
`Schema` objects were using `instance.description` but not the schema within the schema definition json.

Did some research and determined that OpenAI ignores `parameters.description` in a function call definition. There may be useful instructions in the schema so `to_openaj_fn` helper now joins both `description` values together for the `fn` description.

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
