### PR TITLE
Skill.tags is now optional. Was blocking the saving of skills

### DIFF
--- a/ix/runnable/output_parser.py
+++ b/ix/runnable/output_parser.py
@@ -23,6 +23,9 @@ class ParseFunctionCall(RunnableSerializable[AIMessage, FunctionCall]):
         config: Optional[RunnableConfig] = None,
         **kwargs: Any,
     ) -> FunctionCall:
+        if isinstance(input, dict):
+            input = AIMessage(**input)
+
         additional_kwargs = input.additional_kwargs
         if "function_call" in additional_kwargs:
             function_call = additional_kwargs["function_call"]
@@ -42,6 +45,9 @@ class ParseFunctionCall(RunnableSerializable[AIMessage, FunctionCall]):
         config: Optional[RunnableConfig] = None,
         **kwargs: Any,
     ) -> FunctionCall:
+        if isinstance(input, dict):
+            input = AIMessage(**input)
+
         additional_kwargs = input.additional_kwargs
         if "function_call" in additional_kwargs:
             function_call = additional_kwargs["function_call"]

--- a/ix/skills/types.py
+++ b/ix/skills/types.py
@@ -15,7 +15,7 @@ class SkillBase(BaseModel):
     name: str = Field(max_length=128)
     description: Optional[str] = None
     code: str
-    tags: List[str] = Field(default_factory=list)
+    tags: Optional[List[str]] = Field(default_factory=list)
     func_name: Optional[str] = None
     input_schema: Optional[dict[str, Any]] = None
 
@@ -30,12 +30,6 @@ class EditSkill(SkillBase):
 
     class Config:
         from_attributes = True
-
-    @model_validator(mode="before")
-    def default_tags(cls, values):
-        if not values["tags"]:
-            values["tags"] = []
-        return values
 
     @model_validator(mode="before")
     def parse_code_and_set_fields(cls, values):


### PR DESCRIPTION
### Description
The addition of `skill.tags` blocked the UI from saving skills. Adjusted typehints to make tags optional since there is no UI for it yet. 

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
