### PR TITLE
OpenAPIRequest should return response json for error responses 

### DIFF
--- a/ix/runnable/openapi.py
+++ b/ix/runnable/openapi.py
@@ -99,7 +99,4 @@ class RunOpenAPIRequest(RunnableSerializable[Input, Output]):
             client_method = getattr(client, self.method)
             response = await client_method(**request_kwargs)
 
-        if response.status_code != 200:
-            raise Exception(f"Failed to get schema: {response.content}")
-
         return response.json()


### PR DESCRIPTION


### Description
`RunOpenAPIRequest` was raising errors for any http error code. Errors will now be returned as output so an agent may reflect on it.

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
