### PR TITLE
Agents may now reflect on parsing errors to correct them.

### DIFF
--- a/ix/chains/fixture_src/agents.py
+++ b/ix/chains/fixture_src/agents.py
@@ -22,6 +22,13 @@ EXECUTOR_BASE_FIELDS = [
         "type": "float",
         "nullable": True,
     },
+    {
+        "name": "handle_parsing_errors",
+        "label": "Handle Parsing Errors",
+        "description": "Send parsing errors back to the agent to resolve.",
+        "type": "boolean",
+        "default": True,
+    },
     VERBOSE,
 ]
 

--- a/test_data/snapshots/components/ix.chains.loaders.agents.initialize_chat_conversational_react_description.json
+++ b/test_data/snapshots/components/ix.chains.loaders.agents.initialize_chat_conversational_react_description.json
@@ -4,6 +4,12 @@
     "config_schema": {
         "display_groups": null,
         "properties": {
+            "handle_parsing_errors": {
+                "default": true,
+                "description": "Send parsing errors back to the agent to resolve.",
+                "label": "Handle Parsing Errors",
+                "type": "boolean"
+            },
             "max_execution_time": {
                 "label": "",
                 "type": "number"
@@ -116,6 +122,23 @@
             "step": null,
             "style": null,
             "type": "float"
+        },
+        {
+            "choices": null,
+            "default": true,
+            "description": "Send parsing errors back to the agent to resolve.",
+            "init_type": "init",
+            "input_type": null,
+            "label": "Handle Parsing Errors",
+            "max": null,
+            "min": null,
+            "name": "handle_parsing_errors",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "boolean"
         },
         {
             "choices": null,

--- a/test_data/snapshots/components/ix.chains.loaders.agents.initialize_chat_zero_shot_react_description.json
+++ b/test_data/snapshots/components/ix.chains.loaders.agents.initialize_chat_zero_shot_react_description.json
@@ -4,6 +4,12 @@
     "config_schema": {
         "display_groups": null,
         "properties": {
+            "handle_parsing_errors": {
+                "default": true,
+                "description": "Send parsing errors back to the agent to resolve.",
+                "label": "Handle Parsing Errors",
+                "type": "boolean"
+            },
             "max_execution_time": {
                 "label": "",
                 "type": "number"
@@ -116,6 +122,23 @@
             "step": null,
             "style": null,
             "type": "float"
+        },
+        {
+            "choices": null,
+            "default": true,
+            "description": "Send parsing errors back to the agent to resolve.",
+            "init_type": "init",
+            "input_type": null,
+            "label": "Handle Parsing Errors",
+            "max": null,
+            "min": null,
+            "name": "handle_parsing_errors",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "boolean"
         },
         {
             "choices": null,

--- a/test_data/snapshots/components/ix.chains.loaders.agents.initialize_conversational_react_description.json
+++ b/test_data/snapshots/components/ix.chains.loaders.agents.initialize_conversational_react_description.json
@@ -4,6 +4,12 @@
     "config_schema": {
         "display_groups": null,
         "properties": {
+            "handle_parsing_errors": {
+                "default": true,
+                "description": "Send parsing errors back to the agent to resolve.",
+                "label": "Handle Parsing Errors",
+                "type": "boolean"
+            },
             "max_execution_time": {
                 "label": "",
                 "type": "number"
@@ -116,6 +122,23 @@
             "step": null,
             "style": null,
             "type": "float"
+        },
+        {
+            "choices": null,
+            "default": true,
+            "description": "Send parsing errors back to the agent to resolve.",
+            "init_type": "init",
+            "input_type": null,
+            "label": "Handle Parsing Errors",
+            "max": null,
+            "min": null,
+            "name": "handle_parsing_errors",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "boolean"
         },
         {
             "choices": null,

--- a/test_data/snapshots/components/ix.chains.loaders.agents.initialize_openai_functions.json
+++ b/test_data/snapshots/components/ix.chains.loaders.agents.initialize_openai_functions.json
@@ -4,6 +4,12 @@
     "config_schema": {
         "display_groups": null,
         "properties": {
+            "handle_parsing_errors": {
+                "default": true,
+                "description": "Send parsing errors back to the agent to resolve.",
+                "label": "Handle Parsing Errors",
+                "type": "boolean"
+            },
             "max_execution_time": {
                 "label": "",
                 "type": "number"
@@ -131,6 +137,23 @@
             "step": null,
             "style": null,
             "type": "float"
+        },
+        {
+            "choices": null,
+            "default": true,
+            "description": "Send parsing errors back to the agent to resolve.",
+            "init_type": "init",
+            "input_type": null,
+            "label": "Handle Parsing Errors",
+            "max": null,
+            "min": null,
+            "name": "handle_parsing_errors",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "boolean"
         },
         {
             "choices": null,

--- a/test_data/snapshots/components/ix.chains.loaders.agents.initialize_openai_multi_functions.json
+++ b/test_data/snapshots/components/ix.chains.loaders.agents.initialize_openai_multi_functions.json
@@ -4,6 +4,12 @@
     "config_schema": {
         "display_groups": null,
         "properties": {
+            "handle_parsing_errors": {
+                "default": true,
+                "description": "Send parsing errors back to the agent to resolve.",
+                "label": "Handle Parsing Errors",
+                "type": "boolean"
+            },
             "max_execution_time": {
                 "label": "",
                 "type": "number"
@@ -131,6 +137,23 @@
             "step": null,
             "style": null,
             "type": "float"
+        },
+        {
+            "choices": null,
+            "default": true,
+            "description": "Send parsing errors back to the agent to resolve.",
+            "init_type": "init",
+            "input_type": null,
+            "label": "Handle Parsing Errors",
+            "max": null,
+            "min": null,
+            "name": "handle_parsing_errors",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "boolean"
         },
         {
             "choices": null,

--- a/test_data/snapshots/components/ix.chains.loaders.agents.initialize_react_docstore.json
+++ b/test_data/snapshots/components/ix.chains.loaders.agents.initialize_react_docstore.json
@@ -4,6 +4,12 @@
     "config_schema": {
         "display_groups": null,
         "properties": {
+            "handle_parsing_errors": {
+                "default": true,
+                "description": "Send parsing errors back to the agent to resolve.",
+                "label": "Handle Parsing Errors",
+                "type": "boolean"
+            },
             "max_execution_time": {
                 "label": "",
                 "type": "number"
@@ -116,6 +122,23 @@
             "step": null,
             "style": null,
             "type": "float"
+        },
+        {
+            "choices": null,
+            "default": true,
+            "description": "Send parsing errors back to the agent to resolve.",
+            "init_type": "init",
+            "input_type": null,
+            "label": "Handle Parsing Errors",
+            "max": null,
+            "min": null,
+            "name": "handle_parsing_errors",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "boolean"
         },
         {
             "choices": null,

--- a/test_data/snapshots/components/ix.chains.loaders.agents.initialize_self_ask_with_search.json
+++ b/test_data/snapshots/components/ix.chains.loaders.agents.initialize_self_ask_with_search.json
@@ -4,6 +4,12 @@
     "config_schema": {
         "display_groups": null,
         "properties": {
+            "handle_parsing_errors": {
+                "default": true,
+                "description": "Send parsing errors back to the agent to resolve.",
+                "label": "Handle Parsing Errors",
+                "type": "boolean"
+            },
             "max_execution_time": {
                 "label": "",
                 "type": "number"
@@ -116,6 +122,23 @@
             "step": null,
             "style": null,
             "type": "float"
+        },
+        {
+            "choices": null,
+            "default": true,
+            "description": "Send parsing errors back to the agent to resolve.",
+            "init_type": "init",
+            "input_type": null,
+            "label": "Handle Parsing Errors",
+            "max": null,
+            "min": null,
+            "name": "handle_parsing_errors",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "boolean"
         },
         {
             "choices": null,

--- a/test_data/snapshots/components/ix.chains.loaders.agents.initialize_structured_chat_zero_shot_react_description.json
+++ b/test_data/snapshots/components/ix.chains.loaders.agents.initialize_structured_chat_zero_shot_react_description.json
@@ -4,6 +4,12 @@
     "config_schema": {
         "display_groups": null,
         "properties": {
+            "handle_parsing_errors": {
+                "default": true,
+                "description": "Send parsing errors back to the agent to resolve.",
+                "label": "Handle Parsing Errors",
+                "type": "boolean"
+            },
             "max_execution_time": {
                 "label": "",
                 "type": "number"
@@ -116,6 +122,23 @@
             "step": null,
             "style": null,
             "type": "float"
+        },
+        {
+            "choices": null,
+            "default": true,
+            "description": "Send parsing errors back to the agent to resolve.",
+            "init_type": "init",
+            "input_type": null,
+            "label": "Handle Parsing Errors",
+            "max": null,
+            "min": null,
+            "name": "handle_parsing_errors",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "boolean"
         },
         {
             "choices": null,

--- a/test_data/snapshots/components/ix.chains.loaders.agents.initialize_zero_shot_react_description.json
+++ b/test_data/snapshots/components/ix.chains.loaders.agents.initialize_zero_shot_react_description.json
@@ -4,6 +4,12 @@
     "config_schema": {
         "display_groups": null,
         "properties": {
+            "handle_parsing_errors": {
+                "default": true,
+                "description": "Send parsing errors back to the agent to resolve.",
+                "label": "Handle Parsing Errors",
+                "type": "boolean"
+            },
             "max_execution_time": {
                 "label": "",
                 "type": "number"
@@ -131,6 +137,23 @@
             "step": null,
             "style": null,
             "type": "float"
+        },
+        {
+            "choices": null,
+            "default": true,
+            "description": "Send parsing errors back to the agent to resolve.",
+            "init_type": "init",
+            "input_type": null,
+            "label": "Handle Parsing Errors",
+            "max": null,
+            "min": null,
+            "name": "handle_parsing_errors",
+            "parent": null,
+            "required": false,
+            "secret_key": null,
+            "step": null,
+            "style": null,
+            "type": "boolean"
         },
         {
             "choices": null,


### PR DESCRIPTION


### Description
Encountered JSON parsing errors with SchemaForge #439. The agent struggled with the JSON nested inside the field. Updating config to support enabling reflection to handle parsing errors.

##### Example error that was fixed by enabling reflection.
![image](https://github.com/kreneskyp/ix/assets/68635/516cb3c8-ace9-446e-b833-b292993dc448)


### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
