### PR TITLE
Run log can now load missing nodes.

### DIFF
--- a/frontend/chains/ChainGraphEditor.js
+++ b/frontend/chains/ChainGraphEditor.js
@@ -40,6 +40,7 @@ import { TabState } from "chains/hooks/useTabState";
 import { NOTIFY_SAVED } from "chains/editor/constants";
 import { PropEdge } from "chains/PropEdge";
 import { LinkEdge } from "chains/LinkEdge";
+import { addNode, addType } from "chains/utils";
 
 // Nodes are either a single node or a group of nodes
 // ConfigNode renders class_path specific content
@@ -59,15 +60,6 @@ const getExpectedTypes = (connector) => {
   return Array.isArray(connector?.source_type)
     ? new Set(connector.source_type)
     : new Set([connector.source_type]);
-};
-
-const addType = (type, setTypes) => {
-  setTypes((prev) => {
-    if (!prev.some((t) => t.id === type.id)) {
-      return [...prev, type];
-    }
-    return prev;
-  });
 };
 
 const ChainGraphEditor = ({ graph }) => {

--- a/frontend/chains/editor/run_log/ExecutionList.js
+++ b/frontend/chains/editor/run_log/ExecutionList.js
@@ -21,18 +21,27 @@ import { StyledIcon } from "components/StyledIcon";
 import { DEFAULT_NODE_STYLE, NODE_STYLES } from "chains/editor/styles";
 import { useRunLog } from "chains/editor/run_log/useRunLog";
 
-const useExecutionTree = (executions, nodes, types) => {
+const useExecutionTree = (
+  executions,
+  nodes,
+  types,
+  extra_nodes,
+  extra_types
+) => {
   const buildTree = (items, parentId = null) => {
     return (
       items
         ?.filter((item) => item.parent_id === parentId)
         ?.map((item) => {
-          const node = nodes?.[item.node_id];
+          const node = nodes?.[item.node_id] || extra_nodes?.[item.node_id];
+          const type =
+            types?.find((t) => t.id === node?.node_type_id) ||
+            extra_types?.[node?.node_type_id];
           return {
             execution: item,
             children: buildTree(items, item.id),
-            node: node,
-            type: types?.find((t) => t.id === node?.node_type_id),
+            node,
+            type,
           };
         }) || []
     );
@@ -40,7 +49,7 @@ const useExecutionTree = (executions, nodes, types) => {
 
   return React.useMemo(() => {
     return buildTree(executions);
-  }, [executions, nodes, types]);
+  }, [executions, nodes, types, extra_nodes, extra_types]);
 };
 
 const ExecutionIcon = ({ type, isLight }) => {
@@ -171,11 +180,17 @@ const ExecutionTreeNode = ({ execution, isFirst, isLast }) => {
   );
 };
 
-export const ExecutionList = ({ log }) => {
+export const ExecutionList = ({ log, extra_nodes, extra_types }) => {
   const { nodes } = React.useContext(NodeStateContext);
   const [types, setTypes] = React.useContext(ChainTypes);
 
-  const executions = useExecutionTree(log?.executions, nodes, types);
+  const executions = useExecutionTree(
+    log?.executions,
+    nodes,
+    types,
+    extra_nodes,
+    extra_types
+  );
 
   return (
     <Box width={"200px"}>

--- a/frontend/chains/editor/run_log/ExecutionList.js
+++ b/frontend/chains/editor/run_log/ExecutionList.js
@@ -132,7 +132,10 @@ const ExecutionTreeNode = ({ execution, isFirst, isLast }) => {
         {...(isSelected ? selectedItemStyle : itemStyle)}
         width={"100%"}
       >
-        <TreeItem isFirst={isFirst} isLast={isLast}>
+        <TreeItem
+          isFirst={isFirst}
+          isLast={isLast && (execution.children.length < 0 || !isOpen)}
+        >
           <ExecutionIcon type={execution.type} isLight={isLight} />
         </TreeItem>
         <ExecutionBrief
@@ -160,7 +163,7 @@ const ExecutionTreeNode = ({ execution, isFirst, isLast }) => {
 
       {isOpen && (
         <HStack bg={"transparent"} height={"100%"} spacing={0}>
-          <BranchLine height={execution.children.length * 60} />
+          <BranchLine height={execution.children.length * 60} isLast={isLast} />
           {children.length > 1 && <VStack spacing={0}>{children}</VStack>}
         </HStack>
       )}

--- a/frontend/chains/editor/run_log/RunLog.js
+++ b/frontend/chains/editor/run_log/RunLog.js
@@ -7,7 +7,8 @@ import { ExecutionDetail } from "chains/editor/run_log/ExecutionDetail";
 import { useEditorColorMode } from "chains/editor/useColorMode";
 
 export const RunLog = ({}) => {
-  const { log, execution, setExecution } = useRunLog();
+  const { log, execution, setExecution, extra_nodes, extra_types } =
+    useRunLog();
   const { scrollbar } = useEditorColorMode();
 
   return (
@@ -21,6 +22,8 @@ export const RunLog = ({}) => {
       >
         <ExecutionList
           log={log}
+          extra_nodes={extra_nodes}
+          extra_types={extra_types}
           selectedExecution={execution}
           setExecution={setExecution}
         />

--- a/frontend/chains/editor/run_log/RunLogProvider.js
+++ b/frontend/chains/editor/run_log/RunLogProvider.js
@@ -1,12 +1,17 @@
 import React from "react";
-import { RunLog } from "chains/editor/contexts";
+import { ChainTypes, NodeStateContext, RunLog } from "chains/editor/contexts";
 import { useAxios } from "utils/hooks/useAxios";
 import { useDisclosure } from "@chakra-ui/react";
 import { useRunEventStream } from "chains/editor/run_log/useRunEventStream";
+import { addNodes, addTypes } from "chains/utils";
 
 export const RunLogProvider = ({ chain_id, children }) => {
   const disclosure = useDisclosure();
   const { call, response, error } = useAxios();
+  const { call: fetch_nodes } = useAxios({ method: "post" });
+
+  const [types, setTypes] = React.useContext(ChainTypes);
+  const { nodes, setNodes } = React.useContext(NodeStateContext);
 
   const [log, setLog] = React.useState(null);
   const [execution, setExecution] = React.useState(null);
@@ -18,6 +23,29 @@ export const RunLogProvider = ({ chain_id, children }) => {
         .catch((err) => {});
     }
   }, [chain_id]);
+
+  // preemptively load any nodes that are missing from local state
+  // this loads nodes & types for any executions for nested chains
+  React.useEffect(() => {
+    if (log) {
+      const missing_nodes = log.executions
+        ?.map((e) => e.node_id)
+        ?.filter((id) => !nodes[id]);
+
+      if (missing_nodes?.length > 0) {
+        fetch_nodes(`/api/nodes/bulk`, {
+          data: missing_nodes,
+        })
+          .then((resp) => {
+            addTypes(resp.data.types, setTypes);
+            addNodes(resp.data.nodes, setNodes);
+          })
+          .catch((err) => {
+            console.error("Failed to load missing nodes", err);
+          });
+      }
+    }
+  }, [log]);
 
   React.useEffect(() => {
     if (chain_id !== undefined) {
@@ -64,7 +92,7 @@ export const RunLogProvider = ({ chain_id, children }) => {
       });
     }
     return log_by_node;
-  }, [log]);
+  }, [log, nodes, types]);
 
   const state = React.useMemo(() => {
     const has_errors = log?.executions?.some((e) => e.completed === false);
@@ -81,9 +109,15 @@ export const RunLogProvider = ({ chain_id, children }) => {
     };
   }, [log]);
 
+  // HAX: force refresh of log object whenever types or nodes changes.
+  //      this is a cheap way of injecting this dependency into the log object
+  //      so downstream components don't need to know that nodes or types have
+  //      changed.
+  const _log = React.useMemo(() => ({ ...log }), [log, types, nodes]);
+
   const value = React.useMemo(() => {
     return {
-      log,
+      log: _log,
       state,
       log_by_node,
       execution,

--- a/frontend/chains/editor/run_log/Tree.js
+++ b/frontend/chains/editor/run_log/Tree.js
@@ -39,7 +39,7 @@ const VerticalLine = ({ flexGrow, ...props }) => {
   );
 };
 
-export const BranchLine = ({ height }) => {
+export const BranchLine = ({ height, isLast }) => {
   return (
     <Box display="flex" flexDirection="column" height={`${height}px`} ml={2}>
       <VStack
@@ -57,7 +57,7 @@ export const BranchLine = ({ height }) => {
           ml={"10px"}
           flexGrow={0}
         />
-        <VerticalLine />
+        {isLast ? <Spacer /> : <VerticalLine />}
       </VStack>
     </Box>
   );

--- a/frontend/chains/utils.js
+++ b/frontend/chains/utils.js
@@ -1,11 +1,35 @@
-import React from "react";
-import { LLM_NAME_MAP } from "chains/constants";
+export const addType = (type, setTypes) => {
+  setTypes((prev) => {
+    if (!prev.some((t) => t.id === type.id)) {
+      return [...prev, type];
+    }
+    return prev;
+  });
+};
 
-export function llm_name(classPath) {
-  if (classPath === undefined) {
-    return <i>inherited</i>;
-  }
+export const addTypes = (types, setTypes) => {
+  setTypes((prev) => {
+    const new_types = types.filter(
+      (type) => !prev.some((t) => t.id === type.id)
+    );
+    return [...prev, ...new_types];
+  });
+};
 
-  // lookup LLM name, default to class name if classPath isn't mapped with a label
-  return LLM_NAME_MAP[classPath] || classPath.split(".").pop();
-}
+export const addNode = (node, setNodes) => {
+  setNodes((prevNodes) => {
+    return { ...prevNodes, [node.id]: node };
+  });
+};
+
+export const addNodes = (newNodes, setNodes) => {
+  setNodes((prevNodes) => {
+    const updatedNodes = { ...prevNodes };
+    newNodes.forEach((node) => {
+      if (!prevNodes[node.id]) {
+        updatedNodes[node.id] = node;
+      }
+    });
+    return updatedNodes;
+  });
+};

--- a/ix/api/editor/types.py
+++ b/ix/api/editor/types.py
@@ -75,3 +75,8 @@ class GraphModel(BaseModel):
     nodes: List[NodePydantic]
     edges: List[EdgePydantic]
     types: List[NodeTypePydantic]
+
+
+class GraphNodes(BaseModel):
+    nodes: List[NodePydantic]
+    types: List[NodeTypePydantic]


### PR DESCRIPTION
### Description
RunLog was updated to show executions for nested chains in #454  but it wasn't yet loading the nodes or node types.  This PR updates RunLogProvider to load missing nodes whenever they are detected in the log.

![image](https://github.com/kreneskyp/ix/assets/68635/2e3fc72e-beb3-4696-84fe-f6cbf973511a)

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
