### PR TITLE
CodeEditor line numbers now account for line wrapping.

### DIFF
--- a/frontend/components/code_editor/LineNumbers.js
+++ b/frontend/components/code_editor/LineNumbers.js
@@ -3,7 +3,7 @@ import { useSlate } from "slate-react";
 import { Box } from "@chakra-ui/react";
 import { useColorMode } from "@chakra-ui/react";
 
-export const LineNumbers = () => {
+export const LineNumbers = ({ lineHeights }) => {
   const editor = useSlate();
   const element = editor.children[0];
   const lines = element.children || [];
@@ -20,6 +20,7 @@ export const LineNumbers = () => {
       bg={bg}
       px={1}
       py={2}
+      pt={3}
       fontSize="xs"
       fontFamily="monospace"
       color={color}
@@ -28,10 +29,10 @@ export const LineNumbers = () => {
         <Box
           key={index}
           w="full"
-          h="21px"
+          h={lineHeights[index] ? `${lineHeights[index]}px` : "21px"}
           m={0}
           display="flex"
-          alignItems="end"
+          alignItems="start"
           justifyContent="flex-end"
         >
           {index + 1}


### PR DESCRIPTION
### Description
CodeEditor component linenumbers will now match linewrap.

![image](https://github.com/kreneskyp/ix/assets/68635/85808eda-a4df-465e-a5e1-005dc32f9248)


### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
