### PR TITLE
Increasing debounce delay for node config forms

### DIFF
--- a/frontend/chains/hooks/useNodeEditorAPI.js
+++ b/frontend/chains/hooks/useNodeEditorAPI.js
@@ -26,7 +26,7 @@ export const useNodeEditorAPI = (node, setNode) => {
     [api.updateNode]
   );
 
-  const { callback: debouncedUpdateNode } = useDebounce(updateNode, 500);
+  const { callback: debouncedUpdateNode } = useDebounce(updateNode, 800);
   const toast = useToast();
   const handleConfigChange = React.useMemo(() => {
     function all(newNode, delay = 0) {


### PR DESCRIPTION


### Description
The `on save` message for node config forms was spamming when typing long text. Increasing debounce delay reduces it. 

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
- There may be a state issue with the debounce handler not clearing updates. Should investigate further.
