### PR TITLE
empty function_call prop passed to IxChatOpenAI is now ignored

### DIFF
--- a/ix/runnable/llm.py
+++ b/ix/runnable/llm.py
@@ -32,9 +32,12 @@ class IXChatOpenAI(ChatOpenAI):
         """
         kwargs = kwargs.copy()
 
-        if "function_call" in kwargs:
-            if isinstance(kwargs["function_call"], str):
-                kwargs["function_call"] = {"name": kwargs["function_call"]}
+        function_call = kwargs.pop("function_call", None)
+        if function_call:
+            if isinstance(function_call, str):
+                kwargs["function_call"] = {"name": function_call}
+            else:
+                kwargs["function_call"] = function_call
 
         if "functions" in kwargs:
             kwargs["functions"] = [to_openai_fn(obj) for obj in kwargs["functions"]]


### PR DESCRIPTION
### Description
The `function_call` prop passed to `IxChatOpenAI ` was breaking when it was an `empty string` or `None`.  This happens when a user sets `function_call` but then removes it leaving an `empty string`.

### Changes
[List out the changes you've made in this pull request. Be as specific as possible.]

### How Tested
[Explain how you tested this pull request. Include any relevant steps or scripts.]

### TODOs
[List any outstanding TODOs or known issues that still need to be addressed.]
