### PR TITLE
OpenAPI request instructions

### DIFF
--- a/ix/chains/fixture_src/openapi.py
+++ b/ix/chains/fixture_src/openapi.py
@@ -15,12 +15,20 @@ RUN_OPEN_API_REQUEST = NodeType(
             "path",
             "method",
             "headers",
+            "instructions",
         ],
         field_options={
             "schema_id": {"label": "Schema", "input_type": "IX:openapi_schema"},
             "server": {"input_type": "IX:openapi_server"},
             "path": {"label": "Action", "input_type": "IX:openapi_action"},
             "method": {"input_type": "hidden"},
+            "instructions": {
+                "type": "str",
+                "input_type": "textarea",
+                "style": {"width": "100%"},
+                "label": "Instructions",
+                "description": "Extra instructions added to input schema",
+            },
         },
     ),
     display_groups=[
@@ -29,6 +37,7 @@ RUN_OPEN_API_REQUEST = NodeType(
             label="Config",
             fields=["schema_id", "server", "path", "method"],
         ),
+        DisplayGroup(key="Instructions", label="Instructions", fields=["instructions"]),
         DisplayGroup(key="Auth", label="Authentication", fields=["headers"]),
     ],
 )

--- a/ix/chains/loaders/tools.py
+++ b/ix/chains/loaders/tools.py
@@ -74,6 +74,11 @@ def get_runnable_tool(
             f"Unsupported input schema type {runnable.input_schema.__class__}"
         )
 
+    # Add the input schema's docstring to the tool description. OpenAI ignores the
+    # parameter schema's description. It needs to be moved into the description.
+    if runnable.input_schema.__doc__:
+        description = f"{description}\n\nInput docs:\n{runnable.input_schema.__doc__}"
+
     return tool_class(
         name=name,
         description=description,

--- a/ix/chains/tests/test_config_loader.py
+++ b/ix/chains/tests/test_config_loader.py
@@ -498,7 +498,10 @@ class TestLoadTools:
         )
         assert isinstance(tool, BaseTool)
         assert tool.name == "test"
-        assert tool.description == "this is a test"
+        assert (
+            tool.description
+            == "this is a test\n\nInput docs:\nMock input for the mock runnable"
+        )
         assert tool.args_schema.schema() == {
             "description": "Mock input for the mock runnable",
             "properties": {
@@ -519,7 +522,7 @@ class TestLoadTools:
         # verify it converts correctly to openai function
         fn = convert_to_openai_function(tool)
         assert fn == {
-            "description": "this is a test",
+            "description": "this is a test\n\nInput docs:\nMock input for the mock runnable",
             "name": "test",
             "parameters": {
                 "properties": {

--- a/ix/runnable/openapi.py
+++ b/ix/runnable/openapi.py
@@ -44,6 +44,7 @@ class RunOpenAPIRequest(RunnableSerializable[Input, Output]):
     path: str
     method: HTTP_METHODS
     headers: Optional[dict] = None
+    instructions: str = ""
 
     class Config:
         arbitrary_types_allowed = True
@@ -61,6 +62,15 @@ class RunOpenAPIRequest(RunnableSerializable[Input, Output]):
 
         action_schema = get_action_schema(schema.value, self.path, self.method)
         input_schema = get_input_schema(action_schema, self.path, self.method)
+
+        # bake in prompt on top of any existing description
+        instructions = self.instructions or ""
+        description = input_schema.get("description", "")
+        input_schema["description"] = (
+            f"{description}\n\nInstructions:\n{instructions}"
+            if description
+            else instructions
+        )
         return input_schema
 
     def get_input_schema(

--- a/ix/runnable/tests/test_openapi.py
+++ b/ix/runnable/tests/test_openapi.py
@@ -156,6 +156,56 @@ class TestRunOpenAPIRequest:
             "type": "object",
         }
 
+    def test_instructions(self, schema):
+        """Test that custom instructions are added to the input_schema's docstring and schema description"""
+        runnable = RunOpenAPIRequest(
+            schema_id=schema.id,
+            path=LIST_PATH,
+            method="get",
+            server=SERVER,
+            instructions="extra instructions",
+        )
+        assert issubclass(runnable.get_input_schema(), (BaseModel, BaseModelV1))
+        assert runnable.get_input_schema().model_json_schema() == {
+            "$defs": {
+                "DynamicModel": {
+                    "properties": {
+                        "search": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "default": None,
+                            "title": "Search",
+                        },
+                        "limit": {
+                            "anyOf": [{"type": "integer"}, {"type": "null"}],
+                            "default": 10,
+                            "title": "Limit",
+                        },
+                        "offset": {
+                            "anyOf": [{"type": "integer"}, {"type": "null"}],
+                            "default": 0,
+                            "title": "Offset",
+                        },
+                        "is_agent": {
+                            "anyOf": [{"type": "boolean"}, {"type": "null"}],
+                            "default": None,
+                            "title": "Is Agent",
+                        },
+                    },
+                    "title": "DynamicModel",
+                    "type": "object",
+                }
+            },
+            "description": "extra instructions",
+            "properties": {
+                "query": {
+                    "anyOf": [{"$ref": "#/$defs/DynamicModel"}, {"type": "null"}],
+                    "default": None,
+                }
+            },
+            "title": "DynamicModel",
+            "type": "object",
+        }
+
     async def test_ainvoke_get_list(self, auser, aschema, mock_httpx):
         await afake_chain()
         runnable = RunOpenAPIRequest(

--- a/test_data/snapshots/components/ix.runnable.openapi.RunOpenAPIRequest.json
+++ b/test_data/snapshots/components/ix.runnable.openapi.RunOpenAPIRequest.json
@@ -15,6 +15,13 @@
             },
             {
                 "fields": [
+                    "instructions"
+                ],
+                "key": "Instructions",
+                "label": "Instructions"
+            },
+            {
+                "fields": [
                     "headers"
                 ],
                 "key": "Auth",
@@ -25,6 +32,16 @@
             "headers": {
                 "label": "Headers",
                 "type": "object"
+            },
+            "instructions": {
+                "default": "",
+                "description": "Extra instructions added to input schema",
+                "input_type": "textarea",
+                "label": "Instructions",
+                "style": {
+                    "width": "100%"
+                },
+                "type": "string"
             },
             "method": {
                 "enum": [
@@ -182,6 +199,25 @@
             "step": null,
             "style": null,
             "type": "dict"
+        },
+        {
+            "choices": null,
+            "default": "",
+            "description": "Extra instructions added to input schema",
+            "init_type": "init",
+            "input_type": "textarea",
+            "label": "Instructions",
+            "max": null,
+            "min": null,
+            "name": "instructions",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": {
+                "width": "100%"
+            },
+            "type": "str"
         }
     ],
     "name": "OpenAPI Request",


### PR DESCRIPTION
### Description
Two improvements to function calling:
- `RunOpenAPIRequest` now has an `instructions` config option for adding extra instructions to send to the LLM. This helps tune the component in addition to what is provided by the API spec.
- Runnable.input_schema description is now added to tools

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
